### PR TITLE
validation: start evidence-first P0 agent loop

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,64 @@
+name: Deploy Signal to Insight Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate public knowledge contracts
+        run: |
+          python scripts/validate.py
+          python scripts/validate_claim_evidence.py
+          python scripts/validate_knowledge_deltas.py
+          python scripts/validate_graph.py
+          python scripts/validate_syntheses.py
+          python scripts/validate_source_decisions.py
+
+      - name: Regenerate public and review surfaces
+        run: |
+          python scripts/build.py
+          python scripts/build_previews.py
+          python scripts/build_library.py
+          python scripts/build_graph.py
+          python scripts/build_syntheses.py
+          python scripts/build_sitemap.py
+
+      - name: Configure Pages metadata
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,8 @@
 name: Deploy Signal to Insight Pages
 
+# Pages is currently a repository-level setting. Keep this workflow manual until Pages is
+# enabled for GitHub Actions; then it can be switched to push-on-main deployment.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,8 +64,17 @@ jobs:
       - name: Test one-command source orchestration
         run: python scripts/run_source.py --self-test
 
+      - name: Test private personal knowledge baseline
+        run: python scripts/personal_baseline.py self-test
+
       - name: Test learning utility local loop
         run: python scripts/learning_utility.py self-test
+
+      - name: Test dogfood cohort evidence store
+        run: python scripts/dogfood.py self-test
+
+      - name: Test Source Decision calibration store
+        run: python scripts/source_decision_benchmark.py self-test
 
       - name: Test explicit publication lifecycle boundaries
         run: |
@@ -80,6 +89,8 @@ jobs:
           node --check app.js
           node --check evidence.js
           node --check library.js
+          node --check capture.js
+          node capture.js --self-test
 
       - name: Run pipeline acceptance tests
         run: python -m unittest discover -s tests -p "test_*.py" -v

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dzmitryi Kharlanau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/capture.css
+++ b/capture.css
@@ -1,0 +1,35 @@
+:root {
+  color-scheme: light dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f3f1eb;
+  color: #171713;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; background: inherit; color: inherit; }
+.shell { width: min(760px, calc(100% - 32px)); margin: 0 auto; padding: 42px 0 72px; }
+.back { color: inherit; text-decoration: none; font-size: 14px; border-bottom: 1px solid currentColor; }
+header { margin: 64px 0 30px; }
+.eyebrow { margin: 0 0 12px; font-size: 12px; letter-spacing: .14em; text-transform: uppercase; opacity: .62; }
+h1 { max-width: 650px; margin: 0; font-size: clamp(38px, 7vw, 68px); line-height: .98; letter-spacing: -.055em; font-weight: 650; }
+.lede { max-width: 620px; margin: 24px 0 0; font-size: 18px; line-height: 1.55; opacity: .72; }
+.card { display: grid; gap: 18px; padding: 26px; border: 1px solid rgba(23,23,19,.16); background: rgba(255,255,255,.45); }
+label { display: grid; gap: 8px; font-size: 13px; font-weight: 650; }
+label span { font-weight: 400; opacity: .55; }
+input, select, textarea, button { font: inherit; }
+input, select, textarea { width: 100%; padding: 13px 14px; border: 1px solid rgba(23,23,19,.18); border-radius: 0; background: rgba(255,255,255,.72); color: inherit; outline: none; }
+input:focus, select:focus, textarea:focus { border-color: currentColor; }
+textarea { resize: vertical; }
+button, .bookmarklet { justify-self: start; padding: 12px 16px; border: 1px solid currentColor; background: #171713; color: #f8f6ef; text-decoration: none; cursor: pointer; }
+.error { min-height: 1em; margin: -4px 0 0; font-size: 13px; }
+.secondary { margin-top: 36px; padding-top: 30px; border-top: 1px solid rgba(23,23,19,.18); }
+.secondary h2 { margin: 0 0 10px; font-size: 22px; }
+.secondary p { max-width: 620px; line-height: 1.55; opacity: .72; }
+.bookmarklet { display: inline-block; margin: 8px 0; }
+.small { font-size: 13px; }
+@media (prefers-color-scheme: dark) {
+  :root { background: #181815; color: #f2efe5; }
+  .card { border-color: rgba(242,239,229,.18); background: rgba(255,255,255,.035); }
+  input, select, textarea { border-color: rgba(242,239,229,.2); background: rgba(255,255,255,.05); }
+  button, .bookmarklet { background: #f2efe5; color: #181815; }
+  .secondary { border-color: rgba(242,239,229,.18); }
+}

--- a/capture.js
+++ b/capture.js
@@ -97,7 +97,8 @@
     if (inferType("https://github.com/open-policy-agent/opa") !== "repository") throw new Error("repository inference failed");
     if (inferType("https://arxiv.org/abs/2210.03629") !== "paper") throw new Error("paper inference failed");
     const issue = buildIssueUrl({ url: "https://example.com/a?utm_source=x", type: "article", focus: "why", note: "note" });
-    if (!issue.includes("issues/new") || !decodeURIComponent(issue).includes("### Source URL")) throw new Error("issue prefill failed");
+    const issueUrl = new URL(issue);
+    if (!issue.includes("issues/new") || !(issueUrl.searchParams.get("body") || "").includes("### Source URL")) throw new Error("issue prefill failed");
     console.log("capture self-test passed; URL cleanup, type inference and GitHub issue prefill work.");
   }
 

--- a/capture.js
+++ b/capture.js
@@ -1,0 +1,111 @@
+(function () {
+  "use strict";
+
+  const REPO_ISSUE_URL = "https://github.com/dkharlanau/signal-to-insight/issues/new";
+  const TRACKING_PARAMS = new Set([
+    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "utm_id",
+    "gclid", "fbclid", "mc_cid", "mc_eid", "ref", "ref_src"
+  ]);
+
+  function cleanUrl(raw) {
+    if (!raw) return "";
+    const url = new URL(raw.trim());
+    for (const key of Array.from(url.searchParams.keys())) {
+      if (TRACKING_PARAMS.has(key.toLowerCase())) url.searchParams.delete(key);
+    }
+    if (/(^|\.)youtube\.com$/i.test(url.hostname) || /^youtu\.be$/i.test(url.hostname)) {
+      for (const key of ["t", "start", "time_continue", "si", "feature"]) url.searchParams.delete(key);
+    }
+    url.hash = "";
+    return url.toString();
+  }
+
+  function inferType(raw) {
+    const url = new URL(raw);
+    const host = url.hostname.toLowerCase();
+    const path = url.pathname.toLowerCase();
+    if (host.includes("youtube.com") || host === "youtu.be" || host.includes("vimeo.com")) return "video";
+    if (host === "github.com" && path.split("/").filter(Boolean).length >= 2) return "repository";
+    if (path.endsWith(".pdf") || host.includes("arxiv.org")) return "paper";
+    if (host.includes("podcasts.apple.com") || host.includes("spotify.com") && path.includes("episode")) return "podcast";
+    if (host.includes("docs.") || path.includes("/docs/") || path.includes("/documentation/")) return "documentation";
+    if (path.endsWith(".ppt") || path.endsWith(".pptx") || host.includes("slideshare.net")) return "presentation";
+    return "article";
+  }
+
+  function issueBody(values) {
+    return [
+      "### Source URL", "", values.url,
+      "", "### Source type", "", values.type,
+      "", "### Focus", "", values.focus || "_No response_",
+      "", "### Note", "", values.note || "_No response_"
+    ].join("\n");
+  }
+
+  function buildIssueUrl(values) {
+    const clean = cleanUrl(values.url);
+    const parsed = new URL(clean);
+    const params = new URLSearchParams({
+      title: `[source] ${parsed.hostname}`,
+      body: issueBody({ ...values, url: clean })
+    });
+    return `${REPO_ISSUE_URL}?${params.toString()}`;
+  }
+
+  function bookmarklet() {
+    const capture = "https://dkharlanau.github.io/signal-to-insight/capture/";
+    return `javascript:location.href='${capture}?url='+encodeURIComponent(location.href)`;
+  }
+
+  function bindPage() {
+    const form = document.querySelector("[data-capture-form]");
+    if (!form) return;
+    const urlInput = form.querySelector("[name=url]");
+    const typeInput = form.querySelector("[name=type]");
+    const query = new URLSearchParams(location.search);
+    if (query.get("url")) {
+      try {
+        urlInput.value = cleanUrl(query.get("url"));
+        typeInput.value = inferType(urlInput.value);
+      } catch (_) {
+        urlInput.value = query.get("url");
+      }
+    }
+    urlInput.addEventListener("change", () => {
+      try {
+        urlInput.value = cleanUrl(urlInput.value);
+        typeInput.value = inferType(urlInput.value);
+      } catch (_) {}
+    });
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const values = Object.fromEntries(new FormData(form).entries());
+      try {
+        location.href = buildIssueUrl(values);
+      } catch (error) {
+        const target = document.querySelector("[data-error]");
+        if (target) target.textContent = `Enter a valid http(s) URL. ${error.message}`;
+      }
+    });
+    const bookmarkTarget = document.querySelector("[data-bookmarklet]");
+    if (bookmarkTarget) bookmarkTarget.href = bookmarklet();
+  }
+
+  function selfTest() {
+    const cleaned = cleanUrl("https://www.youtube.com/watch?v=abc&t=30&utm_source=x&si=z");
+    if (cleaned.includes("utm_source") || cleaned.includes("&t=") || cleaned.includes("&si=")) throw new Error("tracking cleanup failed");
+    if (inferType("https://github.com/open-policy-agent/opa") !== "repository") throw new Error("repository inference failed");
+    if (inferType("https://arxiv.org/abs/2210.03629") !== "paper") throw new Error("paper inference failed");
+    const issue = buildIssueUrl({ url: "https://example.com/a?utm_source=x", type: "article", focus: "why", note: "note" });
+    if (!issue.includes("issues/new") || !decodeURIComponent(issue).includes("### Source URL")) throw new Error("issue prefill failed");
+    console.log("capture self-test passed; URL cleanup, type inference and GitHub issue prefill work.");
+  }
+
+  const api = { cleanUrl, inferType, issueBody, buildIssueUrl, bookmarklet };
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (typeof window !== "undefined") {
+    window.SignalToInsightCapture = api;
+    window.addEventListener("DOMContentLoaded", bindPage);
+  }
+  if (typeof process !== "undefined" && process.argv && process.argv.includes("--self-test")) selfTest();
+})();

--- a/capture/index.html
+++ b/capture/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Capture a source · Signal to Insight</title>
+  <link rel="stylesheet" href="../capture.css">
+</head>
+<body>
+  <main class="shell">
+    <a class="back" href="../">Signal to Insight</a>
+    <header>
+      <p class="eyebrow">Quick capture</p>
+      <h1>Queue a source without a backend.</h1>
+      <p class="lede">Paste or share a URL. This page only prepares the existing owner GitHub intake; it holds no credentials and publishes nothing.</p>
+    </header>
+
+    <form data-capture-form class="card">
+      <label>Source URL
+        <input name="url" type="url" inputmode="url" placeholder="https://…" required autofocus>
+      </label>
+      <label>Source type
+        <select name="type">
+          <option>article</option>
+          <option>video</option>
+          <option>paper</option>
+          <option>podcast</option>
+          <option>documentation</option>
+          <option>repository</option>
+          <option>tool</option>
+          <option>product</option>
+          <option>course</option>
+          <option>presentation</option>
+          <option>system</option>
+          <option>notes</option>
+        </select>
+      </label>
+      <label>Focus <span>optional</span>
+        <textarea name="focus" rows="3" placeholder="What should I understand, learn, try or build from this?"></textarea>
+      </label>
+      <label>Note <span>optional</span>
+        <textarea name="note" rows="2" placeholder="Why this looked useful"></textarea>
+      </label>
+      <p data-error class="error" aria-live="polite"></p>
+      <button type="submit">Open source intake</button>
+    </form>
+
+    <section class="secondary">
+      <h2>One-click desktop capture</h2>
+      <p>Drag this link to the bookmarks bar. On any page, click it to open this form with the current URL prefilled.</p>
+      <a data-bookmarklet class="bookmarklet" href="#">Capture to Signal to Insight</a>
+      <p class="small">On mobile, copy/share the source URL and paste it here. No GitHub token is exposed in this page.</p>
+    </section>
+  </main>
+  <script src="../capture.js"></script>
+</body>
+</html>

--- a/config/personal-baseline.example.json
+++ b/config/personal-baseline.example.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0",
+  "revision": 2,
+  "updated_at": "2026-08-27T00:00:00Z",
+  "entries": [
+    {
+      "id": "personal-durable-execution",
+      "concept": "Durable execution",
+      "state": "known",
+      "origin": "experience",
+      "note": "Example only. Real personal baseline data belongs in .local/.",
+      "tags": ["reliability", "workflow"],
+      "updated_at": "2026-08-27T00:00:00Z"
+    }
+  ],
+  "active_context": {
+    "goals": ["Example goal: understand production agent control"],
+    "projects": [],
+    "questions": []
+  }
+}

--- a/docs/GOLDEN_WALKTHROUGH.md
+++ b/docs/GOLDEN_WALKTHROUGH.md
@@ -1,0 +1,134 @@
+# Golden walkthrough — from source to changed understanding
+
+This walkthrough uses the first published reference case to show the product loop without requiring a reader to understand the repository architecture first.
+
+## 1. Start with a source, not a prompt
+
+The reference source is the AI Engineer World's Fair 2026 talk **“Why Your Enterprise Tech Stack Isn't Ready for AI Agents — And What to Build Instead”** by Christopher Lovejoy and Saul Howard.
+
+Signal to Insight preserves the canonical source, creator/date information when verifiable, capture/analysis dates and any verification sources. The source is not copied into the repository as a transcript.
+
+## 2. Map the whole source before selecting highlights
+
+The research bundle first reconstructs the source structure:
+
+```text
+problem
+  ↓
+why normal application assumptions fail for consequential agent work
+  ↓
+mechanisms / responsibilities required in production
+  ↓
+limitations and boundaries
+  ↓
+practical implications
+```
+
+This step is what prevents the output from becoming a collection of attractive but disconnected takeaways.
+
+## 3. Ask what is already known
+
+Before the explainer is finalized, the system retrieves relevant concepts from the cumulative graph and classifies every candidate as reinforcement, refinement, contradiction, new knowledge or not relevant.
+
+The important rule is precision over graph density: a lexical match is not automatically a meaningful connection.
+
+With the private personal-baseline layer enabled, the run can also know whether a concept is personally familiar or relevant to an active goal. That private context changes explanation depth/relevance; it never becomes external evidence.
+
+## 4. Produce the Knowledge Delta
+
+The explainer does not stop at “what the talk says.” Its Knowledge Delta separates three layers:
+
+```text
+current source basis
+        +
+prior evidence-backed model
+        ↓
+project interpretation of what changed
+```
+
+Only meaningful `new / reinforces / refines / contradicts` changes are surfaced. Attractive false connections are explicitly suppressible.
+
+This is the central product distinction from a generic summarizer: the output is a change to an accumulated mental model, not another isolated document.
+
+## 5. Make the time decision explicit
+
+After whole-source mapping, Source Decision asks whether the original is still worth consuming:
+
+```text
+consume
+skim selected parts
+explainer is enough
+skip for now
+```
+
+The recommendation considers novelty, source quality, practical leverage and information lost by compression. It is deliberately produced after source mapping, never from metadata alone.
+
+The recommendation is not assumed to be correct. `scripts/source_decision_benchmark.py` exists specifically to calibrate it against later full-source consumption.
+
+## 6. Render a coherent explainer
+
+Structured knowledge is transformed into a visual explanation using a semantic primitive such as causal chain, sequence, layered system, comparison or decision structure.
+
+The page must let the reader reconstruct:
+
+```text
+problem → mechanism → result → boundary
+```
+
+Claim-level evidence keeps source claims, external verification, prior knowledge and project interpretation distinguishable at the point where trust matters.
+
+## 7. Test whether understanding survives
+
+Immediate comprehension is not enough. The local retention loop asks the reader to reconstruct the central model later without reopening the source.
+
+The repository stores only labels for recalled/missed model pieces, not the private free-text answer.
+
+Example measurement loop:
+
+```text
+read explainer
+→ leave it
+→ reconstruct central model later
+→ reveal compact answer key
+→ record recalled / missed pieces
+→ attempt transfer to a new example
+```
+
+`scripts/learning_utility.py` aggregates time saved, immediate can-explain rate, delayed reconstruction and transfer outcomes.
+
+## 8. Let the next source start from the accumulated state
+
+The durable result is not the generated page. It is the combination of:
+
+- source provenance;
+- evidenced claims;
+- reusable concepts and typed relations;
+- Knowledge Delta;
+- contradiction/refinement history;
+- prerequisites/gaps;
+- private learning evidence;
+- optional explicit personal context.
+
+The next source therefore starts from an evolved model rather than from an empty chat window.
+
+## What this walkthrough proves
+
+It demonstrates the intended product mechanics and the evidence boundaries already encoded in the repository.
+
+It does **not** yet prove that:
+
+- Source Decision is calibrated well enough to trust broadly;
+- delayed reconstruction is consistently better than reading the original;
+- twenty diverse sources can pass through the workflow with low friction;
+- the same personal baseline works equally well across every domain.
+
+Those are the current validation loops, not claims the public product should make prematurely.
+
+## The product promise to test
+
+A successful Signal to Insight run should make four measurable improvements:
+
+1. less time spent consuming low-value/redundant material;
+2. clearer understanding of the central model and its boundaries;
+3. better retained/reconstructable understanding later;
+4. a higher-quality next learning or practical decision because new evidence was integrated with what was already known.

--- a/docs/PERSONAL_BASELINE.md
+++ b/docs/PERSONAL_BASELINE.md
@@ -1,0 +1,112 @@
+# Private personal knowledge baseline
+
+Signal to Insight has two different kinds of memory and they must not be conflated.
+
+## 1. Evidence-backed project knowledge
+
+`data/knowledge-graph.json`, claim evidence, Knowledge Delta and related public/project records represent knowledge derived from processed sources. They have provenance and may participate in public output according to review status.
+
+## 2. Explicit private personal context
+
+`.local/personal-baseline.json` represents what the user explicitly says they already know, partly know, are uncertain about, or do not know, plus current goals/projects/questions.
+
+It is private input. It is not source evidence.
+
+Allowed knowledge states:
+
+- `known`
+- `partially_known`
+- `uncertain`
+- `unknown`
+
+Allowed origins:
+
+- `user_assertion`
+- `experience`
+
+The tool deliberately does not infer a profile from clicks, reading history or opaque behavioral signals.
+
+## Create and edit the baseline
+
+```bash
+python scripts/personal_baseline.py init
+
+python scripts/personal_baseline.py set \
+  --concept "Durable execution" \
+  --state known \
+  --origin experience \
+  --tags "workflow,reliability"
+
+python scripts/personal_baseline.py context-add \
+  --kind goal \
+  --text "Understand production agent control"
+```
+
+Inspect only metadata/fingerprint:
+
+```bash
+python scripts/personal_baseline.py show
+```
+
+Inspect the full local file only when deliberately needed:
+
+```bash
+python scripts/personal_baseline.py show --full
+```
+
+## Use it during a source run
+
+```bash
+python scripts/run_personalized.py <intake-id>
+```
+
+or:
+
+```bash
+python scripts/run_personalized.py "https://example.com/source" \
+  --type article \
+  --focus "What changes my current mental model?"
+```
+
+The wrapper writes a selected context snapshot to:
+
+```text
+.local/run-context/<intake-id>.json
+```
+
+The versioned run manifest stores only baseline version, revision, fingerprint, private sidecar path and selected-entry count. It does not copy private knowledge statements into the repository.
+
+## How personalization may influence analysis
+
+Private context may change:
+
+- explanation depth;
+- prerequisite emphasis;
+- practical relevance;
+- which unfamiliar concepts deserve attention;
+- whether an idea is personally novel or already familiar.
+
+It must **not**:
+
+- become a source claim;
+- become verification evidence;
+- silently enter the public knowledge graph;
+- be cited as if it came from an external source.
+
+## Two different deltas
+
+Keep these concepts separate:
+
+**Evidence Knowledge Delta** answers: what does the current source change relative to prior evidence-backed project knowledge?
+
+**Personal novelty/relevance** answers: what is new or useful relative to this user's explicit private baseline and active context?
+
+The first may be public after review. The second is private personalization unless the user explicitly chooses otherwise.
+
+## Safety check
+
+`.local/` is gitignored. Public builders and validators should never depend on private baseline content. The personalized run wrapper passes only a fingerprint/revision into versioned manifests so a run can be reproduced as “used baseline revision N” without exposing its contents.
+
+```bash
+python scripts/personal_baseline.py self-test
+```

--- a/docs/QUICK_CAPTURE.md
+++ b/docs/QUICK_CAPTURE.md
@@ -1,0 +1,52 @@
+# Quick Capture
+
+`/capture/` is a zero-backend capture surface for the existing owner GitHub source intake.
+
+## Why it exists
+
+Source intake should be cheap enough to use during normal browsing. The capture page does not create a second database or expose a GitHub credential. It only normalizes the URL, infers a likely source type and opens a pre-filled GitHub issue that is handled by the existing queue workflow.
+
+## Browser flow
+
+1. Open `/capture/`.
+2. Paste a source URL, or open the page with `?url=<encoded-url>`.
+3. Confirm the inferred source type and optionally add focus/context.
+4. Choose **Open source intake**.
+5. GitHub opens the normal `[source]` issue with the fields already populated.
+
+The existing issue workflow remains responsible for owner authorization, canonical URL normalization and deduplication.
+
+## One-click desktop capture
+
+The capture page exposes a bookmarklet. Drag **Capture to Signal to Insight** to the bookmarks bar. Clicking it on any webpage opens the capture page with the current URL prefilled.
+
+No token is stored in the bookmarklet.
+
+## Mobile flow
+
+The minimal portable flow is deliberately backend-free:
+
+1. use the browser/app Share or Copy Link action;
+2. open the capture page;
+3. paste the URL;
+4. open the GitHub intake.
+
+A native share-target/PWA is not required until repeated dogfood shows that these extra taps materially reduce capture usage.
+
+## Normalization
+
+`capture.js` removes common tracking parameters and YouTube timestamp/share parameters before preparing the issue. The canonical repository intake performs normalization again, so capture-side cleanup is convenience rather than the authoritative deduplication layer.
+
+## Safety boundary
+
+- no GitHub credential is embedded in client code;
+- capture does not publish anything;
+- the source still enters the normal `queued → research → review` lifecycle;
+- the page is `noindex,nofollow` because it is an owner utility, not a discovery surface.
+
+## Checks
+
+```bash
+node --check capture.js
+node capture.js --self-test
+```

--- a/docs/SOURCE_DECISION_BENCHMARK.md
+++ b/docs/SOURCE_DECISION_BENCHMARK.md
@@ -1,0 +1,57 @@
+# Source Decision calibration
+
+The Source Decision card is valuable only if its `consume / skim selected parts / explainer is enough / skip for now` recommendation can be trusted to save time.
+
+`python scripts/source_decision_benchmark.py` records private calibration evidence after the original source has actually been consumed.
+
+## Benchmark method
+
+Use a balanced sample across video, documentation, repository/tool, paper and article sources.
+
+For each case:
+
+1. finish whole-source mapping and generate the Source Decision normally;
+2. record the predicted recommendation before using the original as the benchmark;
+3. consume the original source;
+4. judge whether meaningful information was missed (`none / minor / major`);
+5. classify the recommendation as `correct / too_optimistic / too_conservative`;
+6. for `skim_selected_parts`, verify whether the recommended sections/timestamps really contained the promised additional value.
+
+Example:
+
+```bash
+python scripts/source_decision_benchmark.py record \
+  --insight temporal-durable-execution-mental-model \
+  --source-type documentation \
+  --predicted skim_selected_parts \
+  --missed none \
+  --verdict correct \
+  --skim-targets all
+```
+
+Report:
+
+```bash
+python scripts/source_decision_benchmark.py report
+python scripts/source_decision_benchmark.py report --json
+```
+
+## Metrics
+
+The report surfaces:
+
+- overall verdict accuracy;
+- false `explainer is enough` decisions;
+- unnecessary `consume` recommendations;
+- major information-miss rate;
+- accuracy of `skim selected parts` locators.
+
+False `explainer is enough` is especially important: it means the system recommended saving time when the compressed artifact still omitted useful material.
+
+## What belongs in CI
+
+Subjective benchmark judgments do not become deterministic CI gates. CI only checks the store contract and aggregation code with fixtures. Product rules/schema/prompts may later gain deterministic tests after repeated failures expose a stable rule.
+
+```bash
+python scripts/source_decision_benchmark.py self-test
+```

--- a/docs/VALIDATION_COHORT.md
+++ b/docs/VALIDATION_COHORT.md
@@ -1,0 +1,75 @@
+# 20-source dogfood and reliability cohort
+
+The next architecture investment should be justified by repeated observed friction, not by hypothetical completeness.
+
+`python scripts/dogfood.py` records a private cohort under `.local/dogfood-cohort.json`.
+
+## Cohort shape
+
+Process at least 20 real sources across at least five source types and several domains. Do not choose sources only because they are easy for the current pipeline.
+
+For each run, record:
+
+- source type and domain;
+- elapsed hands-on work time;
+- agent/provider used;
+- manual interventions;
+- validation failures;
+- structural rewrites;
+- publication decision;
+- Knowledge Delta false positives and trivial deltas;
+- prerequisite misses;
+- prior-knowledge retrieval noise;
+- whether prior knowledge reduced repeated explanation;
+- Source Decision calibration outcome when known;
+- optional link to a private learning-utility record.
+
+Example:
+
+```bash
+python scripts/dogfood.py record \
+  --intake intake-2026-08-27-example \
+  --insight example-insight \
+  --source-type article \
+  --domain architecture \
+  --minutes 24 \
+  --agent chatgpt \
+  --manual-interventions 1 \
+  --validation-failures 0 \
+  --structural-rewrites 1 \
+  --publication keep_review \
+  --delta-false-positives 1 \
+  --retrieval-noise 1 \
+  --retrieval-saved-repetition yes \
+  --source-decision-outcome not_checked
+```
+
+Report:
+
+```bash
+python scripts/dogfood.py report
+python scripts/dogfood.py report --json
+```
+
+## Pair with learning evidence
+
+For useful cases, also use `scripts/learning_utility.py` to record source-time estimate, explainer consumption time, immediate model understanding, delayed reconstruction and transfer. The dogfood cohort measures production friction/quality failure modes; the learning-utility store measures user benefit.
+
+## Exit condition
+
+The cohort is structurally complete when it contains at least:
+
+- 20 unique intakes;
+- five source types.
+
+That alone is not product success. The report must identify the most frequent failure modes and the next three product changes justified by them.
+
+Candidate architecture work such as extraction providers, embeddings, more visual primitives or a service backend should be promoted only when the cohort shows a repeated bottleneck they solve.
+
+## Privacy
+
+Dogfood observations are private local evidence. They may include subjective judgments and operational notes, so they are not stored in public repository data by default.
+
+```bash
+python scripts/dogfood.py self-test
+```

--- a/scripts/dogfood.py
+++ b/scripts/dogfood.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Record and summarize the private 20-source dogfood/reliability cohort.
+
+All observations default to .local/ and are intentionally excluded from public builds.
+The goal is to discover repeated product failure modes, not to maximize processed-source count.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_STORE = ROOT / ".local" / "dogfood-cohort.json"
+VERSION = "1.0.0"
+PUBLICATION = {"publish", "keep_review", "archive", "not_ready"}
+YN_UNKNOWN = {"yes", "no", "unknown"}
+SOURCE_DECISION_OUTCOME = {"correct", "too_optimistic", "too_conservative", "not_checked"}
+
+
+class DogfoodError(ValueError):
+    pass
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def empty_store() -> dict:
+    return {"version": VERSION, "records": []}
+
+
+def load_store(path: Path) -> dict:
+    if not path.exists():
+        return empty_store()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    validate_store(data)
+    return data
+
+
+def write_store(path: Path, data: dict) -> None:
+    validate_store(data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def nonnegative_int(record: dict, field: str, where: str) -> None:
+    value = record.get(field)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise DogfoodError(f"{where}.{field} must be a non-negative integer")
+
+
+def validate_store(data: dict) -> None:
+    if data.get("version") != VERSION:
+        raise DogfoodError(f"unsupported dogfood store version: {data.get('version')!r}")
+    records = data.get("records")
+    if not isinstance(records, list):
+        raise DogfoodError("records must be a list")
+    seen: set[str] = set()
+    for index, record in enumerate(records):
+        where = f"records[{index}]"
+        if not isinstance(record, dict):
+            raise DogfoodError(f"{where} must be an object")
+        required = {
+            "id",
+            "intake_id",
+            "source_type",
+            "domain",
+            "elapsed_work_minutes",
+            "agent_provider",
+            "manual_interventions",
+            "validation_failures",
+            "structural_rewrites",
+            "publication_decision",
+            "knowledge_delta_false_positives",
+            "trivial_deltas",
+            "prerequisite_misses",
+            "retrieval_noise",
+            "retrieval_saved_repetition",
+            "source_decision_outcome",
+            "recorded_at",
+        }
+        missing = required - set(record)
+        if missing:
+            raise DogfoodError(f"{where} missing fields: {sorted(missing)}")
+        if not isinstance(record["id"], str) or not record["id"]:
+            raise DogfoodError(f"{where}.id must be non-empty")
+        if record["id"] in seen:
+            raise DogfoodError(f"duplicate record id: {record['id']}")
+        seen.add(record["id"])
+        for field in ("intake_id", "source_type", "domain", "agent_provider"):
+            if not isinstance(record[field], str) or not record[field].strip():
+                raise DogfoodError(f"{where}.{field} must be non-empty")
+        minutes = record["elapsed_work_minutes"]
+        if isinstance(minutes, bool) or not isinstance(minutes, (int, float)) or minutes <= 0:
+            raise DogfoodError(f"{where}.elapsed_work_minutes must be > 0")
+        for field in (
+            "manual_interventions",
+            "validation_failures",
+            "structural_rewrites",
+            "knowledge_delta_false_positives",
+            "trivial_deltas",
+            "prerequisite_misses",
+            "retrieval_noise",
+        ):
+            nonnegative_int(record, field, where)
+        if record["publication_decision"] not in PUBLICATION:
+            raise DogfoodError(f"{where}.publication_decision invalid")
+        if record["retrieval_saved_repetition"] not in YN_UNKNOWN:
+            raise DogfoodError(f"{where}.retrieval_saved_repetition invalid")
+        if record["source_decision_outcome"] not in SOURCE_DECISION_OUTCOME:
+            raise DogfoodError(f"{where}.source_decision_outcome invalid")
+        try:
+            datetime.fromisoformat(record["recorded_at"].replace("Z", "+00:00"))
+        except (AttributeError, ValueError) as exc:
+            raise DogfoodError(f"{where}.recorded_at must be ISO datetime") from exc
+
+
+def make_record_id(intake_id: str, store: dict) -> str:
+    existing = {item["id"] for item in store["records"]}
+    base = intake_id
+    candidate = base
+    counter = 2
+    while candidate in existing:
+        candidate = f"{base}-{counter}"
+        counter += 1
+    return candidate
+
+
+def record_run(store: dict, **values) -> dict:
+    record = {
+        "id": values.get("record_id") or make_record_id(values["intake_id"], store),
+        "intake_id": values["intake_id"],
+        "insight_id": values.get("insight_id") or None,
+        "source_type": values["source_type"],
+        "domain": values["domain"],
+        "elapsed_work_minutes": float(values["elapsed_work_minutes"]),
+        "agent_provider": values["agent_provider"],
+        "manual_interventions": values["manual_interventions"],
+        "validation_failures": values["validation_failures"],
+        "structural_rewrites": values["structural_rewrites"],
+        "publication_decision": values["publication_decision"],
+        "knowledge_delta_false_positives": values["knowledge_delta_false_positives"],
+        "trivial_deltas": values["trivial_deltas"],
+        "prerequisite_misses": values["prerequisite_misses"],
+        "retrieval_noise": values["retrieval_noise"],
+        "retrieval_saved_repetition": values["retrieval_saved_repetition"],
+        "source_decision_outcome": values["source_decision_outcome"],
+        "learning_record_id": values.get("learning_record_id") or None,
+        "note": values.get("note") or None,
+        "recorded_at": now_iso(),
+    }
+    store["records"].append(record)
+    validate_store(store)
+    return record
+
+
+def summarize(store: dict) -> dict:
+    validate_store(store)
+    records = store["records"]
+    if not records:
+        return {
+            "runs": 0,
+            "unique_intakes": 0,
+            "source_types": {},
+            "domains": {},
+            "total_work_minutes": 0.0,
+            "avg_work_minutes": None,
+            "publication_decisions": {},
+            "source_decision_outcomes": {},
+            "retrieval_saved_repetition_yes": 0,
+            "failure_totals": {},
+            "top_failure_modes": [],
+            "cohort_ready": False,
+            "exit_gap": {"sources_remaining": 20, "source_types_remaining": 5},
+        }
+
+    unique_intakes = {item["intake_id"] for item in records}
+    source_types = Counter(item["source_type"] for item in records)
+    domains = Counter(item["domain"] for item in records)
+    publication = Counter(item["publication_decision"] for item in records)
+    decisions = Counter(item["source_decision_outcome"] for item in records)
+    failure_fields = {
+        "manual_interventions": "manual interventions",
+        "validation_failures": "validation failures",
+        "structural_rewrites": "structural rewrites",
+        "knowledge_delta_false_positives": "Knowledge Delta false positives",
+        "trivial_deltas": "trivial Knowledge Deltas",
+        "prerequisite_misses": "prerequisite misses",
+        "retrieval_noise": "prior-knowledge retrieval noise",
+    }
+    failure_totals = {label: sum(item[field] for item in records) for field, label in failure_fields.items()}
+    ranked = sorted(
+        [{"failure": label, "count": count} for label, count in failure_totals.items() if count],
+        key=lambda item: (-item["count"], item["failure"]),
+    )
+    total_minutes = sum(item["elapsed_work_minutes"] for item in records)
+    types_needed = max(0, 5 - len(source_types))
+    sources_needed = max(0, 20 - len(unique_intakes))
+    return {
+        "runs": len(records),
+        "unique_intakes": len(unique_intakes),
+        "source_types": dict(sorted(source_types.items())),
+        "domains": dict(sorted(domains.items())),
+        "total_work_minutes": round(total_minutes, 2),
+        "avg_work_minutes": round(total_minutes / len(records), 2),
+        "publication_decisions": dict(sorted(publication.items())),
+        "source_decision_outcomes": dict(sorted(decisions.items())),
+        "retrieval_saved_repetition_yes": sum(item["retrieval_saved_repetition"] == "yes" for item in records),
+        "failure_totals": failure_totals,
+        "top_failure_modes": ranked[:7],
+        "cohort_ready": sources_needed == 0 and types_needed == 0,
+        "exit_gap": {"sources_remaining": sources_needed, "source_types_remaining": types_needed},
+    }
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "dogfood.json"
+        store = load_store(path)
+        for index, source_type in enumerate(("video", "article", "paper", "repository", "documentation"), start=1):
+            record_run(
+                store,
+                record_id=f"case-{index}",
+                intake_id=f"intake-{index}",
+                insight_id=None,
+                source_type=source_type,
+                domain="test",
+                elapsed_work_minutes=10 + index,
+                agent_provider="fixture-agent",
+                manual_interventions=index % 2,
+                validation_failures=0,
+                structural_rewrites=1 if index == 1 else 0,
+                publication_decision="keep_review",
+                knowledge_delta_false_positives=0,
+                trivial_deltas=0,
+                prerequisite_misses=0,
+                retrieval_noise=1 if index == 2 else 0,
+                retrieval_saved_repetition="yes",
+                source_decision_outcome="not_checked",
+                learning_record_id=None,
+                note=None,
+            )
+        write_store(path, store)
+        report = summarize(load_store(path))
+        if report["unique_intakes"] != 5 or len(report["source_types"]) != 5:
+            print("dogfood self-test failed: cohort diversity aggregation")
+            return 1
+        if report["failure_totals"]["structural rewrites"] != 1:
+            print("dogfood self-test failed: failure aggregation")
+            return 1
+        if report["cohort_ready"]:
+            print("dogfood self-test failed: five fixtures must not satisfy 20-source exit")
+            return 1
+    print("dogfood self-test passed; private cohort records and failure-mode aggregation work.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store", type=Path, default=DEFAULT_STORE)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    rec = sub.add_parser("record")
+    rec.add_argument("--intake", required=True)
+    rec.add_argument("--insight")
+    rec.add_argument("--source-type", required=True)
+    rec.add_argument("--domain", required=True)
+    rec.add_argument("--minutes", type=float, required=True)
+    rec.add_argument("--agent", required=True)
+    rec.add_argument("--manual-interventions", type=int, default=0)
+    rec.add_argument("--validation-failures", type=int, default=0)
+    rec.add_argument("--structural-rewrites", type=int, default=0)
+    rec.add_argument("--publication", choices=sorted(PUBLICATION), required=True)
+    rec.add_argument("--delta-false-positives", type=int, default=0)
+    rec.add_argument("--trivial-deltas", type=int, default=0)
+    rec.add_argument("--prerequisite-misses", type=int, default=0)
+    rec.add_argument("--retrieval-noise", type=int, default=0)
+    rec.add_argument("--retrieval-saved-repetition", choices=sorted(YN_UNKNOWN), default="unknown")
+    rec.add_argument("--source-decision-outcome", choices=sorted(SOURCE_DECISION_OUTCOME), default="not_checked")
+    rec.add_argument("--learning-record-id")
+    rec.add_argument("--note")
+    rec.add_argument("--record-id")
+
+    report = sub.add_parser("report")
+    report.add_argument("--json", action="store_true")
+    sub.add_parser("self-test")
+
+    args = parser.parse_args()
+    try:
+        if args.command == "self-test":
+            return self_test()
+        store = load_store(args.store)
+        if args.command == "record":
+            item = record_run(
+                store,
+                record_id=args.record_id,
+                intake_id=args.intake,
+                insight_id=args.insight,
+                source_type=args.source_type,
+                domain=args.domain,
+                elapsed_work_minutes=args.minutes,
+                agent_provider=args.agent,
+                manual_interventions=args.manual_interventions,
+                validation_failures=args.validation_failures,
+                structural_rewrites=args.structural_rewrites,
+                publication_decision=args.publication,
+                knowledge_delta_false_positives=args.delta_false_positives,
+                trivial_deltas=args.trivial_deltas,
+                prerequisite_misses=args.prerequisite_misses,
+                retrieval_noise=args.retrieval_noise,
+                retrieval_saved_repetition=args.retrieval_saved_repetition,
+                source_decision_outcome=args.source_decision_outcome,
+                learning_record_id=args.learning_record_id,
+                note=args.note,
+            )
+            write_store(args.store, store)
+            print(json.dumps(item, ensure_ascii=False, indent=2))
+        else:
+            report_data = summarize(store)
+            if args.json:
+                print(json.dumps(report_data, ensure_ascii=False, indent=2))
+            else:
+                print(f"Unique sources: {report_data['unique_intakes']} / 20")
+                print(f"Source types: {len(report_data['source_types'])} / 5 minimum")
+                print(f"Average work minutes: {report_data['avg_work_minutes'] if report_data['avg_work_minutes'] is not None else 'n/a'}")
+                print(f"Cohort ready: {'yes' if report_data['cohort_ready'] else 'no'}")
+                if report_data["top_failure_modes"]:
+                    print("Top failure modes:")
+                    for item in report_data["top_failure_modes"]:
+                        print(f"- {item['failure']}: {item['count']}")
+                print("Exit gap: " + json.dumps(report_data["exit_gap"], sort_keys=True))
+    except (DogfoodError, json.JSONDecodeError) as exc:
+        print(f"dogfood error: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/personal_baseline.py
+++ b/scripts/personal_baseline.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Manage a private, explicit personal knowledge baseline for Signal to Insight.
+
+The default store lives under .local/ and is therefore excluded from git. It contains only
+facts the user explicitly chooses to record; this script never infers a profile from behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_STORE = ROOT / ".local" / "personal-baseline.json"
+VERSION = "1.0.0"
+STATES = {"known", "partially_known", "uncertain", "unknown"}
+ORIGINS = {"user_assertion", "experience"}
+CONTEXT_KINDS = {"goal", "project", "question"}
+
+
+class PersonalBaselineError(ValueError):
+    pass
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def empty_store() -> dict:
+    return {
+        "version": VERSION,
+        "revision": 0,
+        "updated_at": None,
+        "entries": [],
+        "active_context": {"goals": [], "projects": [], "questions": []},
+    }
+
+
+def load_store(path: Path) -> dict:
+    if not path.exists():
+        return empty_store()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    validate_store(data)
+    return data
+
+
+def write_store(path: Path, data: dict) -> None:
+    validate_store(data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def validate_store(data: dict) -> None:
+    if data.get("version") != VERSION:
+        raise PersonalBaselineError(f"unsupported baseline version: {data.get('version')!r}")
+    revision = data.get("revision")
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision < 0:
+        raise PersonalBaselineError("revision must be a non-negative integer")
+    if data.get("updated_at") is not None:
+        try:
+            datetime.fromisoformat(str(data["updated_at"]).replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise PersonalBaselineError("updated_at must be null or ISO datetime") from exc
+
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        raise PersonalBaselineError("entries must be a list")
+    seen: set[str] = set()
+    for index, entry in enumerate(entries):
+        where = f"entries[{index}]"
+        if not isinstance(entry, dict):
+            raise PersonalBaselineError(f"{where} must be an object")
+        entry_id = entry.get("id")
+        concept = entry.get("concept")
+        if not isinstance(entry_id, str) or not entry_id.strip():
+            raise PersonalBaselineError(f"{where}.id must be non-empty")
+        if entry_id in seen:
+            raise PersonalBaselineError(f"duplicate entry id: {entry_id}")
+        seen.add(entry_id)
+        if not isinstance(concept, str) or not concept.strip():
+            raise PersonalBaselineError(f"{where}.concept must be non-empty")
+        if entry.get("state") not in STATES:
+            raise PersonalBaselineError(f"{where}.state invalid")
+        if entry.get("origin") not in ORIGINS:
+            raise PersonalBaselineError(f"{where}.origin invalid")
+        tags = entry.get("tags", [])
+        if not isinstance(tags, list) or not all(isinstance(item, str) and item.strip() for item in tags):
+            raise PersonalBaselineError(f"{where}.tags must be a list of non-empty strings")
+        if entry.get("note") is not None and not isinstance(entry.get("note"), str):
+            raise PersonalBaselineError(f"{where}.note must be null or string")
+
+    context = data.get("active_context")
+    if not isinstance(context, dict):
+        raise PersonalBaselineError("active_context must be an object")
+    for plural in ("goals", "projects", "questions"):
+        values = context.get(plural)
+        if not isinstance(values, list) or not all(isinstance(item, str) and item.strip() for item in values):
+            raise PersonalBaselineError(f"active_context.{plural} must be a list of non-empty strings")
+
+
+def canonical_fingerprint(data: dict) -> str:
+    payload = json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def slug(value: str) -> str:
+    candidate = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return candidate[:60] or "concept"
+
+
+def touch(data: dict) -> None:
+    data["revision"] += 1
+    data["updated_at"] = now_iso()
+
+
+def upsert_entry(
+    data: dict,
+    concept: str,
+    state: str,
+    origin: str,
+    note: str | None = None,
+    tags: list[str] | None = None,
+    entry_id: str | None = None,
+) -> dict:
+    if state not in STATES:
+        raise PersonalBaselineError(f"state must be one of {sorted(STATES)}")
+    if origin not in ORIGINS:
+        raise PersonalBaselineError(f"origin must be one of {sorted(ORIGINS)}")
+    concept = concept.strip()
+    if not concept:
+        raise PersonalBaselineError("concept must not be empty")
+    tags = sorted({item.strip() for item in (tags or []) if item.strip()})
+    target = None
+    if entry_id:
+        target = next((item for item in data["entries"] if item["id"] == entry_id), None)
+    if target is None:
+        target = next((item for item in data["entries"] if item["concept"].casefold() == concept.casefold()), None)
+    if target is None:
+        base = entry_id or f"personal-{slug(concept)}"
+        candidate = base
+        existing = {item["id"] for item in data["entries"]}
+        counter = 2
+        while candidate in existing:
+            candidate = f"{base}-{counter}"
+            counter += 1
+        target = {"id": candidate}
+        data["entries"].append(target)
+
+    target.update(
+        {
+            "concept": concept,
+            "state": state,
+            "origin": origin,
+            "note": note.strip() if isinstance(note, str) and note.strip() else None,
+            "tags": tags,
+            "updated_at": now_iso(),
+        }
+    )
+    touch(data)
+    return target
+
+
+def add_context(data: dict, kind: str, text: str) -> None:
+    if kind not in CONTEXT_KINDS:
+        raise PersonalBaselineError(f"context kind must be one of {sorted(CONTEXT_KINDS)}")
+    text = text.strip()
+    if not text:
+        raise PersonalBaselineError("context text must not be empty")
+    key = {"goal": "goals", "project": "projects", "question": "questions"}[kind]
+    if text not in data["active_context"][key]:
+        data["active_context"][key].append(text)
+        touch(data)
+
+
+def remove_context(data: dict, kind: str, text: str) -> bool:
+    if kind not in CONTEXT_KINDS:
+        raise PersonalBaselineError(f"context kind must be one of {sorted(CONTEXT_KINDS)}")
+    key = {"goal": "goals", "project": "projects", "question": "questions"}[kind]
+    if text in data["active_context"][key]:
+        data["active_context"][key].remove(text)
+        touch(data)
+        return True
+    return False
+
+
+def tokens(text: str) -> set[str]:
+    return {part for part in re.findall(r"[a-z0-9][a-z0-9_-]{1,}", text.casefold()) if len(part) > 2}
+
+
+def select_context(data: dict, query: str, limit: int = 8) -> dict:
+    query_tokens = tokens(query)
+    ranked: list[tuple[int, str, dict]] = []
+    for item in data["entries"]:
+        haystack = " ".join(
+            [
+                item["concept"],
+                item.get("note") or "",
+                " ".join(item.get("tags", [])),
+            ]
+        )
+        overlap = query_tokens & tokens(haystack)
+        score = len(overlap) * 10
+        if item["state"] in {"uncertain", "unknown"}:
+            score += 2
+        if overlap or not query_tokens:
+            ranked.append((score, item["concept"].casefold(), item))
+    ranked.sort(key=lambda row: (-row[0], row[1]))
+    selected = [item for _, _, item in ranked[: max(0, limit)]]
+    return {
+        "baseline_version": data["version"],
+        "baseline_revision": data["revision"],
+        "baseline_fingerprint": canonical_fingerprint(data),
+        "query": query,
+        "active_context": data["active_context"],
+        "entries": selected,
+        "privacy": {
+            "classification": "private_local",
+            "public_evidence": False,
+            "rule": "User assertions and personal experience may guide relevance/explanation depth but never become public source evidence.",
+        },
+    }
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "baseline.json"
+        data = load_store(path)
+        upsert_entry(data, "Durable execution", "known", "experience", tags=["workflow", "reliability"])
+        upsert_entry(data, "Policy as code", "partially_known", "user_assertion", tags=["policy"])
+        add_context(data, "goal", "Understand production agent control")
+        write_store(path, data)
+        restored = load_store(path)
+        selected = select_context(restored, "workflow durable agent", limit=1)
+        if selected["entries"][0]["concept"] != "Durable execution":
+            print("personal baseline self-test failed: retrieval ranking")
+            return 1
+        if selected["baseline_revision"] != 3:
+            print(f"personal baseline self-test failed: revision={selected['baseline_revision']}")
+            return 1
+        if not selected["baseline_fingerprint"]:
+            print("personal baseline self-test failed: fingerprint missing")
+            return 1
+    print("personal baseline self-test passed; private store, explicit context and deterministic selection work.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store", type=Path, default=DEFAULT_STORE)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("init", help="Create an empty private baseline if it does not exist")
+
+    set_cmd = sub.add_parser("set", help="Add or update an explicit knowledge entry")
+    set_cmd.add_argument("--concept", required=True)
+    set_cmd.add_argument("--state", choices=sorted(STATES), required=True)
+    set_cmd.add_argument("--origin", choices=sorted(ORIGINS), required=True)
+    set_cmd.add_argument("--note")
+    set_cmd.add_argument("--tags", default="", help="Comma-separated tags")
+    set_cmd.add_argument("--id")
+
+    context_add = sub.add_parser("context-add", help="Add an active goal/project/question")
+    context_add.add_argument("--kind", choices=sorted(CONTEXT_KINDS), required=True)
+    context_add.add_argument("--text", required=True)
+
+    context_remove = sub.add_parser("context-remove", help="Remove an active goal/project/question")
+    context_remove.add_argument("--kind", choices=sorted(CONTEXT_KINDS), required=True)
+    context_remove.add_argument("--text", required=True)
+
+    context = sub.add_parser("context", help="Print the private context relevant to a query")
+    context.add_argument("--query", default="")
+    context.add_argument("--limit", type=int, default=8)
+    context.add_argument("--out", type=Path)
+
+    show = sub.add_parser("show", help="Print baseline metadata or full local data")
+    show.add_argument("--full", action="store_true")
+
+    sub.add_parser("self-test")
+
+    args = parser.parse_args()
+    try:
+        if args.command == "self-test":
+            return self_test()
+
+        data = load_store(args.store)
+        if args.command == "init":
+            if not args.store.exists():
+                write_store(args.store, data)
+            print(f"baseline ready: {args.store}")
+        elif args.command == "set":
+            item = upsert_entry(
+                data,
+                args.concept,
+                args.state,
+                args.origin,
+                note=args.note,
+                tags=[part.strip() for part in args.tags.split(",") if part.strip()],
+                entry_id=args.id,
+            )
+            write_store(args.store, data)
+            print(json.dumps(item, ensure_ascii=False, indent=2))
+        elif args.command == "context-add":
+            add_context(data, args.kind, args.text)
+            write_store(args.store, data)
+            print(f"added {args.kind}: {args.text}")
+        elif args.command == "context-remove":
+            removed = remove_context(data, args.kind, args.text)
+            if removed:
+                write_store(args.store, data)
+            print("removed" if removed else "not found")
+        elif args.command == "context":
+            snapshot = select_context(data, args.query, args.limit)
+            if args.out:
+                args.out.parent.mkdir(parents=True, exist_ok=True)
+                args.out.write_text(json.dumps(snapshot, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                print(args.out)
+            else:
+                print(json.dumps(snapshot, ensure_ascii=False, indent=2))
+        elif args.command == "show":
+            if args.full:
+                print(json.dumps(data, ensure_ascii=False, indent=2))
+            else:
+                print(
+                    json.dumps(
+                        {
+                            "version": data["version"],
+                            "revision": data["revision"],
+                            "updated_at": data["updated_at"],
+                            "entries": len(data["entries"]),
+                            "active_context_counts": {key: len(value) for key, value in data["active_context"].items()},
+                            "fingerprint": canonical_fingerprint(data),
+                        },
+                        ensure_ascii=False,
+                        indent=2,
+                    )
+                )
+    except (PersonalBaselineError, json.JSONDecodeError) as exc:
+        print(f"personal baseline error: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_personalized.py
+++ b/scripts/run_personalized.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Prepare/resume a source run with an explicit private personal-context sidecar.
+
+This wraps scripts/run_source.py. Public/versioned run manifests receive only baseline
+metadata (version, revision and fingerprint); selected personal entries stay under .local/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import run_source
+from personal_baseline import DEFAULT_STORE, load_store, select_context
+
+ROOT = Path(__file__).resolve().parents[1]
+PRIVATE_CONTEXT_DIR = ROOT / ".local" / "run-context"
+
+
+def write_private_context(item: dict, store_path: Path, limit: int) -> dict:
+    data = load_store(store_path)
+    query = " ".join(
+        part
+        for part in (
+            item.get("requested_focus") or "",
+            item.get("source_type") or "",
+            item.get("source_url") or "",
+        )
+        if part
+    )
+    snapshot = select_context(data, query, limit=limit)
+    target = PRIVATE_CONTEXT_DIR / f"{item['id']}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(snapshot, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return {
+        "available": bool(snapshot["entries"] or any(snapshot["active_context"].values())),
+        "baseline_version": snapshot["baseline_version"],
+        "baseline_revision": snapshot["baseline_revision"],
+        "baseline_fingerprint": snapshot["baseline_fingerprint"],
+        "private_sidecar": str(target.relative_to(ROOT)),
+        "selected_entries": len(snapshot["entries"]),
+        "privacy": "private_local_not_public_evidence",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", help="Intake ID or http(s) source URL")
+    parser.add_argument(
+        "--type",
+        dest="source_type",
+        default="article",
+        choices=[
+            "video",
+            "article",
+            "paper",
+            "podcast",
+            "documentation",
+            "repository",
+            "tool",
+            "product",
+            "course",
+            "presentation",
+            "notes",
+            "system",
+        ],
+    )
+    parser.add_argument("--focus", default="")
+    parser.add_argument("--note", default="")
+    parser.add_argument("--baseline-store", type=Path, default=DEFAULT_STORE)
+    parser.add_argument("--personal-limit", type=int, default=8)
+    parser.add_argument("--no-checks", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    focus = args.focus.strip() or None
+    note = args.note.strip() or None
+    if args.source.startswith(("http://", "https://")):
+        item = run_source.queue_url(args.source, args.source_type, focus, note)
+    else:
+        item = run_source.get_intake(args.source)
+
+    bundle, bundle_path, created_bundle = run_source.ensure_bundle(item)
+    state = run_source.evaluate_state(item, bundle)
+    manifest = run_source.write_manifest(item, state, bundle_path, created_bundle)
+
+    personal = write_private_context(item, args.baseline_store, args.personal_limit)
+    manifest["personal_context"] = personal
+    instruction = manifest.setdefault("agent_handoff", {}).get("instruction", "")
+    manifest["agent_handoff"]["instruction"] = (
+        instruction
+        + " If personal_context.available is true, read the private sidecar before selecting explanation depth/relevance. "
+        + "Treat user assertions and personal experience as private context only: never cite them as source evidence, "
+        + "never merge them into the public knowledge graph, and keep evidence-backed Knowledge Delta separate from "
+        + "personal novelty/relevance."
+    ).strip()
+
+    mature = (
+        state["insight_review_ready"]
+        and state["knowledge_delta_ready"]
+        and state["learning_prompt_ready"]
+        and item.get("status") in {"review", "published"}
+    )
+    if mature and not args.no_checks:
+        ok, results = run_source.run_checks()
+        manifest["checks"] = {"ok": ok, "results": results}
+        manifest["last_checked_at"] = run_source.now_iso()
+        if not ok:
+            failed = next((result for result in results if not result["ok"]), None)
+            if failed:
+                manifest["state"]["next_blocking_action"] = (
+                    f"Fix failing repository check: {failed['command']}. Then rerun personalized source orchestration."
+                )
+
+    manifest_path = run_source.MANIFESTS / f"{item['id']}.json"
+    run_source.dump(manifest_path, manifest)
+
+    if args.json:
+        print(json.dumps(manifest, ensure_ascii=False, indent=2))
+    else:
+        print(f"intake: {item['id']}")
+        print(f"private context: {personal['private_sidecar']} ({personal['selected_entries']} selected entries)")
+        print(f"baseline revision: {personal['baseline_revision']} / {personal['baseline_fingerprint'][:12]}")
+        print(f"next: {manifest['state']['next_blocking_action']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/source_decision_benchmark.py
+++ b/scripts/source_decision_benchmark.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Calibrate Source Decision predictions against later full-source consumption.
+
+Benchmark observations are private/local by default. Subjective human outcomes are not CI
+assertions; only the deterministic store and aggregate math are self-tested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_STORE = ROOT / ".local" / "source-decision-benchmark.json"
+VERSION = "1.0.0"
+DECISIONS = {"consume", "skim_selected_parts", "explainer_is_enough", "skip_for_now"}
+MISSED = {"none", "minor", "major"}
+VERDICTS = {"correct", "too_optimistic", "too_conservative"}
+SKIM = {"all", "partial", "none", "not_applicable"}
+
+
+class BenchmarkError(ValueError):
+    pass
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def empty_store() -> dict:
+    return {"version": VERSION, "records": []}
+
+
+def load_store(path: Path) -> dict:
+    if not path.exists():
+        return empty_store()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    validate_store(data)
+    return data
+
+
+def write_store(path: Path, data: dict) -> None:
+    validate_store(data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def validate_store(data: dict) -> None:
+    if data.get("version") != VERSION:
+        raise BenchmarkError(f"unsupported benchmark version: {data.get('version')!r}")
+    records = data.get("records")
+    if not isinstance(records, list):
+        raise BenchmarkError("records must be a list")
+    seen: set[str] = set()
+    for index, item in enumerate(records):
+        where = f"records[{index}]"
+        if not isinstance(item, dict):
+            raise BenchmarkError(f"{where} must be an object")
+        required = {
+            "id", "insight_id", "source_type", "predicted_decision", "original_consumed",
+            "missed_meaningful_info", "verdict", "skim_targets_verified", "recorded_at"
+        }
+        missing = required - set(item)
+        if missing:
+            raise BenchmarkError(f"{where} missing fields: {sorted(missing)}")
+        if not isinstance(item["id"], str) or not item["id"]:
+            raise BenchmarkError(f"{where}.id must be non-empty")
+        if item["id"] in seen:
+            raise BenchmarkError(f"duplicate id: {item['id']}")
+        seen.add(item["id"])
+        for field in ("insight_id", "source_type"):
+            if not isinstance(item[field], str) or not item[field].strip():
+                raise BenchmarkError(f"{where}.{field} must be non-empty")
+        if item["predicted_decision"] not in DECISIONS:
+            raise BenchmarkError(f"{where}.predicted_decision invalid")
+        if item["original_consumed"] is not True:
+            raise BenchmarkError(f"{where}.original_consumed must be true for calibration evidence")
+        if item["missed_meaningful_info"] not in MISSED:
+            raise BenchmarkError(f"{where}.missed_meaningful_info invalid")
+        if item["verdict"] not in VERDICTS:
+            raise BenchmarkError(f"{where}.verdict invalid")
+        if item["skim_targets_verified"] not in SKIM:
+            raise BenchmarkError(f"{where}.skim_targets_verified invalid")
+        if item["predicted_decision"] != "skim_selected_parts" and item["skim_targets_verified"] != "not_applicable":
+            raise BenchmarkError(f"{where}.skim_targets_verified only applies to skim_selected_parts")
+        try:
+            datetime.fromisoformat(item["recorded_at"].replace("Z", "+00:00"))
+        except (AttributeError, ValueError) as exc:
+            raise BenchmarkError(f"{where}.recorded_at must be ISO datetime") from exc
+
+
+def add_record(store: dict, **values) -> dict:
+    insight_id = values["insight_id"]
+    base = values.get("record_id") or insight_id
+    existing = {item["id"] for item in store["records"]}
+    candidate = base
+    counter = 2
+    while candidate in existing:
+        candidate = f"{base}-{counter}"
+        counter += 1
+    item = {
+        "id": candidate,
+        "insight_id": insight_id,
+        "source_type": values["source_type"],
+        "predicted_decision": values["predicted_decision"],
+        "original_consumed": True,
+        "missed_meaningful_info": values["missed_meaningful_info"],
+        "verdict": values["verdict"],
+        "skim_targets_verified": values["skim_targets_verified"],
+        "note": values.get("note") or None,
+        "recorded_at": now_iso(),
+    }
+    store["records"].append(item)
+    validate_store(store)
+    return item
+
+
+def summarize(store: dict) -> dict:
+    validate_store(store)
+    records = store["records"]
+    if not records:
+        return {
+            "cases": 0,
+            "source_types": {},
+            "verdicts": {},
+            "accuracy": None,
+            "false_explainer_enough": 0,
+            "unnecessary_consume": 0,
+            "skim_cases": 0,
+            "skim_all_targets_hit_rate": None,
+            "major_miss_rate": None,
+        }
+
+    verdicts = Counter(item["verdict"] for item in records)
+    source_types = Counter(item["source_type"] for item in records)
+    false_enough = sum(
+        item["predicted_decision"] == "explainer_is_enough" and item["missed_meaningful_info"] in {"minor", "major"}
+        for item in records
+    )
+    unnecessary_consume = sum(
+        item["predicted_decision"] == "consume" and item["verdict"] == "too_conservative"
+        for item in records
+    )
+    skim_cases = [item for item in records if item["predicted_decision"] == "skim_selected_parts"]
+    return {
+        "cases": len(records),
+        "source_types": dict(sorted(source_types.items())),
+        "verdicts": dict(sorted(verdicts.items())),
+        "accuracy": round(verdicts["correct"] / len(records), 3),
+        "false_explainer_enough": false_enough,
+        "unnecessary_consume": unnecessary_consume,
+        "skim_cases": len(skim_cases),
+        "skim_all_targets_hit_rate": (
+            round(sum(item["skim_targets_verified"] == "all" for item in skim_cases) / len(skim_cases), 3)
+            if skim_cases else None
+        ),
+        "major_miss_rate": round(sum(item["missed_meaningful_info"] == "major" for item in records) / len(records), 3),
+    }
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "benchmark.json"
+        store = load_store(path)
+        add_record(
+            store,
+            record_id="a",
+            insight_id="insight-a",
+            source_type="video",
+            predicted_decision="explainer_is_enough",
+            missed_meaningful_info="major",
+            verdict="too_optimistic",
+            skim_targets_verified="not_applicable",
+        )
+        add_record(
+            store,
+            record_id="b",
+            insight_id="insight-b",
+            source_type="documentation",
+            predicted_decision="skim_selected_parts",
+            missed_meaningful_info="none",
+            verdict="correct",
+            skim_targets_verified="all",
+        )
+        write_store(path, store)
+        report = summarize(load_store(path))
+        if report["false_explainer_enough"] != 1 or report["accuracy"] != 0.5:
+            print("source-decision benchmark self-test failed: calibration aggregation")
+            return 1
+        if report["skim_all_targets_hit_rate"] != 1.0:
+            print("source-decision benchmark self-test failed: skim target aggregation")
+            return 1
+    print("source-decision benchmark self-test passed; private calibration metrics work.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store", type=Path, default=DEFAULT_STORE)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    rec = sub.add_parser("record")
+    rec.add_argument("--insight", required=True)
+    rec.add_argument("--source-type", required=True)
+    rec.add_argument("--predicted", choices=sorted(DECISIONS), required=True)
+    rec.add_argument("--missed", choices=sorted(MISSED), required=True)
+    rec.add_argument("--verdict", choices=sorted(VERDICTS), required=True)
+    rec.add_argument("--skim-targets", choices=sorted(SKIM), default="not_applicable")
+    rec.add_argument("--note")
+    rec.add_argument("--record-id")
+
+    report = sub.add_parser("report")
+    report.add_argument("--json", action="store_true")
+    sub.add_parser("self-test")
+
+    args = parser.parse_args()
+    try:
+        if args.command == "self-test":
+            return self_test()
+        store = load_store(args.store)
+        if args.command == "record":
+            item = add_record(
+                store,
+                insight_id=args.insight,
+                source_type=args.source_type,
+                predicted_decision=args.predicted,
+                missed_meaningful_info=args.missed,
+                verdict=args.verdict,
+                skim_targets_verified=args.skim_targets,
+                note=args.note,
+                record_id=args.record_id,
+            )
+            write_store(args.store, store)
+            print(json.dumps(item, ensure_ascii=False, indent=2))
+        else:
+            result = summarize(store)
+            if args.json:
+                print(json.dumps(result, ensure_ascii=False, indent=2))
+            else:
+                print(f"Cases: {result['cases']}")
+                print(f"Accuracy: {result['accuracy'] if result['accuracy'] is not None else 'n/a'}")
+                print(f"False explainer-is-enough: {result['false_explainer_enough']}")
+                print(f"Unnecessary consume: {result['unnecessary_consume']}")
+                print(f"Major miss rate: {result['major_miss_rate'] if result['major_miss_rate'] is not None else 'n/a'}")
+                print(
+                    "Skim all-targets-hit rate: "
+                    + (str(result["skim_all_targets_hit_rate"]) if result["skim_all_targets_hit_rate"] is not None else "n/a")
+                )
+    except (BenchmarkError, json.JSONDecodeError) as exc:
+        print(f"source-decision benchmark error: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://dkharlanau.github.io/signal-to-insight/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://dkharlanau.github.io/signal-to-insight/library/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://dkharlanau.github.io/signal-to-insight/knowledge/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>


### PR DESCRIPTION
Implements the first validation-first product loop from #37.

This PR adds:
- zero-backend browser/mobile source capture for #27;
- explicit private personal knowledge baseline + personalized run sidecar for #41;
- private Source Decision calibration harness for #39;
- private 20-source dogfood/reliability cohort harness for #40;
- public golden walkthrough, MIT license and Pages deployment workflow as part of #45;
- CI self-tests for the new deterministic/local-first tools.

Important boundaries preserved:
- private personal context stays under `.local/` and cannot become public source evidence;
- subjective calibration/dogfood observations remain local rather than CI truth;
- review/publish state is unchanged and this PR does not auto-publish any third-party-derived insight;
- Pages deployment is configured, but repository-level Pages enablement may still require a GitHub setting/token with administration permission.

After CI, #27 and the implementation slice of #41 can be closed. #39/#40 remain open until real calibration/cohort evidence exists; #45 remains open until the public repository settings/surface are verified.