### PR TITLE
P2: add physically separate private source/insight overlay

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -87,6 +87,12 @@ jobs:
           python scripts/validate_private_boundary.py
           python scripts/validate_private_boundary.py --self-test
 
+      - name: Validate private sensitive-source overlay
+        run: |
+          python scripts/private_overlay.py self-test
+          python scripts/validate_private_overlay.py
+          python scripts/validate_private_overlay.py --self-test
+
       - name: Test learning utility local loop
         run: python scripts/learning_utility.py self-test
 

--- a/docs/PRIVATE_OVERLAY.md
+++ b/docs/PRIVATE_OVERLAY.md
@@ -1,0 +1,172 @@
+# Private/local overlay
+
+Signal to Insight can use sensitive personal or internal sources without placing those records in the public repository.
+
+The safety boundary is physical, not a `private: true` flag inside public JSON:
+
+```text
+public repository
+  data/...
+  explainers/...
+  library/...
+  knowledge/...
+
+.local/private/                ← gitignored boundary
+  data/inbox.json
+  data/sources.json
+  data/insights.json
+  data/knowledge-graph.json
+  data/research-bundles/
+  run-context/
+  exports/
+```
+
+Public builders do not read `.local/private/`. This reduces the risk that one forgotten filter exposes a sensitive record through GitHub Pages.
+
+## Threat model
+
+This layer protects against the main accidental-publication failures in a local-first repository workflow:
+
+- committing sensitive source, insight or graph records by mistake;
+- allowing a public graph relation to depend on a private-only concept/insight;
+- making a public generator read the private store;
+- treating private experience/internal material as public source evidence;
+- exporting a private insight straight into `published` state;
+- carrying private URLs into an export without explicitly choosing to retain them.
+
+It does **not** make the local computer or external research provider confidential by itself. Sensitive raw content still needs appropriate device, provider and access controls. Full third-party/internal source text should remain transient research input where possible; `full_content_committed` remains false even inside the overlay.
+
+## Initialize
+
+```bash
+python scripts/private_overlay.py init
+```
+
+The default root is `.local/private`. A different root may be supplied with `--root`, but the repository validator only considers an overlay safe for normal operation when it remains under `.local/`.
+
+## Queue a sensitive source
+
+```bash
+python scripts/private_overlay.py queue \
+  "https://internal.example/source" \
+  --type documentation \
+  --focus "What changes my current model?" \
+  --note "Internal source — do not publish"
+```
+
+The intake record is written only to `.local/private/data/inbox.json`.
+
+## Scaffold the research bundle
+
+```bash
+python scripts/private_overlay.py scaffold <private-intake-id>
+```
+
+The normalized bundle uses the same source-safe bundle shape as the public pipeline where possible. It includes the normal public prior-knowledge snapshot.
+
+Private cumulative knowledge is intentionally **not** merged into that bundle. Instead the command writes a local `run-context/<intake-id>.json` sidecar with two clearly separated sets:
+
+```text
+public_matches   → public graph evidence/context
+private_matches  → local relevance/context only
+```
+
+A private match may reduce redundant explanation, highlight an internal dependency or influence practical relevance. It is never source evidence for a public claim merely because the local agent used it.
+
+## Private source / insight / graph records
+
+The overlay stores source, insight and graph objects in separate local registries. Reuse the public record shapes where applicable so research agents do not need a second conceptual model.
+
+Additional rules are stricter than the public pipeline:
+
+- a private insight may be `review` or `archived`, never `published`;
+- private source/insight/concept/relation IDs must not collide with public registry IDs;
+- private graph nodes may depend on public concepts/insights as read-only evidence/context;
+- public graph nodes may never depend on private-only IDs;
+- private records do not carry a `public` projection block;
+- normalized research bundles still require `full_content_committed: false`.
+
+## Query combined context
+
+```bash
+python scripts/private_overlay.py context \
+  "policy decision enforcement" \
+  --limit 5 \
+  --json
+```
+
+The result labels every match with provenance (`public_graph` or `private_overlay`). Keep that separation visible throughout analysis.
+
+## Export / redaction path
+
+A private insight that becomes safe to share must not be copied directly into `data/insights.json`.
+
+Create a local review candidate:
+
+```bash
+python scripts/private_overlay.py export \
+  --insight <private-insight-id> \
+  --confirm EXPORT:<private-insight-id>
+```
+
+Default export behavior:
+
+- writes only to `.local/private/exports/`;
+- strips overlay/public-projection metadata;
+- forces the insight back to `review`;
+- removes URL fields by default;
+- sets `public_write_allowed: false`;
+- includes a manual redaction/provenance checklist.
+
+Use `--keep-urls` only when those URLs are independently safe to expose.
+
+The export is **not** publication. After manual redaction, recreate or import the safe material through the normal public source/case contracts, establish canonical public provenance, run the normal validators, and use the explicit human review/publish workflow.
+
+## Accidental-commit and leak guards
+
+`.gitignore` contains the exact `.local/` rule.
+
+Run:
+
+```bash
+python scripts/private_overlay.py self-test
+python scripts/validate_private_overlay.py
+python scripts/validate_private_overlay.py --self-test
+python scripts/validate_private_boundary.py
+```
+
+`validate_private_overlay.py` checks an existing overlay and also provides fixture-driven leak tests. It rejects:
+
+- private overlay roots outside `.local/`;
+- private `published` status;
+- dangling private source/insight/bundle/graph references;
+- public/private ID collisions;
+- private graph `public` projection blocks;
+- private-only IDs appearing in versioned/public data or generated surfaces;
+- public graph dependency on private-only IDs;
+- public builders importing or referencing the private overlay;
+- export candidates that do not stop at `review` with `public_write_allowed: false`.
+
+`validate_private_boundary.py` additionally asserts that **all** public builders stay independent from `.local/` storage, including graph, library, synthesis, history, sitemap, preview and re-analysis generation.
+
+The CI self-test injects a private sentinel into a fake public graph and couples a fake public builder to `private_overlay`; both must be rejected.
+
+## Design rule
+
+Private knowledge can make the next private analysis better. It must never become public evidence by inference.
+
+The promotion boundary is always explicit:
+
+```text
+private source / experience
+        ↓
+private analysis
+        ↓
+redacted local export candidate
+        ↓
+human review + safe public provenance
+        ↓
+normal public review pipeline
+        ↓
+explicit publication
+```

--- a/scripts/private_overlay.py
+++ b/scripts/private_overlay.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Operate a physically separate local overlay for sensitive sources and insights.
+
+Private records live under .local/private by default. Public builders never read this directory.
+The overlay reuses public source/bundle/insight/graph shapes where possible, while private context
+is combined with public prior knowledge only in a local research sidecar.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import re
+import tempfile
+from datetime import date
+from pathlib import Path
+
+from graph_context import rank as public_rank
+from new_source import normalize_url, source_key
+from scaffold_bundle import build_bundle, prior_query
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ROOT = ROOT / ".local" / "private"
+ALLOWED_TYPES = {
+    "video", "article", "paper", "podcast", "documentation", "repository", "tool",
+    "product", "course", "presentation", "notes", "system",
+}
+
+
+class PrivateOverlayError(ValueError):
+    pass
+
+
+def load(path: Path, default: dict | None = None) -> dict:
+    if not path.exists() and default is not None:
+        return copy.deepcopy(default)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def dump(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def paths(root: Path) -> dict[str, Path]:
+    data = root / "data"
+    return {
+        "root": root,
+        "data": data,
+        "inbox": data / "inbox.json",
+        "sources": data / "sources.json",
+        "insights": data / "insights.json",
+        "graph": data / "knowledge-graph.json",
+        "bundles": data / "research-bundles",
+        "context": root / "run-context",
+        "exports": root / "exports",
+    }
+
+
+def init_overlay(root: Path) -> None:
+    p = paths(root)
+    root.mkdir(parents=True, exist_ok=True)
+    defaults = {
+        "inbox": {"items": []},
+        "sources": {"sources": []},
+        "insights": {"insights": []},
+        "graph": {"graph_version": "private-1.0.0", "updated_at": date.today().isoformat(), "concepts": [], "relations": []},
+    }
+    for name, value in defaults.items():
+        if not p[name].exists():
+            dump(p[name], value)
+    p["bundles"].mkdir(parents=True, exist_ok=True)
+    p["context"].mkdir(parents=True, exist_ok=True)
+    p["exports"].mkdir(parents=True, exist_ok=True)
+
+
+def find_private_source(root: Path, normalized_url: str) -> dict | None:
+    for source in load(paths(root)["sources"], {"sources": []}).get("sources", []):
+        try:
+            if normalize_url(source.get("canonical_url", "")) == normalized_url:
+                return source
+        except ValueError:
+            continue
+    return None
+
+
+def queue_source(root: Path, url: str, source_type: str, focus: str | None, note: str | None) -> dict:
+    if source_type not in ALLOWED_TYPES:
+        raise PrivateOverlayError(f"unsupported source type: {source_type}")
+    init_overlay(root)
+    p = paths(root)
+    normalized = normalize_url(url)
+    inbox = load(p["inbox"])
+    for item in inbox.get("items", []):
+        if normalize_url(item.get("source_url", "")) == normalized and (item.get("requested_focus") or None) == focus:
+            return item
+
+    existing_source = find_private_source(root, normalized)
+    today = date.today().isoformat()
+    base = f"intake-{today}-{source_key(normalized)}"
+    existing_ids = {item.get("id") for item in inbox.get("items", [])}
+    intake_id = base
+    suffix = 2
+    while intake_id in existing_ids:
+        intake_id = f"{base}-{suffix}"
+        suffix += 1
+    item = {
+        "id": intake_id,
+        "source_url": normalized,
+        "source_type": source_type,
+        "submitted_at": today,
+        "requested_focus": focus,
+        "status": "queued",
+        "source_id": existing_source.get("id") if existing_source else None,
+        "insight_id": None,
+        "notes": note,
+    }
+    inbox.setdefault("items", []).append(item)
+    dump(p["inbox"], inbox)
+    return item
+
+
+def tokens(text: str) -> set[str]:
+    return {part for part in re.findall(r"[a-z0-9][a-z0-9_-]+", text.casefold()) if len(part) > 2}
+
+
+def private_rank(root: Path, query: str, limit: int = 5) -> list[dict]:
+    graph = load(paths(root)["graph"], {"concepts": [], "relations": []})
+    insights = {item.get("id"): item for item in load(paths(root)["insights"], {"insights": []}).get("insights", [])}
+    query_tokens = tokens(query)
+    scored: list[tuple[float, dict]] = []
+    for concept in graph.get("concepts", []):
+        text = " ".join([
+            str(concept.get("id") or ""), str(concept.get("label") or ""), str(concept.get("summary") or ""),
+            " ".join(concept.get("aliases") or []), " ".join(concept.get("tags") or []),
+        ])
+        concept_tokens = tokens(text)
+        overlap = query_tokens & concept_tokens
+        if not overlap:
+            continue
+        score = len(overlap) / max(1, len(query_tokens))
+        evidence = []
+        for insight_id in concept.get("insight_ids") or []:
+            insight = insights.get(insight_id) or {}
+            evidence.append({"id": insight_id, "status": insight.get("status"), "title": insight.get("title")})
+        scored.append((score, {
+            "concept_id": concept.get("id"),
+            "label": concept.get("label"),
+            "coverage": concept.get("coverage"),
+            "matched_terms": sorted(overlap),
+            "evidence_insights": evidence,
+            "provenance": "private_overlay",
+        }))
+    scored.sort(key=lambda item: (-item[0], item[1].get("concept_id") or ""))
+    return [item for _, item in scored[:limit]]
+
+
+def combined_context(root: Path, query: str, limit: int = 5) -> dict:
+    public = public_rank(query, limit=limit)
+    public_matches = []
+    for match in public.get("matches", []):
+        item = copy.deepcopy(match)
+        item["provenance"] = "public_graph"
+        public_matches.append(item)
+    return {
+        "captured_at": date.today().isoformat(),
+        "query": query,
+        "public_matches": public_matches,
+        "private_matches": private_rank(root, query, limit=limit),
+        "rule": "Private matches may guide local explanation/relevance but are never public evidence unless explicitly exported, redacted and reviewed.",
+    }
+
+
+def get_intake(root: Path, intake_id: str) -> dict:
+    item = next((row for row in load(paths(root)["inbox"]).get("items", []) if row.get("id") == intake_id), None)
+    if item is None:
+        raise PrivateOverlayError(f"private intake not found: {intake_id}")
+    return item
+
+
+def scaffold(root: Path, intake_id: str) -> tuple[Path, Path]:
+    init_overlay(root)
+    p = paths(root)
+    item = get_intake(root, intake_id)
+    target = p["bundles"] / f"{intake_id}.json"
+    context_target = p["context"] / f"{intake_id}.json"
+    if target.exists():
+        raise PrivateOverlayError(f"private bundle already exists: {target}")
+    bundle = build_bundle(item)
+    # Keep the normalized bundle shape compatible with the public contract. Private knowledge is
+    # added only in the local sidecar so the core bundle does not gain secret/public semantics.
+    dump(target, bundle)
+    dump(context_target, combined_context(root, prior_query(item), limit=5))
+    return target, context_target
+
+
+def strip_public_markers(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            key: strip_public_markers(item)
+            for key, item in value.items()
+            if key not in {"public", "private", "privacy", "internal_note", "private_note"}
+        }
+    if isinstance(value, list):
+        return [strip_public_markers(item) for item in value]
+    return value
+
+
+def redact_urls(value: object) -> object:
+    if isinstance(value, dict):
+        output = {}
+        for key, item in value.items():
+            if key in {"url", "canonical_url", "source_url", "html_url", "download_url"}:
+                output[key] = None
+            else:
+                output[key] = redact_urls(item)
+        return output
+    if isinstance(value, list):
+        return [redact_urls(item) for item in value]
+    return value
+
+
+def export_candidate(root: Path, insight_id: str, keep_urls: bool, confirm: str) -> Path:
+    if confirm != f"EXPORT:{insight_id}":
+        raise PrivateOverlayError(f"export confirmation must exactly equal EXPORT:{insight_id}")
+    init_overlay(root)
+    p = paths(root)
+    insights = load(p["insights"]).get("insights", [])
+    insight = next((item for item in insights if item.get("id") == insight_id), None)
+    if insight is None:
+        raise PrivateOverlayError(f"private insight not found: {insight_id}")
+    source_id = insight.get("source_id")
+    source = next((item for item in load(p["sources"]).get("sources", []) if item.get("id") == source_id), None)
+    if source is None:
+        raise PrivateOverlayError(f"private insight source not found: {source_id}")
+
+    clean_insight = strip_public_markers(copy.deepcopy(insight))
+    clean_source = strip_public_markers(copy.deepcopy(source))
+    if isinstance(clean_insight, dict):
+        clean_insight["status"] = "review"
+    if not keep_urls:
+        clean_source = redact_urls(clean_source)
+        clean_insight = redact_urls(clean_insight)
+    candidate = {
+        "export_version": "1.0.0",
+        "created_at": date.today().isoformat(),
+        "source": clean_source,
+        "insight": clean_insight,
+        "redaction": {
+            "urls_retained": bool(keep_urls),
+            "automatic_steps": [
+                "Removed overlay-only/private/public-projection metadata.",
+                "Forced insight status to review.",
+                "Removed URLs by default." if not keep_urls else "URLs explicitly retained by export operator.",
+            ],
+            "manual_review_required": [
+                "Check title, examples, claims, names, identifiers and business context for sensitive information.",
+                "Replace or verify canonical public source provenance before any public registry write.",
+                "Re-run normal claim/evidence, Knowledge Delta, graph and publication review gates.",
+            ],
+        },
+        "public_write_allowed": False,
+        "next_step": "Human-review this local export candidate. A separate normal public case/review workflow is required; this command never writes public data.",
+    }
+    target = p["exports"] / f"{insight_id}.json"
+    dump(target, candidate)
+    return target
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "private"
+        init_overlay(root)
+        p = paths(root)
+        source = {
+            "id": "private-src-fixture",
+            "type": "article",
+            "title": "Private source sentinel",
+            "canonical_url": "https://private.example.invalid/secret",
+            "creators": [],
+            "publisher": None,
+            "published_at": None,
+            "event_date": None,
+            "captured_at": "2026-08-27",
+            "analyzed_at": "2026-08-27",
+            "date_note": "Private fixture.",
+            "verification": [],
+        }
+        insight = {
+            "id": "private-insight-fixture",
+            "source_id": "private-src-fixture",
+            "status": "review",
+            "title": "Private insight sentinel",
+        }
+        graph = load(p["graph"])
+        graph["concepts"].append({
+            "id": "private-secret-concept",
+            "label": "Private secret concept",
+            "summary": "A private sentinel model used only for the overlay self-test.",
+            "domain": "fixture",
+            "coverage": "explained",
+            "insight_ids": ["private-insight-fixture"],
+            "aliases": ["private sentinel"],
+            "tags": ["private", "sentinel"],
+        })
+        dump(p["sources"], {"sources": [source]})
+        dump(p["insights"], {"insights": [insight]})
+        dump(p["graph"], graph)
+
+        item = queue_source(root, "https://private.example.invalid/second", "article", "private sentinel", "fixture")
+        bundle, context_path = scaffold(root, item["id"])
+        if not bundle.exists() or not context_path.exists():
+            print("Private overlay self-test failed: scaffold outputs missing.")
+            return 1
+        context = load(context_path)
+        if not any(match.get("concept_id") == "private-secret-concept" for match in context.get("private_matches", [])):
+            print("Private overlay self-test failed: private knowledge did not assist research context.")
+            return 1
+        if any(match.get("provenance") != "private_overlay" for match in context.get("private_matches", [])):
+            print("Private overlay self-test failed: private context provenance lost.")
+            return 1
+
+        exported = export_candidate(root, "private-insight-fixture", keep_urls=False, confirm="EXPORT:private-insight-fixture")
+        candidate = load(exported)
+        if candidate["source"].get("canonical_url") is not None or candidate["public_write_allowed"] is not False:
+            print("Private overlay self-test failed: safe export boundary not preserved.")
+            return 1
+        if candidate["insight"].get("status") != "review":
+            print("Private overlay self-test failed: export candidate did not stop at review.")
+            return 1
+    print("Private overlay self-test passed; private context stays local and export stops at a redacted review candidate.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT, help="Private overlay root (default: .local/private)")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("init")
+
+    queue = sub.add_parser("queue")
+    queue.add_argument("url")
+    queue.add_argument("--type", dest="source_type", choices=sorted(ALLOWED_TYPES), default="article")
+    queue.add_argument("--focus", default="")
+    queue.add_argument("--note", default="")
+
+    scaffold_cmd = sub.add_parser("scaffold")
+    scaffold_cmd.add_argument("intake_id")
+
+    context_cmd = sub.add_parser("context")
+    context_cmd.add_argument("query")
+    context_cmd.add_argument("--limit", type=int, default=5)
+    context_cmd.add_argument("--json", action="store_true")
+
+    export = sub.add_parser("export")
+    export.add_argument("--insight", required=True)
+    export.add_argument("--keep-urls", action="store_true")
+    export.add_argument("--confirm", required=True)
+
+    sub.add_parser("self-test")
+    args = parser.parse_args()
+    try:
+        if args.command == "init":
+            init_overlay(args.root)
+            print(f"initialized {args.root}")
+        elif args.command == "queue":
+            item = queue_source(args.root, args.url, args.source_type, args.focus.strip() or None, args.note.strip() or None)
+            print(json.dumps(item, ensure_ascii=False, indent=2))
+        elif args.command == "scaffold":
+            bundle, context_path = scaffold(args.root, args.intake_id)
+            print(f"bundle: {bundle}\nprivate context: {context_path}")
+        elif args.command == "context":
+            result = combined_context(args.root, args.query, args.limit)
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+        elif args.command == "export":
+            target = export_candidate(args.root, args.insight, args.keep_urls, args.confirm)
+            print(f"created local redacted export candidate: {target}")
+        else:
+            return self_test()
+    except (PrivateOverlayError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Private overlay command failed: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_private_boundary.py
+++ b/scripts/validate_private_boundary.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-"""Fail if private personal context can leak into versioned/public projection paths."""
+"""Fail if private personal/source context can leak into versioned/public projection paths."""
 
 from __future__ import annotations
 
 import argparse
 import json
-import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -13,12 +12,23 @@ MANIFESTS = ROOT / "data" / "run-manifests"
 GITIGNORE = ROOT / ".gitignore"
 PUBLIC_BUILDERS = [
     ROOT / "scripts" / "build.py",
+    ROOT / "scripts" / "build_previews.py",
     ROOT / "scripts" / "build_graph.py",
+    ROOT / "scripts" / "build_public_graph.py",
     ROOT / "scripts" / "build_library.py",
     ROOT / "scripts" / "build_syntheses.py",
     ROOT / "scripts" / "build_sitemap.py",
+    ROOT / "scripts" / "build_history.py",
+    ROOT / "scripts" / "build_reanalysis.py",
 ]
-FORBIDDEN_BUILDER_MARKERS = [".local/", "personal-baseline.json", "action-outcomes.json", "run-context/"]
+FORBIDDEN_BUILDER_MARKERS = [
+    ".local/",
+    "personal-baseline.json",
+    "action-outcomes.json",
+    "run-context/",
+    "private_overlay",
+    ".local/private",
+]
 ALLOWED_MANIFEST_KEYS = {
     "available",
     "baseline_version",
@@ -61,7 +71,7 @@ def validate_manifest_personal(manifest: dict, where: str) -> None:
 
 def validate_repo() -> None:
     ignore = GITIGNORE.read_text(encoding="utf-8") if GITIGNORE.exists() else ""
-    if ".local/" not in ignore.splitlines():
+    if ".local/" not in {line.strip() for line in ignore.splitlines()}:
         raise PrivateBoundaryError(".gitignore must exclude .local/")
 
     for path in PUBLIC_BUILDERS:
@@ -118,7 +128,7 @@ def main() -> int:
     except (PrivateBoundaryError, json.JSONDecodeError) as exc:
         print(f"private boundary validation failed: {exc}")
         return 1
-    print("Private boundary validation passed; public builders are independent of .local personal context.")
+    print("Private boundary validation passed; public builders are independent of .local personal/source context.")
     return 0
 
 

--- a/scripts/validate_private_overlay.py
+++ b/scripts/validate_private_overlay.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Validate the physical private source/insight overlay and prove public projections cannot depend on it."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PRIVATE_ROOT = ROOT / ".local" / "private"
+GITIGNORE = ROOT / ".gitignore"
+PUBLIC_GRAPH = ROOT / "data" / "knowledge-graph.json"
+PUBLIC_INSIGHTS = ROOT / "data" / "insights.json"
+PUBLIC_SOURCES = ROOT / "data" / "sources.json"
+PUBLIC_DATA_FILES = [
+    ROOT / "data" / "inbox.json",
+    PUBLIC_SOURCES,
+    PUBLIC_INSIGHTS,
+    ROOT / "data" / "claim-evidence.json",
+    ROOT / "data" / "knowledge-deltas.json",
+    ROOT / "data" / "knowledge-reviews.json",
+    ROOT / "data" / "prerequisite-maps.json",
+    ROOT / "data" / "learning-prompts.json",
+    PUBLIC_GRAPH,
+    ROOT / "data" / "knowledge-history.json",
+    ROOT / "data" / "reanalysis-events.json",
+    ROOT / "data" / "source-revisions.json",
+    ROOT / "data" / "source-decisions.json",
+    ROOT / "data" / "syntheses.json",
+]
+PUBLIC_OUTPUT_DIRS = [
+    ROOT / "explainers",
+    ROOT / "library",
+    ROOT / "knowledge",
+    ROOT / "syntheses",
+]
+PUBLIC_BUILDERS = [
+    ROOT / "scripts" / "build.py",
+    ROOT / "scripts" / "build_previews.py",
+    ROOT / "scripts" / "build_graph.py",
+    ROOT / "scripts" / "build_public_graph.py",
+    ROOT / "scripts" / "build_library.py",
+    ROOT / "scripts" / "build_syntheses.py",
+    ROOT / "scripts" / "build_sitemap.py",
+    ROOT / "scripts" / "build_history.py",
+    ROOT / "scripts" / "build_reanalysis.py",
+]
+FORBIDDEN_BUILDER_MARKERS = [".local/private", "private_overlay", "PRIVATE_OVERLAY", "private-source-overlay"]
+ALLOWED_INSIGHT_STATUSES = {"review", "archived"}
+
+
+class PrivateOverlayValidationError(ValueError):
+    pass
+
+
+def load(path: Path, default: dict | None = None) -> dict:
+    if not path.exists() and default is not None:
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def text_files(root: Path):
+    if not root.exists():
+        return
+    for path in root.rglob("*"):
+        if path.is_file() and path.suffix.lower() in {".html", ".json", ".xml", ".txt", ".md", ".js"}:
+            yield path
+
+
+def unique_ids(items: object, where: str, errors: list[str]) -> dict[str, dict]:
+    if not isinstance(items, list):
+        errors.append(f"{where} must be a list")
+        return {}
+    result: dict[str, dict] = {}
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            errors.append(f"{where}[{index}] must be an object")
+            continue
+        item_id = item.get("id")
+        if not isinstance(item_id, str) or not item_id.strip():
+            errors.append(f"{where}[{index}].id must be a non-empty string")
+            continue
+        if item_id in result:
+            errors.append(f"{where}: duplicate id {item_id}")
+        result[item_id] = item
+    return result
+
+
+def private_only_ids(private: dict[str, dict], public: dict[str, dict]) -> set[str]:
+    return set(private) - set(public)
+
+
+def validate_static_repo_boundary(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    ignore_path = root / ".gitignore"
+    ignore = ignore_path.read_text(encoding="utf-8") if ignore_path.exists() else ""
+    if ".local/" not in {line.strip() for line in ignore.splitlines()}:
+        errors.append(".gitignore must contain an exact .local/ rule")
+
+    for builder in PUBLIC_BUILDERS:
+        candidate = root / builder.relative_to(ROOT) if root != ROOT else builder
+        if not candidate.exists():
+            errors.append(f"missing public builder: {candidate.relative_to(root)}")
+            continue
+        text = candidate.read_text(encoding="utf-8")
+        hits = [marker for marker in FORBIDDEN_BUILDER_MARKERS if marker in text]
+        if hits:
+            errors.append(f"public builder {candidate.relative_to(root)} references private overlay: {hits}")
+    return errors
+
+
+def validate_overlay(private_root: Path, public_root: Path = ROOT) -> list[str]:
+    errors = validate_static_repo_boundary(public_root)
+    if not private_root.exists():
+        return errors
+
+    try:
+        private_root.resolve().relative_to((public_root / ".local").resolve())
+    except ValueError:
+        errors.append("private overlay root must stay under .local/")
+
+    data = private_root / "data"
+    inbox_data = load(data / "inbox.json", {"items": []})
+    sources_data = load(data / "sources.json", {"sources": []})
+    insights_data = load(data / "insights.json", {"insights": []})
+    graph_data = load(data / "knowledge-graph.json", {"concepts": [], "relations": []})
+
+    inbox = unique_ids(inbox_data.get("items"), "private inbox.items", errors)
+    private_sources = unique_ids(sources_data.get("sources"), "private sources.sources", errors)
+    private_insights = unique_ids(insights_data.get("insights"), "private insights.insights", errors)
+    private_concepts = unique_ids(graph_data.get("concepts"), "private graph.concepts", errors)
+    private_relations = unique_ids(graph_data.get("relations"), "private graph.relations", errors)
+
+    public_sources_data = load(public_root / "data" / "sources.json", {"sources": []})
+    public_insights_data = load(public_root / "data" / "insights.json", {"insights": []})
+    public_graph_data = load(public_root / "data" / "knowledge-graph.json", {"concepts": [], "relations": []})
+    public_sources = unique_ids(public_sources_data.get("sources"), "public sources.sources", errors)
+    public_insights = unique_ids(public_insights_data.get("insights"), "public insights.insights", errors)
+    public_concepts = unique_ids(public_graph_data.get("concepts"), "public graph.concepts", errors)
+    public_relations = unique_ids(public_graph_data.get("relations"), "public graph.relations", errors)
+
+    for item_id, item in inbox.items():
+        if item.get("status") == "published":
+            errors.append(f"private intake {item_id} cannot have status=published")
+        source_id = item.get("source_id")
+        if source_id is not None and source_id not in private_sources:
+            errors.append(f"private intake {item_id} references non-private source_id {source_id}")
+        insight_id = item.get("insight_id")
+        if insight_id is not None and insight_id not in private_insights:
+            errors.append(f"private intake {item_id} references non-private insight_id {insight_id}")
+
+    for source_id, source in private_sources.items():
+        if "public" in source:
+            errors.append(f"private source {source_id} must not contain a public projection object")
+        if source_id in public_sources:
+            errors.append(f"private source id collides with public registry: {source_id}; export must create/review a public case separately")
+
+    for insight_id, insight in private_insights.items():
+        if insight.get("status") not in ALLOWED_INSIGHT_STATUSES:
+            errors.append(f"private insight {insight_id} status must be review/archived, not {insight.get('status')!r}")
+        if "public" in insight:
+            errors.append(f"private insight {insight_id} must not contain a public projection object")
+        source_id = insight.get("source_id")
+        if source_id not in private_sources:
+            errors.append(f"private insight {insight_id} must reference a private source, got {source_id!r}")
+        if insight_id in public_insights:
+            errors.append(f"private insight id collides with public registry: {insight_id}; use explicit export/review instead")
+
+    all_concepts = set(private_concepts) | set(public_concepts)
+    all_evidence_insights = set(private_insights) | set(public_insights)
+    for concept_id, concept in private_concepts.items():
+        if "public" in concept:
+            errors.append(f"private concept {concept_id} must not contain a public projection object")
+        for insight_id in concept.get("insight_ids") or []:
+            if insight_id not in all_evidence_insights:
+                errors.append(f"private concept {concept_id} references unknown insight {insight_id}")
+        if concept_id in public_concepts:
+            errors.append(f"private concept id collides with public graph: {concept_id}; keep private overlay IDs distinct until explicit export")
+
+    for relation_id, relation in private_relations.items():
+        if "public" in relation:
+            errors.append(f"private relation {relation_id} must not contain a public projection object")
+        if relation.get("from") not in all_concepts or relation.get("to") not in all_concepts:
+            errors.append(f"private relation {relation_id} has dangling concept endpoint")
+        for insight_id in relation.get("evidence_insights") or []:
+            if insight_id not in all_evidence_insights:
+                errors.append(f"private relation {relation_id} references unknown evidence insight {insight_id}")
+        if relation_id in public_relations:
+            errors.append(f"private relation id collides with public graph: {relation_id}")
+
+    bundles = data / "research-bundles"
+    if bundles.exists():
+        for path in sorted(bundles.glob("*.json")):
+            bundle = load(path)
+            intake_id = bundle.get("intake_id")
+            item = inbox.get(intake_id)
+            if item is None:
+                errors.append(f"private bundle {path.name} references unknown private intake {intake_id!r}")
+                continue
+            if (bundle.get("inspection") or {}).get("full_content_committed") is not False:
+                errors.append(f"private bundle {path.name} must keep full_content_committed=false")
+            canonical = (bundle.get("source") or {}).get("canonical_url")
+            if canonical != item.get("source_url"):
+                errors.append(f"private bundle {path.name} canonical URL differs from private intake")
+
+    private_only = (
+        private_only_ids(private_sources, public_sources)
+        | private_only_ids(private_insights, public_insights)
+        | private_only_ids(private_concepts, public_concepts)
+        | private_only_ids(private_relations, public_relations)
+    )
+    if private_only:
+        searchable_files: list[Path] = []
+        for relative in [
+            "data/inbox.json", "data/sources.json", "data/insights.json", "data/claim-evidence.json",
+            "data/knowledge-deltas.json", "data/knowledge-reviews.json", "data/prerequisite-maps.json",
+            "data/learning-prompts.json", "data/knowledge-graph.json", "data/knowledge-history.json",
+            "data/reanalysis-events.json", "data/source-revisions.json", "data/source-decisions.json", "data/syntheses.json",
+        ]:
+            path = public_root / relative
+            if path.exists():
+                searchable_files.append(path)
+        for directory in ["explainers", "library", "knowledge", "syntheses"]:
+            searchable_files.extend(list(text_files(public_root / directory) or []))
+
+        for path in searchable_files:
+            try:
+                text = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                continue
+            leaked = sorted(item_id for item_id in private_only if item_id and item_id in text)
+            if leaked:
+                errors.append(f"public/versioned file {path.relative_to(public_root)} contains private-only ids: {leaked[:5]}")
+
+        public_graph_text = json.dumps(public_graph_data, ensure_ascii=False)
+        leaked_graph_ids = sorted(item_id for item_id in private_only if item_id in public_graph_text)
+        if leaked_graph_ids:
+            errors.append(f"public graph depends on private-only ids: {leaked_graph_ids[:10]}")
+
+    exports = private_root / "exports"
+    if exports.exists():
+        for path in sorted(exports.glob("*.json")):
+            candidate = load(path)
+            if candidate.get("public_write_allowed") is not False:
+                errors.append(f"private export {path.name} must keep public_write_allowed=false")
+            insight = candidate.get("insight") or {}
+            if insight.get("status") != "review":
+                errors.append(f"private export {path.name} must stop at insight status=review")
+            if not isinstance(candidate.get("redaction"), dict):
+                errors.append(f"private export {path.name} must include redaction metadata")
+
+    return errors
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / ".local").mkdir(parents=True)
+        (root / ".gitignore").write_text(".local/\n", encoding="utf-8")
+        scripts = root / "scripts"
+        scripts.mkdir()
+        for builder in PUBLIC_BUILDERS:
+            (scripts / builder.name).write_text("# public-only fixture builder\n", encoding="utf-8")
+        data = root / "data"
+        data.mkdir()
+        for name, payload in {
+            "sources.json": {"sources": []},
+            "insights.json": {"insights": []},
+            "knowledge-graph.json": {"concepts": [], "relations": []},
+            "inbox.json": {"items": []},
+            "claim-evidence.json": {"records": []},
+            "knowledge-deltas.json": {"records": []},
+            "knowledge-reviews.json": {"reviews": []},
+            "prerequisite-maps.json": {"records": []},
+            "learning-prompts.json": {"records": []},
+            "knowledge-history.json": {"entities": []},
+            "reanalysis-events.json": {"events": []},
+            "source-revisions.json": {"sources": []},
+            "source-decisions.json": {"records": []},
+            "syntheses.json": {"records": []},
+        }.items():
+            (data / name).write_text(json.dumps(payload), encoding="utf-8")
+
+        private_root = root / ".local" / "private"
+        private_data = private_root / "data"
+        (private_data / "research-bundles").mkdir(parents=True)
+        sentinel_source = "private-src-leak-sentinel"
+        sentinel_insight = "private-insight-leak-sentinel"
+        sentinel_concept = "private-concept-leak-sentinel"
+        (private_data / "inbox.json").write_text(json.dumps({"items": [{
+            "id": "private-intake", "source_url": "https://private.invalid/x", "status": "review",
+            "source_id": sentinel_source, "insight_id": sentinel_insight
+        }]}), encoding="utf-8")
+        (private_data / "sources.json").write_text(json.dumps({"sources": [{
+            "id": sentinel_source, "canonical_url": "https://private.invalid/x"
+        }]}), encoding="utf-8")
+        (private_data / "insights.json").write_text(json.dumps({"insights": [{
+            "id": sentinel_insight, "source_id": sentinel_source, "status": "review", "title": "Private"
+        }]}), encoding="utf-8")
+        (private_data / "knowledge-graph.json").write_text(json.dumps({"concepts": [{
+            "id": sentinel_concept, "label": "Private", "summary": "Private", "coverage": "introduced",
+            "insight_ids": [sentinel_insight]
+        }], "relations": []}), encoding="utf-8")
+        (private_data / "research-bundles" / "private-intake.json").write_text(json.dumps({
+            "intake_id": "private-intake", "source": {"canonical_url": "https://private.invalid/x"},
+            "inspection": {"full_content_committed": False}
+        }), encoding="utf-8")
+
+        errors = validate_overlay(private_root, root)
+        if errors:
+            print("Private overlay self-test failed on safe fixture:")
+            for error in errors:
+                print(f"- {error}")
+            return 1
+
+        (data / "knowledge-graph.json").write_text(json.dumps({
+            "concepts": [{"id": "public", "summary": sentinel_concept}], "relations": []
+        }), encoding="utf-8")
+        leaked = validate_overlay(private_root, root)
+        if not any("private-only ids" in error or "public graph depends" in error for error in leaked):
+            print("Private overlay self-test failed: public graph leak was not detected")
+            return 1
+
+        (data / "knowledge-graph.json").write_text(json.dumps({"concepts": [], "relations": []}), encoding="utf-8")
+        (scripts / "build.py").write_text("from private_overlay import combined_context\n", encoding="utf-8")
+        coupled = validate_overlay(private_root, root)
+        if not any("references private overlay" in error for error in coupled):
+            print("Private overlay self-test failed: public builder/private overlay coupling was accepted")
+            return 1
+
+    print("Private overlay validation self-test passed; private-only IDs and builder coupling cannot reach public projections.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--private-root", type=Path, default=DEFAULT_PRIVATE_ROOT)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+    try:
+        errors = validate_overlay(args.private_root)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Private overlay validation failed: {exc}")
+        return 1
+    if errors:
+        print(f"Private overlay validation failed with {len(errors)} error(s):")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    state = "overlay present and isolated" if args.private_root.exists() else "no private overlay present; static isolation guards verified"
+    print(f"Private overlay validation passed: {state}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements #35 with a physical local boundary rather than a `private` flag inside public JSON.

What it adds:
- `.local/private/` overlay model for inbox, sources, insights, cumulative graph, research bundles, local run context and redacted export candidates;
- source queue/scaffold commands reusing existing URL normalization and public research-bundle shape where possible;
- combined research context that keeps `public_graph` and `private_overlay` matches explicitly separate;
- private graph may use public concepts/insights as read-only context/evidence, while the public graph is forbidden from depending on private-only IDs;
- private insights can only be `review` or `archived`, never `published`;
- exact-token `EXPORT:<insight-id>` path that writes only a local redacted candidate, forces status back to `review`, removes URLs by default and sets `public_write_allowed=false`;
- threat model + operating documentation in `docs/PRIVATE_OVERLAY.md`;
- expanded public-builder isolation checks across explainers, previews, graph, library, synthesis, sitemap, history and reanalysis generators;
- dedicated validator that scans versioned/public data and generated surfaces for private-only IDs and rejects public-builder coupling to the overlay;
- fixture-driven CI tests that intentionally leak a private sentinel into a public graph and import `private_overlay` from a public builder; both must fail validation.

GitHub recalculated this branch as cleanly mergeable after the concurrent concept-navigation changes landed, so the focused private overlay can remain isolated without overwriting that work.

The export path never writes to public registries and never bypasses the normal human review/publication boundary.

Closes #35