### PR TITLE
P2: package a reusable local-first starter

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Test one-command source orchestration
         run: python scripts/run_source.py --self-test
 
+      - name: Test reusable starter bootstrap
+        run: python scripts/bootstrap_starter.py --self-test
+
       - name: Test private personal knowledge baseline
         run: python scripts/personal_baseline.py self-test
 
@@ -144,4 +147,4 @@ jobs:
         run: python -m unittest discover -s tests -p "test_*.py" -v
 
       - name: Compile Python utilities
-        run: python -m compileall -q scripts tests
+        run: python -m compileall -q sti.py scripts tests

--- a/config/research-profile.example.json
+++ b/config/research-profile.example.json
@@ -1,0 +1,78 @@
+{
+  "profile_version": "1.0.0-starter",
+  "purpose": "Turn useful sources into coherent, verified learning artifacts without locking the workspace to one domain or user profile.",
+  "scope": {
+    "domain_locked": false,
+    "priority_areas": [],
+    "allowed_source_types": [
+      "video",
+      "article",
+      "paper",
+      "podcast",
+      "documentation",
+      "repository",
+      "tool",
+      "product",
+      "course",
+      "presentation",
+      "notes",
+      "system"
+    ]
+  },
+  "goals": [
+    "Understand the whole idea rather than collect isolated facts.",
+    "Preserve prerequisites and mechanisms required to reconstruct the model later.",
+    "Separate source claims, verification, prior knowledge and project interpretation.",
+    "Convert useful understanding into explicit learning or action decisions.",
+    "Reduce source-consumption time without pretending compression is lossless."
+  ],
+  "selection": {
+    "dimensions": [
+      "relevance",
+      "novelty",
+      "conceptual_leverage",
+      "practical_applicability",
+      "evidence_strength",
+      "connection_to_existing_knowledge"
+    ],
+    "rules": [
+      "Keep every prerequisite needed to preserve a coherent mental model.",
+      "Drop repetition and promotional framing that do not change understanding.",
+      "Do not force an application domain when another example is clearer.",
+      "Research beyond the supplied source only when it materially improves verification or understanding."
+    ]
+  },
+  "explanation_preferences": {
+    "style": [
+      "compact but deep",
+      "mechanism-first",
+      "practical",
+      "low-jargon",
+      "critical rather than promotional"
+    ],
+    "required_sections": [
+      "why_this_matters",
+      "mental_model",
+      "key_concepts",
+      "limitations",
+      "what_to_do_with_it",
+      "sources_and_dates"
+    ],
+    "action_buckets": [
+      "use_now",
+      "try",
+      "learn",
+      "build",
+      "watch",
+      "ignore_for_now"
+    ],
+    "visual_rule": "Use visuals only when they explain a mechanism, relationship, comparison, sequence, state or concrete object more clearly than prose."
+  },
+  "publishing": {
+    "auto_publish": false,
+    "public_output": "human-reviewed explainers and published-only discovery surfaces",
+    "private_input_allowed": true,
+    "store_full_third_party_transcripts": false,
+    "require_source_and_date": true
+  }
+}

--- a/docs/STARTER.md
+++ b/docs/STARTER.md
@@ -1,0 +1,148 @@
+# Reusable local-first starter
+
+Signal to Insight can be reused as a repository/workspace without turning it into a hosted service or requiring the original maintainer's knowledge corpus.
+
+## Two ways to start
+
+### 1. Fork/clone and keep the reference cases
+
+Use the repository as-is when the existing examples are useful. The normal commands remain available individually or through the unified wrapper:
+
+```bash
+python sti.py intake "https://example.com/source" --type article
+python sti.py scaffold <intake-id>
+python sti.py context "topic"
+python sti.py validate --all
+python sti.py build
+```
+
+### 2. Generate an empty starter workspace
+
+From a clone of this repository:
+
+```bash
+python scripts/bootstrap_starter.py ../my-signal-to-insight
+cd ../my-signal-to-insight
+```
+
+The bootstrap command refuses to overwrite the current repository and refuses a non-empty target.
+
+The generated workspace contains:
+
+- schemas and deterministic processing/build scripts;
+- `AGENTS.md` operating contract;
+- `sti.py` unified CLI;
+- a generic `config/research-profile.json` copied from `research-profile.example.json`;
+- empty source/insight/graph/evidence/review/history/freshness stores;
+- no reference-case research bundles or generated explainers;
+- only the synthetic acceptance fixture/test;
+- static CSS/JS required by generated pages;
+- owner source Issue Form;
+- a minimal validation workflow;
+- an optional static landing page;
+- empty/generated sitemap, Atom, discovery JSON and llms surfaces.
+
+The maintainer's research priorities are not copied into the starter profile.
+
+## Unified CLI
+
+`sti.py` is deliberately a thin dispatcher over the existing scripts rather than a second implementation.
+
+### Intake
+
+```bash
+python sti.py intake "https://example.com/source" \
+  --type article \
+  --focus "What should I understand or test?"
+```
+
+### Scaffold
+
+```bash
+python sti.py scaffold <intake-id>
+```
+
+This creates the normalized research bundle and prior-knowledge snapshot.
+
+### Resume one source run
+
+```bash
+python sti.py run <intake-id>
+```
+
+The deterministic orchestrator reports the exact next blocker. It does not pretend to research the source by itself.
+
+### Query accumulated knowledge
+
+```bash
+python sti.py context "durable workflow retry" --limit 5 --json
+```
+
+### Validate
+
+```bash
+python sti.py validate
+python sti.py validate --all
+```
+
+The default runs the core structural/graph/bundle/private-boundary checks. `--all` adds evidence, delta, review, prerequisite, prompt, synthesis, freshness/history validation and acceptance tests.
+
+### Build
+
+```bash
+python sti.py build
+```
+
+This regenerates published explainers, review previews, library, graph, concept pages, history, re-analysis views, sitemap and published-only discovery surfaces.
+
+### Publish
+
+```bash
+python sti.py publish \
+  --insight <insight-id> \
+  --confirm PUBLISH:<insight-id> \
+  --reviewed-by <name> \
+  --review-note "What was checked"
+```
+
+The wrapper preserves the existing explicit human publication boundary. It does not add an automatic publication path.
+
+## What still requires an external agent/provider
+
+The repository owns stable contracts, cumulative memory, validation, generation and publication boundaries. It intentionally does **not** embed a universal runtime for:
+
+- YouTube/video transcription;
+- arbitrary web/article extraction;
+- PDF text extraction;
+- repository/tool inspection;
+- LLM research/reasoning.
+
+After intake/scaffold, a capable external research agent uses the source adapter rules and `AGENTS.md` to inspect the source, verify important claims and write normalized artifacts. Full third-party source text remains transient input and is not committed.
+
+This separation avoids provider lock-in: the research agent/provider can change without changing the knowledge model.
+
+## Bootstrap acceptance test
+
+Run:
+
+```bash
+python scripts/bootstrap_starter.py --self-test
+```
+
+The test creates a temporary sanitized copy and verifies:
+
+1. reference source/insight/graph data is empty;
+2. research profile has no maintainer-specific priority areas;
+3. `sti intake` queues and normalizes a synthetic source URL;
+4. `sti scaffold` creates a safe bundle with `full_content_committed=false`;
+5. `sti validate` passes in the clean workspace;
+6. the synthetic E2E fixture proves identifier chain, raw-content boundary, deterministic public rendering and noindex review rendering;
+7. `sti build` completes from the clean workspace and emits discovery/sitemap surfaces.
+
+This is intentionally network-free. It verifies packaging/contracts, not the quality of an external research model.
+
+## GitHub Pages
+
+Pages is optional. The local CLI, data model, private overlay, learning state and validators work without it.
+
+If the generated workspace is later published, enable Pages explicitly and keep the same review → publish boundary. Do not expose review previews or `.local/` data as public evidence.

--- a/scripts/bootstrap_starter.py
+++ b/scripts/bootstrap_starter.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Create a sanitized local-first Signal to Insight starter from the current clone.
+
+The command never resets the current repository in place. It creates a new target directory,
+keeps reusable contracts/runtime code, removes reference-case data and generated public content,
+and installs a generic research profile plus minimal CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILE_EXAMPLE = ROOT / "config" / "research-profile.example.json"
+
+RESET_KEYS = {
+    "inbox.json": ["items"],
+    "sources.json": ["sources"],
+    "insights.json": ["insights"],
+    "claim-evidence.json": ["records"],
+    "knowledge-deltas.json": ["records"],
+    "knowledge-graph.json": ["concepts", "relations"],
+    "knowledge-reviews.json": ["reviews"],
+    "learning-prompts.json": ["records"],
+    "prerequisite-maps.json": ["records"],
+    "source-decisions.json": ["records"],
+    "syntheses.json": ["records"],
+    "knowledge-history.json": ["entities"],
+    "source-revisions.json": ["sources"],
+    "reanalysis-events.json": ["events"],
+}
+
+ROOT_FILES = [
+    ".gitignore",
+    "LICENSE",
+    "AGENTS.md",
+    "sti.py",
+    "app.js",
+    "evidence.js",
+    "library.js",
+    "capture.js",
+    "styles.css",
+    "explainer.css",
+    "preview.css",
+    "evidence.css",
+    "library.css",
+    "decision.css",
+    "retention.css",
+    "synthesis.css",
+    "visual-plan.css",
+    "capture.css",
+]
+
+
+class BootstrapError(ValueError):
+    pass
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def dump(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def ensure_empty_target(target: Path) -> None:
+    if target.resolve() == ROOT.resolve():
+        raise BootstrapError("refusing to bootstrap over the current repository")
+    if target.exists() and any(target.iterdir()):
+        raise BootstrapError(f"target must be empty or absent: {target}")
+    target.mkdir(parents=True, exist_ok=True)
+
+
+def copy_tree_if_exists(source: Path, target: Path) -> None:
+    if not source.exists():
+        return
+    shutil.copytree(
+        source,
+        target,
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store"),
+    )
+
+
+def sanitized_data(target: Path) -> None:
+    data_target = target / "data"
+    data_target.mkdir(parents=True, exist_ok=True)
+    for filename, keys in RESET_KEYS.items():
+        source = ROOT / "data" / filename
+        if source.exists():
+            payload = load(source)
+        else:
+            payload = {}
+        for key in keys:
+            payload[key] = []
+        if filename == "knowledge-graph.json":
+            payload["updated_at"] = date.today().isoformat()
+        dump(data_target / filename, payload)
+
+    for directory in ("research-bundles", "case-patches", "run-manifests"):
+        (data_target / directory).mkdir(parents=True, exist_ok=True)
+        (data_target / directory / ".gitkeep").write_text("", encoding="utf-8")
+
+
+def starter_readme() -> str:
+    return """# Signal to Insight — local-first starter
+
+This workspace was generated from the Signal to Insight repository without its reference-case knowledge.
+
+## Start
+
+```bash
+python sti.py intake \"https://example.com/source\" --type article --focus \"What should I understand?\"
+python sti.py scaffold <intake-id>
+python sti.py context \"topic or mechanism\"
+```
+
+At that point an external capable research agent/provider must inspect the real source and write the normalized artifacts described by `AGENTS.md`. The repository intentionally does not embed a universal transcription/scraping/LLM runtime.
+
+Validate and build deterministic surfaces:
+
+```bash
+python sti.py validate
+python sti.py build
+```
+
+Publication remains human-controlled:
+
+```bash
+python sti.py publish \\
+  --insight <insight-id> \\
+  --confirm PUBLISH:<insight-id> \\
+  --reviewed-by <name> \\
+  --review-note \"What was checked\"
+```
+
+GitHub Pages is optional. The local data/contracts/CLI work without it.
+
+See `docs/STARTER.md` for the full bootstrap and operating boundary.
+"""
+
+
+def starter_index() -> str:
+    return """<!doctype html>
+<html lang=\"en\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>Signal to Insight</title><meta name=\"description\" content=\"Local-first source-to-understanding workspace.\"><link rel=\"stylesheet\" href=\"styles.css\"></head>
+<body><main class=\"wrap\" style=\"padding:8vh 0\"><p class=\"eyebrow\">SIGNAL TO INSIGHT</p><h1>Source → understanding.</h1><p>Empty local-first starter. Queue a source with <code>python sti.py intake …</code>, then follow <code>AGENTS.md</code>.</p><p><a href=\"library/\">Library</a> · <a href=\"knowledge/\">Knowledge</a></p></main></body></html>
+"""
+
+
+def starter_workflow() -> str:
+    return """name: Validate starter workspace
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: \"3.12\"
+      - name: Core validation
+        run: python sti.py validate
+      - name: Synthetic end-to-end contract
+        run: python -m unittest tests.test_e2e -v
+      - name: Bootstrap portability self-test
+        run: python scripts/bootstrap_starter.py --self-test
+      - name: Compile Python
+        run: python -m compileall -q sti.py scripts tests
+"""
+
+
+def create_starter(target: Path) -> None:
+    ensure_empty_target(target)
+
+    # Runtime contracts and deterministic tools.
+    copy_tree_if_exists(ROOT / "scripts", target / "scripts")
+    copy_tree_if_exists(ROOT / "schemas", target / "schemas")
+    copy_tree_if_exists(ROOT / "docs", target / "docs")
+
+    # Only synthetic acceptance fixtures/tests are required in the generated starter.
+    (target / "tests" / "fixtures").mkdir(parents=True, exist_ok=True)
+    shutil.copy2(ROOT / "tests" / "fixtures" / "e2e.json", target / "tests" / "fixtures" / "e2e.json")
+    shutil.copy2(ROOT / "tests" / "test_e2e.py", target / "tests" / "test_e2e.py")
+    (target / "tests" / "__init__.py").write_text("", encoding="utf-8")
+
+    for filename in ROOT_FILES:
+        source = ROOT / filename
+        if source.exists():
+            shutil.copy2(source, target / filename)
+
+    # Generic configuration, not the maintainer's personal research priorities.
+    (target / "config").mkdir(parents=True, exist_ok=True)
+    shutil.copy2(PROFILE_EXAMPLE, target / "config" / "research-profile.json")
+    shutil.copy2(PROFILE_EXAMPLE, target / "config" / "research-profile.example.json")
+
+    sanitized_data(target)
+
+    # Keep source handling guidance but not reference-case content.
+    source_readme = ROOT / "content" / "sources" / "README.md"
+    if source_readme.exists():
+        (target / "content" / "sources").mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_readme, target / "content" / "sources" / "README.md")
+
+    # Owner issue intake can be reused without copying the maintainer's full workflow set.
+    issue_template = ROOT / ".github" / "ISSUE_TEMPLATE" / "source.yml"
+    if issue_template.exists():
+        destination = target / ".github" / "ISSUE_TEMPLATE" / "source.yml"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(issue_template, destination)
+    workflow = target / ".github" / "workflows" / "validate.yml"
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    workflow.write_text(starter_workflow(), encoding="utf-8")
+
+    (target / "README.md").write_text(starter_readme(), encoding="utf-8")
+    (target / "index.html").write_text(starter_index(), encoding="utf-8")
+
+    # Generated directories start empty and are rebuilt locally as needed.
+    for directory in ("explainers", "previews", "library", "knowledge", "syntheses"):
+        path = target / directory
+        path.mkdir(parents=True, exist_ok=True)
+        (path / ".gitkeep").write_text("", encoding="utf-8")
+
+    # Generate safe empty discovery/sitemap surfaces from the sanitized records.
+    for script in ("build_sitemap.py", "build_discovery.py"):
+        completed = subprocess.run([sys.executable, str(target / "scripts" / script)], cwd=target, text=True, capture_output=True)
+        if completed.returncode:
+            raise BootstrapError(f"starter generation failed in {script}: {(completed.stdout + completed.stderr).strip()}")
+
+
+def run_checked(command: list[str], cwd: Path) -> str:
+    completed = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    output = (completed.stdout + completed.stderr).strip()
+    if completed.returncode:
+        raise BootstrapError(f"command failed ({' '.join(command)}):\n{output}")
+    return output
+
+
+def self_test() -> int:
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "starter"
+            create_starter(target)
+
+            profile = load(target / "config" / "research-profile.json")
+            if profile.get("scope", {}).get("priority_areas") != []:
+                raise BootstrapError("starter profile contains maintainer-specific priority areas")
+            insights = load(target / "data" / "insights.json").get("insights", [])
+            sources = load(target / "data" / "sources.json").get("sources", [])
+            graph = load(target / "data" / "knowledge-graph.json")
+            if insights or sources or graph.get("concepts") or graph.get("relations"):
+                raise BootstrapError("starter data was not reset to an empty knowledge workspace")
+
+            run_checked([
+                sys.executable, "sti.py", "intake", "https://example.com/starter-fixture?utm_source=test",
+                "--type", "article", "--focus", "Understand the fixture mechanism",
+            ], target)
+            inbox = load(target / "data" / "inbox.json").get("items", [])
+            if len(inbox) != 1 or "utm_source" in inbox[0].get("source_url", ""):
+                raise BootstrapError("starter CLI intake did not normalize/queue the fixture source")
+            intake_id = inbox[0]["id"]
+            run_checked([sys.executable, "sti.py", "scaffold", intake_id], target)
+            bundle = target / "data" / "research-bundles" / f"{intake_id}.json"
+            if not bundle.exists():
+                raise BootstrapError("starter CLI scaffold did not create a research bundle")
+            if load(bundle).get("inspection", {}).get("full_content_committed") is not False:
+                raise BootstrapError("starter bundle violated raw-content boundary")
+
+            run_checked([sys.executable, "sti.py", "validate"], target)
+            run_checked([sys.executable, "-m", "unittest", "tests.test_e2e", "-v"], target)
+            run_checked([sys.executable, "sti.py", "build"], target)
+
+            if not (target / "atom.xml").exists() or not (target / "sitemap.xml").exists():
+                raise BootstrapError("starter deterministic build did not produce discovery/sitemap surfaces")
+    except (BootstrapError, OSError, json.JSONDecodeError) as exc:
+        print(f"Starter bootstrap self-test failed: {exc}")
+        return 1
+    print("Starter bootstrap self-test passed: sanitized copy completed intake → scaffold → validate → synthetic E2E → build.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("target", nargs="?", type=Path, help="Empty/absent target directory")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+    if args.target is None:
+        parser.error("target is required unless --self-test is used")
+    try:
+        create_starter(args.target)
+    except (BootstrapError, OSError, json.JSONDecodeError) as exc:
+        print(f"Starter bootstrap failed: {exc}")
+        return 1
+    print(f"created sanitized Signal to Insight starter: {args.target}")
+    print(f"next: cd {args.target} && python sti.py intake https://example.com/source --type article")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sti.py
+++ b/sti.py
@@ -102,13 +102,9 @@ def main() -> int:
             return run_script("run_source.py", forwarded)
 
         if args.command == "context":
-            forwarded = [args.query]
+            forwarded = [args.query, "--limit", str(max(1, args.limit))]
             if args.json:
                 forwarded.append("--json")
-            # graph_context currently owns ranking defaults; --limit is accepted by this wrapper
-            # for CLI stability and applied only when the underlying script exposes it later.
-            if args.limit != 5:
-                print("note: graph_context currently uses its own result limit; --limit is reserved for CLI compatibility")
             return run_script("graph_context.py", forwarded)
 
         if args.command == "validate":

--- a/sti.py
+++ b/sti.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Signal to Insight repo-local CLI.
+
+This wrapper keeps the existing deterministic scripts as the implementation units while giving a
+fresh clone one stable entry point. Research/extraction intelligence remains external by design.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+SCRIPTS = ROOT / "scripts"
+
+
+class CliError(ValueError):
+    pass
+
+
+def run_script(name: str, args: list[str]) -> int:
+    path = SCRIPTS / name
+    if not path.exists():
+        raise CliError(f"missing repository script: scripts/{name}")
+    return subprocess.call([sys.executable, str(path), *args], cwd=ROOT)
+
+
+def run_many(commands: list[tuple[str, list[str]]]) -> int:
+    for name, args in commands:
+        print(f"==> {name} {' '.join(args)}".rstrip())
+        code = run_script(name, args)
+        if code:
+            return code
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="sti",
+        description="Repo-local Signal to Insight CLI. External research agent/provider is still required to inspect real sources.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    intake = sub.add_parser("intake", help="Queue a source URL")
+    intake.add_argument("url")
+    intake.add_argument("--type", dest="source_type", default="article")
+    intake.add_argument("--focus", default="")
+    intake.add_argument("--note", default="")
+
+    scaffold = sub.add_parser("scaffold", help="Create the normalized research bundle for an intake")
+    scaffold.add_argument("intake_id")
+
+    run = sub.add_parser("run", help="Prepare/resume one source run and report the exact next blocker")
+    run.add_argument("source")
+    run.add_argument("--type", dest="source_type", default="article")
+    run.add_argument("--focus", default="")
+    run.add_argument("--note", default="")
+    run.add_argument("--no-checks", action="store_true")
+    run.add_argument("--json", action="store_true")
+
+    context = sub.add_parser("context", help="Query cumulative public prior knowledge")
+    context.add_argument("query")
+    context.add_argument("--limit", type=int, default=5)
+    context.add_argument("--json", action="store_true")
+
+    validate = sub.add_parser("validate", help="Run deterministic core repository validation")
+    validate.add_argument("--all", action="store_true", help="Also run extended evidence/freshness/history validators and acceptance tests")
+
+    sub.add_parser("build", help="Regenerate deterministic public/review static surfaces")
+
+    publish = sub.add_parser("publish", help="Explicit human review → publish transition")
+    publish.add_argument("--insight", required=True)
+    publish.add_argument("--confirm", required=True)
+    publish.add_argument("--reviewed-by", required=True)
+    publish.add_argument("--review-note", required=True)
+
+    args = parser.parse_args()
+    try:
+        if args.command == "intake":
+            forwarded = [args.url, "--type", args.source_type]
+            if args.focus:
+                forwarded += ["--focus", args.focus]
+            if args.note:
+                forwarded += ["--note", args.note]
+            return run_script("new_source.py", forwarded)
+
+        if args.command == "scaffold":
+            return run_script("scaffold_bundle.py", [args.intake_id])
+
+        if args.command == "run":
+            forwarded = [args.source, "--type", args.source_type]
+            if args.focus:
+                forwarded += ["--focus", args.focus]
+            if args.note:
+                forwarded += ["--note", args.note]
+            if args.no_checks:
+                forwarded.append("--no-checks")
+            if args.json:
+                forwarded.append("--json")
+            return run_script("run_source.py", forwarded)
+
+        if args.command == "context":
+            forwarded = [args.query]
+            if args.json:
+                forwarded.append("--json")
+            # graph_context currently owns ranking defaults; --limit is accepted by this wrapper
+            # for CLI stability and applied only when the underlying script exposes it later.
+            if args.limit != 5:
+                print("note: graph_context currently uses its own result limit; --limit is reserved for CLI compatibility")
+            return run_script("graph_context.py", forwarded)
+
+        if args.command == "validate":
+            core = [
+                ("validate.py", []),
+                ("validate_graph.py", []),
+                ("validate_bundles.py", []),
+                ("validate_private_boundary.py", []),
+            ]
+            if not args.all:
+                return run_many(core)
+            extended = [
+                ("validate_claim_evidence.py", []),
+                ("validate_knowledge_deltas.py", []),
+                ("validate_knowledge_reviews.py", []),
+                ("validate_prerequisites.py", []),
+                ("validate_learning_prompts.py", []),
+                ("validate_syntheses.py", []),
+                ("validate_freshness.py", []),
+                ("validate_knowledge_history.py", []),
+            ]
+            code = run_many(core + extended)
+            if code:
+                return code
+            return subprocess.call(
+                [sys.executable, "-m", "unittest", "discover", "-s", "tests", "-p", "test_*.py", "-v"],
+                cwd=ROOT,
+            )
+
+        if args.command == "build":
+            commands = [
+                ("build.py", []),
+                ("build_previews.py", []),
+                ("build_library.py", []),
+                ("build_graph.py", []),
+                ("build_concepts.py", []),
+                ("build_history.py", []),
+                ("build_reanalysis.py", []),
+                ("build_sitemap.py", []),
+                ("build_discovery.py", []),
+            ]
+            return run_many(commands)
+
+        if args.command == "publish":
+            return run_script("publish_reviewed.py", [
+                "--insight", args.insight,
+                "--confirm", args.confirm,
+                "--reviewed-by", args.reviewed_by,
+                "--review-note", args.review_note,
+            ])
+    except CliError as exc:
+        print(f"sti: {exc}", file=sys.stderr)
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements #36 as a fresh-clone/fork starter rather than a hosted service.

Adds:
- `sti.py` unified repo-local CLI for intake, scaffold, run/resume, graph context, core/extended validation, deterministic build and explicit publish;
- generic `config/research-profile.example.json` with no maintainer-specific priority areas;
- safe `scripts/bootstrap_starter.py <empty-target>` that refuses current-repo/non-empty targets, copies reusable runtime/contracts, removes reference-case data/generated pages and creates empty knowledge stores;
- generated starter README/index + minimal CI, owner source Issue Form, synthetic fixture/test only, optional Pages surface;
- `docs/STARTER.md` covering clean bootstrap, CLI, external research-agent/provider boundary and optional Pages;
- main CI bootstrap self-test.

The bootstrap self-test creates a temporary sanitized copy and actually verifies:
1. no reference source/insight/graph data remains;
2. generic profile has no maintainer priorities;
3. `sti intake` normalizes/queues a fixture URL;
4. `sti scaffold` creates a bundle with `full_content_committed=false`;
5. `sti validate` passes in the clean copy;
6. the synthetic E2E contract proves identifier/publication/raw-content boundaries;
7. `sti build` completes from the clean workspace and emits sitemap/discovery surfaces.

Real source inspection still requires an external capable research agent/provider by design; the starter does not add provider lock-in or an embedded LLM runtime.

Closes #36