### PR TITLE
knowledge: close the private learning and action loop

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,8 +67,22 @@ jobs:
       - name: Test private personal knowledge baseline
         run: python scripts/personal_baseline.py self-test
 
+      - name: Validate private/public projection boundary
+        run: |
+          python scripts/validate_private_boundary.py
+          python scripts/validate_private_boundary.py --self-test
+
       - name: Test learning utility local loop
         run: python scripts/learning_utility.py self-test
+
+      - name: Test private action outcome loop
+        run: python scripts/action_outcomes.py self-test
+
+      - name: Test portable local state
+        run: python scripts/local_state.py self-test
+
+      - name: Test evidence-driven next research queue
+        run: python scripts/next_research.py self-test
 
       - name: Test dogfood cohort evidence store
         run: python scripts/dogfood.py self-test

--- a/docs/ACTION_OUTCOMES.md
+++ b/docs/ACTION_OUTCOMES.md
@@ -1,0 +1,73 @@
+# Insight → action → outcome
+
+Signal to Insight should remember whether an idea actually worked in the user's context, not only whether the source looked useful.
+
+Personal outcome evidence is private. It may influence future practical relevance and action recommendations, but it never becomes external/source evidence.
+
+## Start an action
+
+```bash
+python scripts/action_outcomes.py start \
+  --insight open-policy-agent-decision-enforcement-model \
+  --action try \
+  --hypothesis "Moving authorization rules out of application branching will make policy review clearer" \
+  --outcome "Prototype one decision boundary and compare change/review effort" \
+  --concepts "policy-as-code;policy-decision-enforcement-separation"
+```
+
+Optional `--review-at` can hold an ISO date/datetime. This is a review point, not a task-management backend.
+
+## Record what happened
+
+Statuses:
+
+```text
+planned → tried → adopted
+                ↘ rejected
+                ↘ inconclusive
+                ↘ superseded
+```
+
+Example:
+
+```bash
+python scripts/action_outcomes.py update \
+  --id action-open-policy-agent-decision-enforcement-model \
+  --status adopted \
+  --result "The explicit decision boundary reduced hidden branching in the prototype."
+```
+
+Final statuses require a result summary.
+
+## Reuse the outcome later
+
+```bash
+python scripts/action_outcomes.py context --query "policy authorization"
+```
+
+`run_personalized.py` automatically selects relevant prior outcomes into the private run sidecar. The versioned manifest receives only an outcome-store fingerprint and selected-count metadata.
+
+An `adopted` outcome can make a similar recommendation more practically relevant. A `rejected` outcome can warn the next analysis that the idea already failed in this context. Neither outcome proves or disproves the source claim itself.
+
+## Report
+
+```bash
+python scripts/action_outcomes.py report
+```
+
+The aggregate is intentionally small: status counts, number of insights with outcomes and adoption rate among resolved experiments.
+
+## Privacy boundary
+
+Default store:
+
+```text
+.local/action-outcomes.json
+```
+
+It is included in portable local-state export/import, not public builds.
+
+```bash
+python scripts/action_outcomes.py self-test
+python scripts/validate_private_boundary.py
+```

--- a/docs/LOCAL_STATE.md
+++ b/docs/LOCAL_STATE.md
@@ -1,0 +1,65 @@
+# Portable private local state
+
+Personal learning/context should survive browser/device moves without requiring an account or backend.
+
+`local_state.py` packages supported `.local` stores into one versioned JSON bundle:
+
+- explicit personal baseline;
+- learning-utility history;
+- insight/action outcomes;
+- dogfood cohort evidence;
+- Source Decision calibration evidence.
+
+## Export
+
+```bash
+python scripts/local_state.py export --out ~/signal-to-insight-state.json
+```
+
+The export contains private derived/user evidence only. It does not read or mirror source transcripts/articles/PDF text/repository contents.
+
+## Inspect before import
+
+```bash
+python scripts/local_state.py inspect --in ~/signal-to-insight-state.json
+```
+
+## Import / merge
+
+```bash
+python scripts/local_state.py import --in ~/signal-to-insight-state.json
+```
+
+Merge rules are conflict-safe:
+
+- new record IDs are added;
+- identical records are deduplicated;
+- records with distinct timestamps keep the newer version;
+- delayed learning evidence can replace the same immediate record when it is clearly a later completion;
+- ambiguous same-ID/same-time differences fail instead of silently overwriting;
+- personal baseline active goals/projects/questions are unioned;
+- baseline revision is advanced after merge.
+
+## Source-content guard
+
+Both export and import recursively reject fields such as:
+
+```text
+transcript
+full_text
+raw_content
+source_text
+pdf_text
+repository_contents
+```
+
+This is defense in depth: the normal project contracts already avoid committing full third-party content, and the portability layer should not become an accidental archive for it.
+
+## Privacy
+
+The resulting JSON is portable but still private. Treat it as personal data and store it accordingly. It is never consumed by public builders.
+
+```bash
+python scripts/local_state.py self-test
+python scripts/validate_private_boundary.py
+```

--- a/docs/NEXT_RESEARCH.md
+++ b/docs/NEXT_RESEARCH.md
@@ -1,0 +1,70 @@
+# Knowledge gaps → next research
+
+The system should recommend what to investigate next only when an explicit gap justifies it. This is not an engagement feed.
+
+`next_research.py` derives candidates from:
+
+- unresolved prerequisite maps;
+- unresolved multi-source synthesis gaps;
+- unresolved contradiction/refinement reviews;
+- concepts that are only `introduced` and supported by a narrow evidence base.
+
+It deliberately does **not** recommend generic graph neighbors.
+
+## Show the current queue
+
+```bash
+python scripts/next_research.py show
+```
+
+With private personal context available, active goals/projects/questions add a transparent score boost when terms overlap. The output shows the matching terms rather than hiding personalization in a model score.
+
+Each candidate includes:
+
+- type (`learn_prerequisite`, `verify_claim`, `resolve_contradiction`, `update_living_source`, `explore_adjacent_leverage`);
+- explicit target statement;
+- why it exists;
+- evidence refs;
+- ranking score;
+- matching personal-context terms;
+- existing unprocessed inbox source when one genuinely matches;
+- otherwise a research brief that asks for a primary/official/high-quality source without inventing a URL.
+
+## Queue / defer / ignore
+
+The local disposition store is:
+
+```text
+.local/next-research.json
+```
+
+Example:
+
+```bash
+python scripts/next_research.py set \
+  --candidate next-verify-claim-xxxxxxxxxx \
+  --status queued \
+  --note "Use this after the current Temporal review."
+```
+
+Other statuses are `deferred`, `ignored` and `closed`.
+
+Closing a target requires the intake that addressed it:
+
+```bash
+python scripts/next_research.py set \
+  --candidate next-verify-claim-xxxxxxxxxx \
+  --status closed \
+  --closed-by-intake intake-2026-... \
+  --materially-closed
+```
+
+This lets later evaluation measure whether recommended research actually closed the intended gap rather than merely producing another source.
+
+## Design rule
+
+A candidate must have a reason that can be traced to an explicit gap or low-coverage state. “This concept is related” is insufficient.
+
+```bash
+python scripts/next_research.py self-test
+```

--- a/scripts/action_outcomes.py
+++ b/scripts/action_outcomes.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Track private insight → action → outcome evidence.
+
+Personal outcomes are useful future context, but they are not external/source evidence and are
+never written to public knowledge records. The default store lives under .local/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tempfile
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_STORE = ROOT / ".local" / "action-outcomes.json"
+INSIGHTS = ROOT / "data" / "insights.json"
+VERSION = "1.0.0"
+STATUSES = {"planned", "tried", "adopted", "rejected", "inconclusive", "superseded"}
+ACTION_BUCKETS = {"use_now", "try", "learn", "build", "watch", "ignore_for_now"}
+FINAL_STATUSES = {"adopted", "rejected", "inconclusive", "superseded"}
+
+
+class OutcomeError(ValueError):
+    pass
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def empty_store() -> dict:
+    return {"version": VERSION, "records": []}
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_store(path: Path) -> dict:
+    if not path.exists():
+        return empty_store()
+    data = load_json(path)
+    validate_store(data)
+    return data
+
+
+def write_store(path: Path, data: dict) -> None:
+    validate_store(data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def known_insights() -> set[str]:
+    data = load_json(INSIGHTS)
+    return {item.get("id") for item in data.get("insights", []) if item.get("id")}
+
+
+def validate_iso(value: str | None, field: str) -> None:
+    if value is None:
+        return
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise OutcomeError(f"{field} must be null or ISO date/datetime") from exc
+
+
+def validate_store(data: dict) -> None:
+    if data.get("version") != VERSION:
+        raise OutcomeError(f"unsupported outcome store version: {data.get('version')!r}")
+    records = data.get("records")
+    if not isinstance(records, list):
+        raise OutcomeError("records must be a list")
+    seen: set[str] = set()
+    for index, item in enumerate(records):
+        where = f"records[{index}]"
+        required = {
+            "id", "insight_id", "concept_ids", "action_bucket", "hypothesis", "intended_outcome",
+            "status", "review_at", "result_summary", "created_at", "updated_at", "history"
+        }
+        if not isinstance(item, dict):
+            raise OutcomeError(f"{where} must be an object")
+        missing = required - set(item)
+        if missing:
+            raise OutcomeError(f"{where} missing fields: {sorted(missing)}")
+        if not isinstance(item["id"], str) or not item["id"].strip():
+            raise OutcomeError(f"{where}.id must be non-empty")
+        if item["id"] in seen:
+            raise OutcomeError(f"duplicate outcome id: {item['id']}")
+        seen.add(item["id"])
+        if not isinstance(item["insight_id"], str) or not item["insight_id"].strip():
+            raise OutcomeError(f"{where}.insight_id must be non-empty")
+        concepts = item["concept_ids"]
+        if not isinstance(concepts, list) or not all(isinstance(value, str) and value.strip() for value in concepts):
+            raise OutcomeError(f"{where}.concept_ids must be a list of non-empty strings")
+        if item["action_bucket"] not in ACTION_BUCKETS:
+            raise OutcomeError(f"{where}.action_bucket invalid")
+        for field in ("hypothesis", "intended_outcome"):
+            if not isinstance(item[field], str) or not item[field].strip():
+                raise OutcomeError(f"{where}.{field} must be non-empty")
+        if item["status"] not in STATUSES:
+            raise OutcomeError(f"{where}.status invalid")
+        if item["status"] in FINAL_STATUSES and not (isinstance(item["result_summary"], str) and item["result_summary"].strip()):
+            raise OutcomeError(f"{where}.result_summary required for final status")
+        if item["result_summary"] is not None and not isinstance(item["result_summary"], str):
+            raise OutcomeError(f"{where}.result_summary must be null or string")
+        validate_iso(item["review_at"], f"{where}.review_at")
+        validate_iso(item["created_at"], f"{where}.created_at")
+        validate_iso(item["updated_at"], f"{where}.updated_at")
+        if not isinstance(item["history"], list):
+            raise OutcomeError(f"{where}.history must be a list")
+
+
+def make_id(insight_id: str, store: dict) -> str:
+    stem = re.sub(r"[^a-z0-9]+", "-", insight_id.lower()).strip("-")[:48] or "outcome"
+    existing = {item["id"] for item in store["records"]}
+    candidate = f"action-{stem}"
+    index = 2
+    while candidate in existing:
+        candidate = f"action-{stem}-{index}"
+        index += 1
+    return candidate
+
+
+def start_record(
+    store: dict,
+    insight_id: str,
+    action_bucket: str,
+    hypothesis: str,
+    intended_outcome: str,
+    concept_ids: list[str],
+    review_at: str | None,
+    record_id: str | None = None,
+) -> dict:
+    if insight_id not in known_insights():
+        raise OutcomeError(f"unknown insight: {insight_id}")
+    if action_bucket not in ACTION_BUCKETS:
+        raise OutcomeError(f"action bucket must be one of {sorted(ACTION_BUCKETS)}")
+    timestamp = now_iso()
+    item = {
+        "id": record_id or make_id(insight_id, store),
+        "insight_id": insight_id,
+        "concept_ids": sorted({value.strip() for value in concept_ids if value.strip()}),
+        "action_bucket": action_bucket,
+        "hypothesis": hypothesis.strip(),
+        "intended_outcome": intended_outcome.strip(),
+        "status": "planned",
+        "review_at": review_at,
+        "result_summary": None,
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "history": [{"at": timestamp, "status": "planned", "note": "Action created from an insight recommendation."}],
+        "privacy": "private_personal_experience_not_source_evidence",
+    }
+    if any(existing["id"] == item["id"] for existing in store["records"]):
+        raise OutcomeError(f"outcome id already exists: {item['id']}")
+    store["records"].append(item)
+    validate_store(store)
+    return item
+
+
+def update_record(store: dict, record_id: str, status: str, result: str | None, note: str | None = None) -> dict:
+    if status not in STATUSES:
+        raise OutcomeError(f"status must be one of {sorted(STATUSES)}")
+    item = next((record for record in store["records"] if record["id"] == record_id), None)
+    if item is None:
+        raise OutcomeError(f"outcome not found: {record_id}")
+    if status in FINAL_STATUSES and not (result and result.strip()):
+        raise OutcomeError("final outcome status requires --result")
+    timestamp = now_iso()
+    item["status"] = status
+    if result is not None:
+        item["result_summary"] = result.strip() or None
+    item["updated_at"] = timestamp
+    item["history"].append({"at": timestamp, "status": status, "note": note or item["result_summary"]})
+    validate_store(store)
+    return item
+
+
+def tokens(value: str) -> set[str]:
+    return {part for part in re.findall(r"[a-z0-9][a-z0-9_-]{1,}", value.casefold()) if len(part) > 2}
+
+
+def select_context(store: dict, query: str, limit: int = 8) -> list[dict]:
+    query_terms = tokens(query)
+    ranked: list[tuple[int, str, dict]] = []
+    for item in store["records"]:
+        text = " ".join([
+            item["insight_id"], " ".join(item["concept_ids"]), item["hypothesis"],
+            item["intended_outcome"], item.get("result_summary") or ""
+        ])
+        overlap = query_terms & tokens(text)
+        score = 10 * len(overlap)
+        if item["status"] in {"adopted", "rejected"}:
+            score += 3
+        elif item["status"] == "inconclusive":
+            score += 1
+        if overlap or not query_terms:
+            ranked.append((score, item["updated_at"], item))
+    ranked.sort(key=lambda row: (-row[0], row[1], row[2]["id"]), reverse=False)
+    return [item for _, _, item in ranked[: max(limit, 0)]]
+
+
+def summarize(store: dict) -> dict:
+    validate_store(store)
+    statuses = Counter(item["status"] for item in store["records"])
+    by_insight = Counter(item["insight_id"] for item in store["records"])
+    return {
+        "records": len(store["records"]),
+        "statuses": dict(sorted(statuses.items())),
+        "insights_with_outcomes": len(by_insight),
+        "adoption_rate_among_resolved": (
+            round(statuses["adopted"] / sum(statuses[name] for name in FINAL_STATUSES), 3)
+            if sum(statuses[name] for name in FINAL_STATUSES) else None
+        ),
+    }
+
+
+def self_test() -> int:
+    insight_id = next(iter(sorted(known_insights())), None)
+    if not insight_id:
+        print("action outcomes self-test requires an insight")
+        return 1
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "outcomes.json"
+        store = load_store(path)
+        item = start_record(store, insight_id, "try", "A smaller control boundary reduces rework", "Observe fewer unsafe retries", ["controlled-execution"], None, "fixture")
+        update_record(store, item["id"], "adopted", "The pattern was useful in the test case.")
+        write_store(path, store)
+        restored = load_store(path)
+        if restored["records"][0]["status"] != "adopted":
+            print("action outcomes self-test failed: status update")
+            return 1
+        context = select_context(restored, "control retry", 3)
+        if not context or context[0]["id"] != "fixture":
+            print("action outcomes self-test failed: context selection")
+            return 1
+        if summarize(restored)["adoption_rate_among_resolved"] != 1.0:
+            print("action outcomes self-test failed: aggregate")
+            return 1
+    print("action outcomes self-test passed; private experiment lifecycle and future-context retrieval work.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store", type=Path, default=DEFAULT_STORE)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    start = sub.add_parser("start")
+    start.add_argument("--insight", required=True)
+    start.add_argument("--action", choices=sorted(ACTION_BUCKETS), required=True)
+    start.add_argument("--hypothesis", required=True)
+    start.add_argument("--outcome", required=True)
+    start.add_argument("--concepts", default="", help="Semicolon-separated concept IDs")
+    start.add_argument("--review-at")
+    start.add_argument("--id")
+
+    update = sub.add_parser("update")
+    update.add_argument("--id", required=True)
+    update.add_argument("--status", choices=sorted(STATUSES), required=True)
+    update.add_argument("--result")
+    update.add_argument("--note")
+
+    context = sub.add_parser("context")
+    context.add_argument("--query", default="")
+    context.add_argument("--limit", type=int, default=8)
+
+    report = sub.add_parser("report")
+    report.add_argument("--json", action="store_true")
+    sub.add_parser("self-test")
+
+    args = parser.parse_args()
+    try:
+        if args.command == "self-test":
+            return self_test()
+        store = load_store(args.store)
+        if args.command == "start":
+            item = start_record(store, args.insight, args.action, args.hypothesis, args.outcome, [part.strip() for part in args.concepts.split(";") if part.strip()], args.review_at, args.id)
+            write_store(args.store, store)
+            print(json.dumps(item, ensure_ascii=False, indent=2))
+        elif args.command == "update":
+            item = update_record(store, args.id, args.status, args.result, args.note)
+            write_store(args.store, store)
+            print(json.dumps(item, ensure_ascii=False, indent=2))
+        elif args.command == "context":
+            print(json.dumps({"privacy": "private_personal_experience_not_source_evidence", "records": select_context(store, args.query, args.limit)}, ensure_ascii=False, indent=2))
+        else:
+            report_data = summarize(store)
+            if args.json:
+                print(json.dumps(report_data, ensure_ascii=False, indent=2))
+            else:
+                print(f"Records: {report_data['records']}")
+                print("Statuses: " + json.dumps(report_data["statuses"], sort_keys=True))
+                print(f"Insights with outcomes: {report_data['insights_with_outcomes']}")
+                print(f"Adoption rate among resolved: {report_data['adoption_rate_among_resolved'] if report_data['adoption_rate_among_resolved'] is not None else 'n/a'}")
+    except (OutcomeError, json.JSONDecodeError) as exc:
+        print(f"action outcome error: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_state.py
+++ b/scripts/local_state.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Export/import Signal to Insight private local state as one versioned JSON bundle.
+
+This moves explicit personal context and learning/usage evidence between devices without an
+account or backend. It never reads public source payloads and rejects suspicious full-source
+content keys on export/import.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+import action_outcomes
+import dogfood
+import learning_utility
+import personal_baseline
+import source_decision_benchmark
+
+ROOT = Path(__file__).resolve().parents[1]
+VERSION = "1.0.0"
+FORBIDDEN_KEYS = {
+    "transcript", "full_transcript", "full_text", "raw_content", "source_text",
+    "article_text", "pdf_text", "repository_contents", "document_text"
+}
+
+STORE_SPECS = {
+    "personal_baseline": (personal_baseline.DEFAULT_STORE, personal_baseline.validate_store),
+    "learning_utility": (learning_utility.DEFAULT_STORE, learning_utility.validate_store),
+    "action_outcomes": (action_outcomes.DEFAULT_STORE, action_outcomes.validate_store),
+    "dogfood_cohort": (dogfood.DEFAULT_STORE, dogfood.validate_store),
+    "source_decision_benchmark": (source_decision_benchmark.DEFAULT_STORE, source_decision_benchmark.validate_store),
+}
+
+
+class LocalStateError(ValueError):
+    pass
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def dump(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def reject_full_source_content(value, trail: str = "root") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if str(key).casefold() in FORBIDDEN_KEYS:
+                raise LocalStateError(f"forbidden full-source field in private state bundle: {trail}.{key}")
+            reject_full_source_content(child, f"{trail}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_full_source_content(child, f"{trail}[{index}]")
+
+
+def validate_bundle(bundle: dict) -> None:
+    if bundle.get("bundle_version") != VERSION:
+        raise LocalStateError(f"unsupported local-state bundle version: {bundle.get('bundle_version')!r}")
+    if bundle.get("privacy") != "private_local_not_public_evidence":
+        raise LocalStateError("local-state bundle must declare private_local_not_public_evidence")
+    stores = bundle.get("stores")
+    if not isinstance(stores, dict):
+        raise LocalStateError("stores must be an object")
+    unknown = set(stores) - set(STORE_SPECS)
+    if unknown:
+        raise LocalStateError(f"unknown stores in bundle: {sorted(unknown)}")
+    reject_full_source_content(stores)
+    for name, data in stores.items():
+        validator = STORE_SPECS[name][1]
+        validator(data)
+
+
+def export_bundle(overrides: dict[str, Path] | None = None) -> dict:
+    overrides = overrides or {}
+    stores: dict[str, dict] = {}
+    for name, (default_path, validator) in STORE_SPECS.items():
+        path = overrides.get(name, default_path)
+        if not path.exists():
+            continue
+        data = load(path)
+        validator(data)
+        reject_full_source_content(data, name)
+        stores[name] = data
+    bundle = {
+        "bundle_version": VERSION,
+        "created_at": now_iso(),
+        "privacy": "private_local_not_public_evidence",
+        "stores": stores,
+    }
+    validate_bundle(bundle)
+    return bundle
+
+
+def record_timestamp(item: dict) -> str | None:
+    for key in ("updated_at", "recorded_at", "created_at"):
+        if isinstance(item.get(key), str) and item[key]:
+            return item[key]
+    return None
+
+
+def merge_record_lists(current: list[dict], incoming: list[dict], store_name: str) -> list[dict]:
+    merged = {item["id"]: item for item in current}
+    for candidate in incoming:
+        existing = merged.get(candidate["id"])
+        if existing is None:
+            merged[candidate["id"]] = candidate
+            continue
+        if existing == candidate:
+            continue
+
+        # Learning evidence can legitimately acquire delayed results later without changing recorded_at.
+        if store_name == "learning_utility":
+            comparable_existing = dict(existing)
+            comparable_candidate = dict(candidate)
+            delayed_existing = comparable_existing.pop("delayed", None)
+            delayed_candidate = comparable_candidate.pop("delayed", None)
+            transfer_existing = comparable_existing.pop("transfer", None)
+            transfer_candidate = comparable_candidate.pop("transfer", None)
+            if comparable_existing == comparable_candidate:
+                if delayed_existing is None and delayed_candidate is not None:
+                    merged[candidate["id"]] = candidate
+                    continue
+                if delayed_candidate is None and delayed_existing is not None:
+                    continue
+                if delayed_existing == delayed_candidate and transfer_existing == transfer_candidate:
+                    continue
+
+        old_ts = record_timestamp(existing)
+        new_ts = record_timestamp(candidate)
+        if old_ts and new_ts and old_ts != new_ts:
+            merged[candidate["id"]] = candidate if new_ts > old_ts else existing
+            continue
+        raise LocalStateError(f"ambiguous conflict in {store_name} for id {candidate['id']}")
+    return [merged[key] for key in sorted(merged)]
+
+
+def merge_baseline(current: dict, incoming: dict) -> dict:
+    personal_baseline.validate_store(current)
+    personal_baseline.validate_store(incoming)
+    entries = merge_record_lists(current["entries"], incoming["entries"], "personal_baseline")
+    active = {}
+    for key in ("goals", "projects", "questions"):
+        active[key] = sorted(set(current["active_context"][key]) | set(incoming["active_context"][key]))
+    result = {
+        "version": personal_baseline.VERSION,
+        "revision": max(current["revision"], incoming["revision"]) + 1,
+        "updated_at": now_iso(),
+        "entries": entries,
+        "active_context": active,
+    }
+    personal_baseline.validate_store(result)
+    return result
+
+
+def empty_for_store(name: str) -> dict:
+    if name == "personal_baseline":
+        return personal_baseline.empty_store()
+    return {"version": STORE_SPECS[name][1].__module__ and "1.0.0", "records": []}
+
+
+def load_current(name: str, path: Path) -> dict:
+    if path.exists():
+        data = load(path)
+        STORE_SPECS[name][1](data)
+        return data
+    if name == "personal_baseline":
+        return personal_baseline.empty_store()
+    module = {
+        "learning_utility": learning_utility,
+        "action_outcomes": action_outcomes,
+        "dogfood_cohort": dogfood,
+        "source_decision_benchmark": source_decision_benchmark,
+    }[name]
+    return {"version": module.VERSION, "records": []}
+
+
+def merge_store(name: str, current: dict, incoming: dict) -> dict:
+    if name == "personal_baseline":
+        return merge_baseline(current, incoming)
+    result = {"version": current.get("version") or incoming.get("version"), "records": merge_record_lists(current.get("records", []), incoming.get("records", []), name)}
+    STORE_SPECS[name][1](result)
+    return result
+
+
+def import_bundle(bundle: dict, overrides: dict[str, Path] | None = None) -> dict:
+    validate_bundle(bundle)
+    overrides = overrides or {}
+    written: list[str] = []
+    for name, incoming in bundle["stores"].items():
+        default_path = STORE_SPECS[name][0]
+        target = overrides.get(name, default_path)
+        current = load_current(name, target)
+        merged = merge_store(name, current, incoming)
+        reject_full_source_content(merged, name)
+        dump(target, merged)
+        written.append(name)
+    return {"written_stores": sorted(written), "privacy": "private_local_not_public_evidence"}
+
+
+def self_test() -> int:
+    insight_id = next(iter(sorted(action_outcomes.known_insights())), None)
+    if not insight_id:
+        print("local state self-test requires an insight")
+        return 1
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        paths = {
+            "personal_baseline": root / "device-a-baseline.json",
+            "action_outcomes": root / "device-a-outcomes.json",
+        }
+        baseline = personal_baseline.empty_store()
+        personal_baseline.upsert_entry(baseline, "Policy as code", "known", "experience")
+        personal_baseline.write_store(paths["personal_baseline"], baseline)
+        outcomes = action_outcomes.empty_store()
+        action_outcomes.start_record(outcomes, insight_id, "try", "Test a policy boundary", "Observe enforcement separation", ["policy-as-code"], None, "fixture-action")
+        action_outcomes.write_store(paths["action_outcomes"], outcomes)
+
+        bundle = export_bundle(paths)
+        if set(bundle["stores"]) != {"personal_baseline", "action_outcomes"}:
+            print("local state self-test failed: export store selection")
+            return 1
+
+        target_paths = {
+            "personal_baseline": root / "device-b-baseline.json",
+            "action_outcomes": root / "device-b-outcomes.json",
+        }
+        import_bundle(bundle, target_paths)
+        imported_baseline = personal_baseline.load_store(target_paths["personal_baseline"])
+        imported_outcomes = action_outcomes.load_store(target_paths["action_outcomes"])
+        if imported_baseline["entries"][0]["concept"] != "Policy as code" or imported_outcomes["records"][0]["id"] != "fixture-action":
+            print("local state self-test failed: round trip")
+            return 1
+
+        malicious = dict(bundle)
+        malicious["stores"] = {"action_outcomes": {"version": "1.0.0", "records": [{"id": "x", "transcript": "no"}]}}
+        try:
+            validate_bundle(malicious)
+        except LocalStateError:
+            pass
+        else:
+            print("local state self-test failed: full-source content guard")
+            return 1
+    print("local state self-test passed; versioned export/import, merge and full-source guards work.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    export = sub.add_parser("export")
+    export.add_argument("--out", type=Path, required=True)
+    import_cmd = sub.add_parser("import")
+    import_cmd.add_argument("--in", dest="input", type=Path, required=True)
+    inspect = sub.add_parser("inspect")
+    inspect.add_argument("--in", dest="input", type=Path, required=True)
+    sub.add_parser("self-test")
+    args = parser.parse_args()
+
+    try:
+        if args.command == "self-test":
+            return self_test()
+        if args.command == "export":
+            bundle = export_bundle()
+            dump(args.out, bundle)
+            print(f"exported {len(bundle['stores'])} private store(s) to {args.out}")
+        elif args.command == "import":
+            result = import_bundle(load(args.input))
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+        else:
+            bundle = load(args.input)
+            validate_bundle(bundle)
+            print(json.dumps({"bundle_version": bundle["bundle_version"], "created_at": bundle["created_at"], "stores": sorted(bundle["stores"]), "privacy": bundle["privacy"]}, ensure_ascii=False, indent=2))
+    except (LocalStateError, json.JSONDecodeError, ValueError) as exc:
+        print(f"local state error: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/next_research.py
+++ b/scripts/next_research.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Derive a transparent next-research queue from explicit knowledge gaps.
+
+Candidates come from unresolved prerequisites, synthesis gaps, unresolved contradiction/refinement
+reviews and low-coverage concepts. Generic graph neighbors are intentionally not used as a feed.
+User dispositions live under .local/; generated briefs never invent a source URL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import personal_baseline
+except ImportError:  # pragma: no cover
+    personal_baseline = None
+
+ROOT = Path(__file__).resolve().parents[1]
+PREREQUISITES = ROOT / "data" / "prerequisite-maps.json"
+SYNTHESES = ROOT / "data" / "syntheses.json"
+REVIEWS = ROOT / "data" / "knowledge-reviews.json"
+GRAPH = ROOT / "data" / "knowledge-graph.json"
+INBOX = ROOT / "data" / "inbox.json"
+DEFAULT_STORE = ROOT / ".local" / "next-research.json"
+VERSION = "1.0.0"
+DISPOSITIONS = {"new", "queued", "deferred", "ignored", "closed"}
+KINDS = {"learn_prerequisite", "verify_claim", "resolve_contradiction", "update_living_source", "explore_adjacent_leverage"}
+UNPROCESSED_STATUSES = {"queued", "researching", "prepared", "mapped"}
+
+
+class NextResearchError(ValueError):
+    pass
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def empty_store() -> dict:
+    return {"version": VERSION, "dispositions": []}
+
+
+def load_store(path: Path) -> dict:
+    if not path.exists():
+        return empty_store()
+    data = load(path)
+    validate_store(data)
+    return data
+
+
+def write_store(path: Path, data: dict) -> None:
+    validate_store(data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def validate_store(data: dict) -> None:
+    if data.get("version") != VERSION:
+        raise NextResearchError(f"unsupported next-research store version: {data.get('version')!r}")
+    rows = data.get("dispositions")
+    if not isinstance(rows, list):
+        raise NextResearchError("dispositions must be a list")
+    seen: set[str] = set()
+    for index, row in enumerate(rows):
+        where = f"dispositions[{index}]"
+        if not isinstance(row, dict):
+            raise NextResearchError(f"{where} must be an object")
+        if not isinstance(row.get("candidate_id"), str) or not row["candidate_id"]:
+            raise NextResearchError(f"{where}.candidate_id must be non-empty")
+        if row["candidate_id"] in seen:
+            raise NextResearchError(f"duplicate candidate disposition: {row['candidate_id']}")
+        seen.add(row["candidate_id"])
+        if row.get("status") not in DISPOSITIONS - {"new"}:
+            raise NextResearchError(f"{where}.status invalid")
+        if row.get("materially_closed") not in {None, True, False}:
+            raise NextResearchError(f"{where}.materially_closed must be null/bool")
+        if row.get("status") == "closed" and not row.get("closed_by_intake_id"):
+            raise NextResearchError(f"{where}.closed_by_intake_id required when closed")
+
+
+def tokens(value: str) -> set[str]:
+    return {part for part in re.findall(r"[a-z0-9][a-z0-9_-]{2,}", value.casefold()) if len(part) > 2}
+
+
+def candidate_id(kind: str, source_key: str, statement: str) -> str:
+    digest = hashlib.sha1(f"{kind}|{source_key}|{statement}".encode("utf-8")).hexdigest()[:10]
+    return f"next-{kind.replace('_', '-')}-{digest}"
+
+
+def make_candidate(kind: str, source_key: str, statement: str, reason: str, base_score: int, evidence_refs: list[str]) -> dict:
+    if kind not in KINDS:
+        raise NextResearchError(f"unknown candidate kind: {kind}")
+    return {
+        "id": candidate_id(kind, source_key, statement),
+        "kind": kind,
+        "statement": statement.strip(),
+        "reason": reason.strip(),
+        "base_score": base_score,
+        "evidence_refs": evidence_refs,
+        "source_key": source_key,
+    }
+
+
+def derive_candidates(prerequisites: dict, syntheses: dict, reviews: dict, graph: dict) -> list[dict]:
+    candidates: list[dict] = []
+
+    for record in prerequisites.get("records", []):
+        for item in record.get("items", []):
+            unresolved = item.get("state") not in {"known_in_graph", "explained_here"}
+            if unresolved and item.get("priority") in {"must_know_now", "learn_next"}:
+                statement = f"Learn enough about {item.get('label', item.get('concept_id'))} to resolve the prerequisite for {record.get('insight_id')}."
+                candidates.append(make_candidate(
+                    "learn_prerequisite", item.get("id", record.get("insight_id", "prerequisite")), statement,
+                    item.get("reason") or "An explicit prerequisite remains unresolved.",
+                    90 if item.get("priority") == "must_know_now" else 80,
+                    [item.get("id")],
+                ))
+
+    for synthesis in syntheses.get("records", []):
+        for gap in synthesis.get("unresolved_gaps", []):
+            statement = gap.get("statement") or "Resolve an explicit synthesis gap."
+            candidates.append(make_candidate(
+                "verify_claim", gap.get("id", synthesis.get("id", "synthesis")), statement,
+                f"Unresolved gap in synthesis: {synthesis.get('title', synthesis.get('id', 'unknown'))}",
+                100,
+                list(gap.get("claim_refs", [])),
+            ))
+
+    for review in reviews.get("reviews", []):
+        if review.get("status") != "resolved":
+            statement = f"Resolve whether {review.get('concept_id')} is truly {review.get('candidate_type', 'changed')} in light of {review.get('trigger_insight_id')}."
+            candidates.append(make_candidate(
+                "resolve_contradiction", review.get("id", "review"), statement,
+                review.get("rationale") or "A contradiction/refinement review remains unresolved.",
+                95,
+                list(review.get("evidence", {}).get("new_claim_ids", [])) + list(review.get("evidence", {}).get("prior_claim_ids", [])),
+            ))
+
+    for concept in graph.get("concepts", []):
+        if concept.get("coverage") == "introduced" and len(concept.get("insight_ids", [])) <= 1:
+            statement = f"Find independent evidence or a practical source that deepens {concept.get('label', concept.get('id'))}."
+            candidates.append(make_candidate(
+                "explore_adjacent_leverage", concept.get("id", "concept"), statement,
+                "The concept is only introduced and currently depends on a narrow evidence base.",
+                55,
+                list(concept.get("insight_ids", [])),
+            ))
+
+    unique = {item["id"]: item for item in candidates}
+    return list(unique.values())
+
+
+def personal_terms(store_path: Path | None) -> set[str]:
+    if personal_baseline is None or store_path is None or not store_path.exists():
+        return set()
+    data = personal_baseline.load_store(store_path)
+    text = " ".join(
+        data["active_context"]["goals"] + data["active_context"]["projects"] + data["active_context"]["questions"]
+    )
+    return tokens(text)
+
+
+def link_existing_inbox(candidate: dict, inbox: dict) -> dict | None:
+    target_terms = tokens(candidate["statement"] + " " + candidate["reason"])
+    best = None
+    best_score = 0
+    for item in inbox.get("items", []):
+        if item.get("status") not in UNPROCESSED_STATUSES:
+            continue
+        text = " ".join([item.get("requested_focus") or "", item.get("notes") or "", item.get("source_url") or ""])
+        score = len(target_terms & tokens(text))
+        if score > best_score:
+            best = item
+            best_score = score
+    if best is None or best_score < 2:
+        return None
+    return {"intake_id": best["id"], "source_url": best.get("source_url"), "match_terms": best_score}
+
+
+def rank_candidates(candidates: list[dict], inbox: dict, personal: set[str]) -> list[dict]:
+    ranked = []
+    for candidate in candidates:
+        overlap = sorted(personal & tokens(candidate["statement"] + " " + candidate["reason"]))
+        score = candidate["base_score"] + 8 * len(overlap)
+        existing = link_existing_inbox(candidate, inbox)
+        item = dict(candidate)
+        item["score"] = score
+        item["personal_context_matches"] = overlap
+        item["existing_inbox"] = existing
+        item["research_brief"] = (
+            f"Use existing intake {existing['intake_id']} to test whether it closes this target: {candidate['statement']}"
+            if existing else
+            f"Find a primary, official or otherwise high-quality source that can answer this research target without assuming the conclusion: {candidate['statement']}"
+        )
+        ranked.append(item)
+    ranked.sort(key=lambda item: (-item["score"], item["kind"], item["id"]))
+    return ranked
+
+
+def disposition_map(store: dict) -> dict[str, dict]:
+    return {row["candidate_id"]: row for row in store["dispositions"]}
+
+
+def apply_dispositions(candidates: list[dict], store: dict) -> list[dict]:
+    dispositions = disposition_map(store)
+    output = []
+    for item in candidates:
+        row = dispositions.get(item["id"])
+        enriched = dict(item)
+        enriched["disposition"] = row.get("status") if row else "new"
+        enriched["disposition_note"] = row.get("note") if row else None
+        enriched["closed_by_intake_id"] = row.get("closed_by_intake_id") if row else None
+        enriched["materially_closed"] = row.get("materially_closed") if row else None
+        output.append(enriched)
+    return output
+
+
+def set_disposition(store: dict, candidate_id_value: str, status: str, note: str | None, closed_by: str | None, materially_closed: bool | None) -> dict:
+    if status not in DISPOSITIONS - {"new"}:
+        raise NextResearchError(f"status must be one of {sorted(DISPOSITIONS - {'new'})}")
+    if status == "closed" and not closed_by:
+        raise NextResearchError("--closed-by-intake is required for closed status")
+    rows = disposition_map(store)
+    row = rows.get(candidate_id_value)
+    if row is None:
+        row = {"candidate_id": candidate_id_value}
+        store["dispositions"].append(row)
+    row.update({
+        "status": status,
+        "note": note or None,
+        "closed_by_intake_id": closed_by if status == "closed" else None,
+        "materially_closed": materially_closed if status == "closed" else None,
+        "updated_at": now_iso(),
+    })
+    validate_store(store)
+    return row
+
+
+def load_ranked(personal_store: Path | None = None) -> list[dict]:
+    candidates = derive_candidates(load(PREREQUISITES), load(SYNTHESES), load(REVIEWS), load(GRAPH))
+    return rank_candidates(candidates, load(INBOX), personal_terms(personal_store))
+
+
+def self_test() -> int:
+    prereq = {"records": [{"insight_id": "i1", "items": [{"id": "p1", "label": "X", "priority": "learn_next", "state": "unresolved", "reason": "Needed for workflow retry"}]}]}
+    synth = {"records": [{"id": "s1", "title": "S", "unresolved_gaps": [{"id": "g1", "statement": "Does workflow retry preserve external correctness?", "claim_refs": ["c1"]}]}]}
+    reviews = {"reviews": []}
+    graph = {"concepts": [{"id": "c-low", "label": "Low coverage", "coverage": "introduced", "insight_ids": ["i1"]}]}
+    inbox = {"items": [{"id": "intake-1", "status": "queued", "source_url": "https://example.com", "requested_focus": "workflow retry external correctness", "notes": ""}]}
+    candidates = derive_candidates(prereq, synth, reviews, graph)
+    ranked = rank_candidates(candidates, inbox, {"workflow", "retry"})
+    if ranked[0]["kind"] != "verify_claim" or ranked[0]["existing_inbox"] is None:
+        print("next research self-test failed: ranking/inbox matching")
+        return 1
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "state.json"
+        store = load_store(path)
+        set_disposition(store, ranked[0]["id"], "queued", "test", None, None)
+        write_store(path, store)
+        if apply_dispositions(ranked, load_store(path))[0]["disposition"] != "queued":
+            print("next research self-test failed: disposition persistence")
+            return 1
+    print("next research self-test passed; explicit gaps, transparent ranking, inbox reuse and dispositions work.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store", type=Path, default=DEFAULT_STORE)
+    parser.add_argument("--personal-store", type=Path, default=(personal_baseline.DEFAULT_STORE if personal_baseline else None))
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    show = sub.add_parser("show")
+    show.add_argument("--limit", type=int, default=20)
+    show.add_argument("--include-ignored", action="store_true")
+    show.add_argument("--json", action="store_true")
+
+    set_cmd = sub.add_parser("set")
+    set_cmd.add_argument("--candidate", required=True)
+    set_cmd.add_argument("--status", choices=sorted(DISPOSITIONS - {"new"}), required=True)
+    set_cmd.add_argument("--note")
+    set_cmd.add_argument("--closed-by-intake")
+    closure = set_cmd.add_mutually_exclusive_group()
+    closure.add_argument("--materially-closed", action="store_true")
+    closure.add_argument("--not-materially-closed", action="store_true")
+
+    sub.add_parser("self-test")
+    args = parser.parse_args()
+    try:
+        if args.command == "self-test":
+            return self_test()
+        store = load_store(args.store)
+        if args.command == "set":
+            closure_value = True if args.materially_closed else False if args.not_materially_closed else None
+            row = set_disposition(store, args.candidate, args.status, args.note, args.closed_by_intake, closure_value)
+            write_store(args.store, store)
+            print(json.dumps(row, ensure_ascii=False, indent=2))
+        else:
+            candidates = apply_dispositions(load_ranked(args.personal_store), store)
+            if not args.include_ignored:
+                candidates = [item for item in candidates if item["disposition"] not in {"ignored", "closed"}]
+            candidates = candidates[: max(args.limit, 0)]
+            if args.json:
+                print(json.dumps({"candidates": candidates}, ensure_ascii=False, indent=2))
+            else:
+                for item in candidates:
+                    print(f"{item['id']} [{item['kind']}] score={item['score']} status={item['disposition']}")
+                    print(f"  target: {item['statement']}")
+                    print(f"  why: {item['reason']}")
+                    print(f"  next: {item['research_brief']}")
+                    if item["personal_context_matches"]:
+                        print("  context matches: " + ", ".join(item["personal_context_matches"]))
+    except (NextResearchError, json.JSONDecodeError, ValueError) as exc:
+        print(f"next research error: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_personalized.py
+++ b/scripts/run_personalized.py
@@ -1,24 +1,33 @@
 #!/usr/bin/env python3
-"""Prepare/resume a source run with an explicit private personal-context sidecar.
+"""Prepare/resume a source run with explicit private personal context.
 
-This wraps scripts/run_source.py. Public/versioned run manifests receive only baseline
-metadata (version, revision and fingerprint); selected personal entries stay under .local/.
+This wraps scripts/run_source.py. Versioned manifests receive only fingerprints/counts;
+selected baseline entries and personal action outcomes stay under .local/ and never become
+public/source evidence.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from pathlib import Path
 
+import action_outcomes
 import run_source
 from personal_baseline import DEFAULT_STORE, load_store, select_context
 
 ROOT = Path(__file__).resolve().parents[1]
 PRIVATE_CONTEXT_DIR = ROOT / ".local" / "run-context"
+DEFAULT_OUTCOME_STORE = action_outcomes.DEFAULT_STORE
 
 
-def write_private_context(item: dict, store_path: Path, limit: int) -> dict:
+def fingerprint(value: object) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def write_private_context(item: dict, store_path: Path, outcome_store: Path, limit: int) -> dict:
     data = load_store(store_path)
     query = " ".join(
         part
@@ -29,17 +38,31 @@ def write_private_context(item: dict, store_path: Path, limit: int) -> dict:
         )
         if part
     )
-    snapshot = select_context(data, query, limit=limit)
+    baseline_snapshot = select_context(data, query, limit=limit)
+    outcomes_store = action_outcomes.load_store(outcome_store)
+    outcomes = action_outcomes.select_context(outcomes_store, query, limit=limit)
+    sidecar = {
+        "query": query,
+        "baseline": baseline_snapshot,
+        "action_outcomes": outcomes,
+        "privacy": {
+            "classification": "private_local",
+            "public_evidence": False,
+            "rule": "Explicit personal knowledge and outcomes may guide relevance/action recommendations but never become external evidence.",
+        },
+    }
     target = PRIVATE_CONTEXT_DIR / f"{item['id']}.json"
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(json.dumps(snapshot, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    target.write_text(json.dumps(sidecar, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return {
-        "available": bool(snapshot["entries"] or any(snapshot["active_context"].values())),
-        "baseline_version": snapshot["baseline_version"],
-        "baseline_revision": snapshot["baseline_revision"],
-        "baseline_fingerprint": snapshot["baseline_fingerprint"],
+        "available": bool(baseline_snapshot["entries"] or any(baseline_snapshot["active_context"].values()) or outcomes),
+        "baseline_version": baseline_snapshot["baseline_version"],
+        "baseline_revision": baseline_snapshot["baseline_revision"],
+        "baseline_fingerprint": baseline_snapshot["baseline_fingerprint"],
+        "outcomes_fingerprint": fingerprint(outcomes_store),
         "private_sidecar": str(target.relative_to(ROOT)),
-        "selected_entries": len(snapshot["entries"]),
+        "selected_entries": len(baseline_snapshot["entries"]),
+        "selected_outcomes": len(outcomes),
         "privacy": "private_local_not_public_evidence",
     }
 
@@ -69,6 +92,7 @@ def main() -> int:
     parser.add_argument("--focus", default="")
     parser.add_argument("--note", default="")
     parser.add_argument("--baseline-store", type=Path, default=DEFAULT_STORE)
+    parser.add_argument("--outcome-store", type=Path, default=DEFAULT_OUTCOME_STORE)
     parser.add_argument("--personal-limit", type=int, default=8)
     parser.add_argument("--no-checks", action="store_true")
     parser.add_argument("--json", action="store_true")
@@ -85,15 +109,15 @@ def main() -> int:
     state = run_source.evaluate_state(item, bundle)
     manifest = run_source.write_manifest(item, state, bundle_path, created_bundle)
 
-    personal = write_private_context(item, args.baseline_store, args.personal_limit)
+    personal = write_private_context(item, args.baseline_store, args.outcome_store, args.personal_limit)
     manifest["personal_context"] = personal
     instruction = manifest.setdefault("agent_handoff", {}).get("instruction", "")
     manifest["agent_handoff"]["instruction"] = (
         instruction
-        + " If personal_context.available is true, read the private sidecar before selecting explanation depth/relevance. "
-        + "Treat user assertions and personal experience as private context only: never cite them as source evidence, "
-        + "never merge them into the public knowledge graph, and keep evidence-backed Knowledge Delta separate from "
-        + "personal novelty/relevance."
+        + " If personal_context.available is true, read the private sidecar before selecting explanation depth, practical relevance and action recommendations. "
+        + "Treat user assertions, experience and personal action outcomes as private context only: never cite them as source evidence, "
+        + "never merge them into the public knowledge graph, and keep evidence-backed Knowledge Delta separate from personal novelty/relevance. "
+        + "An adopted/rejected personal outcome can adjust what is worth trying next, but it cannot prove or disprove an external claim."
     ).strip()
 
     mature = (
@@ -120,8 +144,12 @@ def main() -> int:
         print(json.dumps(manifest, ensure_ascii=False, indent=2))
     else:
         print(f"intake: {item['id']}")
-        print(f"private context: {personal['private_sidecar']} ({personal['selected_entries']} selected entries)")
+        print(
+            f"private context: {personal['private_sidecar']} "
+            f"({personal['selected_entries']} baseline entries, {personal['selected_outcomes']} prior outcomes)"
+        )
         print(f"baseline revision: {personal['baseline_revision']} / {personal['baseline_fingerprint'][:12]}")
+        print(f"outcomes fingerprint: {personal['outcomes_fingerprint'][:12]}")
         print(f"next: {manifest['state']['next_blocking_action']}")
     return 0
 

--- a/scripts/validate_private_boundary.py
+++ b/scripts/validate_private_boundary.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Fail if private personal context can leak into versioned/public projection paths."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFESTS = ROOT / "data" / "run-manifests"
+GITIGNORE = ROOT / ".gitignore"
+PUBLIC_BUILDERS = [
+    ROOT / "scripts" / "build.py",
+    ROOT / "scripts" / "build_graph.py",
+    ROOT / "scripts" / "build_library.py",
+    ROOT / "scripts" / "build_syntheses.py",
+    ROOT / "scripts" / "build_sitemap.py",
+]
+FORBIDDEN_BUILDER_MARKERS = [".local/", "personal-baseline.json", "action-outcomes.json", "run-context/"]
+ALLOWED_MANIFEST_KEYS = {
+    "available",
+    "baseline_version",
+    "baseline_revision",
+    "baseline_fingerprint",
+    "outcomes_fingerprint",
+    "private_sidecar",
+    "selected_entries",
+    "selected_outcomes",
+    "privacy",
+}
+FORBIDDEN_PERSONAL_KEYS = {
+    "entries", "active_context", "goals", "projects", "questions", "action_outcomes",
+    "hypothesis", "intended_outcome", "result_summary", "user_assertion", "experience"
+}
+
+
+class PrivateBoundaryError(ValueError):
+    pass
+
+
+def validate_manifest_personal(manifest: dict, where: str) -> None:
+    personal = manifest.get("personal_context")
+    if personal is None:
+        return
+    if not isinstance(personal, dict):
+        raise PrivateBoundaryError(f"{where}.personal_context must be metadata object")
+    unknown = set(personal) - ALLOWED_MANIFEST_KEYS
+    if unknown:
+        raise PrivateBoundaryError(f"{where}.personal_context leaks unsupported fields: {sorted(unknown)}")
+    forbidden = set(personal) & FORBIDDEN_PERSONAL_KEYS
+    if forbidden:
+        raise PrivateBoundaryError(f"{where}.personal_context leaks private content: {sorted(forbidden)}")
+    sidecar = personal.get("private_sidecar")
+    if sidecar is not None and not (isinstance(sidecar, str) and sidecar.startswith(".local/run-context/")):
+        raise PrivateBoundaryError(f"{where}.private_sidecar must stay under .local/run-context/")
+    if personal.get("privacy") != "private_local_not_public_evidence":
+        raise PrivateBoundaryError(f"{where}.personal_context must declare private boundary")
+
+
+def validate_repo() -> None:
+    ignore = GITIGNORE.read_text(encoding="utf-8") if GITIGNORE.exists() else ""
+    if ".local/" not in ignore.splitlines():
+        raise PrivateBoundaryError(".gitignore must exclude .local/")
+
+    for path in PUBLIC_BUILDERS:
+        if not path.exists():
+            raise PrivateBoundaryError(f"missing public builder: {path.relative_to(ROOT)}")
+        text = path.read_text(encoding="utf-8")
+        matches = [marker for marker in FORBIDDEN_BUILDER_MARKERS if marker in text]
+        if matches:
+            raise PrivateBoundaryError(
+                f"public builder {path.relative_to(ROOT)} references private storage markers: {matches}"
+            )
+
+    if MANIFESTS.exists():
+        for path in sorted(MANIFESTS.glob("*.json")):
+            manifest = json.loads(path.read_text(encoding="utf-8"))
+            validate_manifest_personal(manifest, str(path.relative_to(ROOT)))
+
+
+def self_test() -> int:
+    safe = {
+        "personal_context": {
+            "available": True,
+            "baseline_version": "1.0.0",
+            "baseline_revision": 4,
+            "baseline_fingerprint": "abc",
+            "outcomes_fingerprint": "def",
+            "private_sidecar": ".local/run-context/intake.json",
+            "selected_entries": 2,
+            "selected_outcomes": 1,
+            "privacy": "private_local_not_public_evidence",
+        }
+    }
+    validate_manifest_personal(safe, "fixture")
+    leaking = {"personal_context": dict(safe["personal_context"], entries=[{"concept": "secret"}])}
+    try:
+        validate_manifest_personal(leaking, "fixture-leak")
+    except PrivateBoundaryError:
+        pass
+    else:
+        print("private boundary self-test failed: leaked entries accepted")
+        return 1
+    print("private boundary self-test passed; manifests can keep fingerprints/counts but not personal content.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.self_test:
+            return self_test()
+        validate_repo()
+    except (PrivateBoundaryError, json.JSONDecodeError) as exc:
+        print(f"private boundary validation failed: {exc}")
+        return 1
+    print("Private boundary validation passed; public builders are independent of .local personal context.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Second validation-first agent loop.

Implements:
- #31 portable versioned local-state export/import with conflict-safe merges and full-source-content guards;
- #42 private insight → action → outcome lifecycle, including future personalized-run relevance without promoting personal experience to source evidence;
- #44 evidence-driven next-research queue derived only from explicit prerequisite/synthesis/review/low-coverage gaps, with transparent personal-context scoring and queue/defer/ignore/close dispositions;
- remaining #41 leak-prevention boundary: public builders cannot depend on `.local`, and versioned run manifests can carry fingerprints/counts but not personal context/outcome content.

No public insight status changes occur in this PR. All personal state remains local/private. New deterministic self-tests are wired into the repository validation workflow.