### PR TITLE
Dogfood case: refine retry idempotency with Idempotent Receiver

### DIFF
--- a/data/case-contracts/idempotent-receiver.json
+++ b/data/case-contracts/idempotent-receiver.json
@@ -99,7 +99,7 @@
         "prior_coverage": "established",
         "state": "known_in_graph",
         "reason": "The receiver pattern solves a concrete instance of the broader problem that retrying a side effect must not create an unintended duplicate outcome.",
-        "resolution": {"kind": "existing_explainer", "insight_id": "temporal-durable-execution-mental-model", "target": null}
+        "resolution": {"kind": "existing_concept", "insight_id": null, "target": "idempotency-under-retry"}
       },
       {
         "id": "idempotent-receiver-prereq-pattern",

--- a/data/case-contracts/idempotent-receiver.json
+++ b/data/case-contracts/idempotent-receiver.json
@@ -1,0 +1,151 @@
+{
+  "contract_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-martinfowler-idempotent-receiver-html",
+  "insight_id": "idempotent-receiver-retry-deduplication",
+  "knowledge_delta": {
+    "insight_id": "idempotent-receiver-retry-deduplication",
+    "summary": "The source does not create a second idempotency concept; it refines the existing idempotency-under-retry model with a concrete receiver-side protocol based on stable logical request identity, duplicate detection and prior-outcome reuse.",
+    "items": [
+      {
+        "relationship": "refines",
+        "concept_id": "idempotency-under-retry",
+        "label": "Idempotency under retry",
+        "source_basis": "Idempotent Receiver identifies repeated client requests and avoids processing the same logical operation again when a retry follows an ambiguous failure.",
+        "prior_basis": "The Temporal case already established that retried external effects need duplicate-safe/idempotent semantics, but it did not specify a receiver protocol for recognizing the same logical mutation.",
+        "interpretation": "The source makes the earlier boundary operational: safe retry needs a receiver-visible identity for the logical request plus durable knowledge of the prior outcome.",
+        "evidence_insights": ["temporal-durable-execution-mental-model"]
+      },
+      {
+        "relationship": "new",
+        "concept_id": "idempotent-receiver",
+        "label": "Idempotent Receiver",
+        "source_basis": "The receiver checks whether the same client/request identity was already processed and returns the saved response instead of processing the mutation again.",
+        "prior_basis": "No earlier graph concept represented a concrete receiver-side duplicate-detection and response-reuse pattern.",
+        "interpretation": "This becomes one implementation pattern for achieving the broader idempotency-under-retry requirement at an API/service boundary.",
+        "evidence_insights": []
+      },
+      {
+        "relationship": "new",
+        "concept_id": "request-identity",
+        "label": "Logical request identity",
+        "source_basis": "The pattern identifies both the client and each request so a retry can be recognized as the same logical operation.",
+        "prior_basis": "The existing retry model did not yet represent identity as a first-class part of duplicate-safe execution.",
+        "interpretation": "Request identity separates repeated delivery of one intended operation from a new operation that merely looks similar.",
+        "evidence_insights": []
+      }
+    ],
+    "suppressed_prior_matches": ["activity-execution"]
+  },
+  "claim_evidence": {
+    "insight_id": "idempotent-receiver-retry-deduplication",
+    "claims": [
+      {
+        "id": "idempotent-receiver-ambiguous-retry",
+        "text": "When a client receives no response, it cannot reliably distinguish response loss from server failure before processing, so retrying can deliver a duplicate of an operation that already completed.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-idempotent-receiver-2023", "url": "https://martinfowler.com/articles/patterns-of-distributed-systems/idempotent-receiver.html", "locator": "Idempotent Receiver → Problem"}
+        ],
+        "note": null
+      },
+      {
+        "id": "idempotent-receiver-reuse-outcome",
+        "text": "A receiver can recognize the same client and request number, detect that the request was already processed, and return the saved response without executing the logical operation again.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-idempotent-receiver-2023", "url": "https://martinfowler.com/articles/patterns-of-distributed-systems/idempotent-receiver.html", "locator": "Idempotent Receiver → Solution"}
+        ],
+        "note": null
+      },
+      {
+        "id": "idempotent-receiver-atomic-token-boundary",
+        "text": "For a production idempotent API, recording the request token and performing the protected mutation must be kept consistent so a crash cannot persist one without the other; caller-provided request identity also preserves intent better than inferring duplicates only from matching parameters.",
+        "impact": "high",
+        "origin": "verification",
+        "status": "supported",
+        "evidence": [
+          {"kind": "verification", "source_id": "src-idempotent-receiver-2023", "url": "https://aws.amazon.com/builders-library/making-retries-safe-with-idempotent-APIs/", "locator": "Reducing client complexity: caller-provided request identifier and atomic/ACID token + mutating operations"}
+        ],
+        "note": "AWS Builders' Library is verification/enrichment for production boundaries; these details are not claimed by the short Idempotent Receiver pattern page."
+      },
+      {
+        "id": "idempotent-receiver-refines-retry-idempotency",
+        "text": "Idempotent Receiver is a concrete receiver-side mechanism for the existing idempotency-under-retry requirement, but it should not be interpreted as a universal exactly-once guarantee across downstream side effects.",
+        "impact": "high",
+        "origin": "project_interpretation",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-idempotent-receiver-2023", "url": "https://martinfowler.com/articles/patterns-of-distributed-systems/idempotent-receiver.html", "locator": "Idempotent Receiver → Problem and Solution"},
+          {"kind": "verification", "source_id": "src-idempotent-receiver-2023", "url": "https://aws.amazon.com/builders-library/making-retries-safe-with-idempotent-APIs/", "locator": "Retrying and side effects; idempotent session and atomic mutation boundary"},
+          {"kind": "prior_insight", "insight_id": "temporal-durable-execution-mental-model", "locator": "Idempotency-under-retry boundary for retryable external effects"}
+        ],
+        "note": "The source supplies the receiver pattern, AWS supplies production implementation boundaries, and the refinement relationship to the existing Temporal-derived concept is project synthesis."
+      }
+    ]
+  },
+  "prerequisite_map": {
+    "insight_id": "idempotent-receiver-retry-deduplication",
+    "summary": "The pattern is easiest to understand by starting from the existing retry-idempotency problem, then adding the source's two concrete pieces: a receiver that remembers prior requests and a stable identity for the logical operation.",
+    "items": [
+      {
+        "id": "idempotent-receiver-prereq-idempotency",
+        "label": "Idempotency under retry",
+        "concept_id": "idempotency-under-retry",
+        "priority": "must_know_now",
+        "prior_coverage": "established",
+        "state": "known_in_graph",
+        "reason": "The receiver pattern solves a concrete instance of the broader problem that retrying a side effect must not create an unintended duplicate outcome.",
+        "resolution": {"kind": "existing_explainer", "insight_id": "temporal-durable-execution-mental-model", "target": null}
+      },
+      {
+        "id": "idempotent-receiver-prereq-pattern",
+        "label": "Idempotent Receiver",
+        "concept_id": "idempotent-receiver",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "The receiver-side lookup and response-reuse behavior is the concrete mechanism introduced by the source.",
+        "resolution": {"kind": "explained_here", "insight_id": "idempotent-receiver-retry-deduplication", "target": null}
+      },
+      {
+        "id": "idempotent-receiver-prereq-request-identity",
+        "label": "Logical request identity",
+        "concept_id": "request-identity",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "Without a stable identity reused by retries, the receiver cannot know whether a delivery represents the same intended operation or a new one.",
+        "resolution": {"kind": "explained_here", "insight_id": "idempotent-receiver-retry-deduplication", "target": null}
+      }
+    ]
+  },
+  "learning_prompt": {
+    "insight_id": "idempotent-receiver-retry-deduplication",
+    "retention_prompt": "Without looking back, reconstruct the Idempotent Receiver model: explain why a missing response creates an ambiguous outcome, how stable logical request identity changes a retry, what the receiver stores or reuses, and why a deduplication token alone is still not a complete production guarantee.",
+    "answer_key": {
+      "problem_from": "whole_source_map.problem",
+      "mechanism_from": "whole_source_map.thesis",
+      "anchor_concept_ids": ["idempotency-under-retry", "idempotent-receiver", "request-identity"],
+      "boundary_limitation_index": 0
+    },
+    "transfer_prompt": {
+      "prompt": "An integration sends a create request, times out, and retries. Design the minimum receiver contract that prevents a second business object from being created: what identity must survive the retry, what does the receiver do when it sees that identity again, and what consistency question must be answered around the mutation?",
+      "expected_concept_ids": ["idempotency-under-retry", "idempotent-receiver", "request-identity"]
+    }
+  },
+  "source_decision": {
+    "insight_id": "idempotent-receiver-retry-deduplication",
+    "decision": "explainer_is_enough",
+    "rationale": "The primary pattern page is intentionally very short. The explainer preserves its complete problem/solution mechanism and adds clearly labeled production verification around request intent and atomic token/mutation handling, so rereading the original adds little unless the reader wants the canonical pattern entry itself.",
+    "novelty": {"level": "medium", "reason": "The broad need for idempotency under retry already existed in the graph; the novelty is the concrete receiver-side request-identity and prior-outcome reuse mechanism."},
+    "source_quality": {"level": "high", "reason": "This is the primary Patterns of Distributed Systems entry by Unmesh Joshi, used directly for the pattern definition and dated provenance."},
+    "relevance": {"level": "high", "reason": "Duplicate-safe retries are directly applicable to APIs, integrations and agent/tool side effects where timeout does not reveal the true remote outcome."},
+    "practical_leverage": {"level": "high", "reason": "The model turns a vague 'make it idempotent' requirement into concrete API design questions about logical request identity, duplicate detection and outcome reuse."},
+    "compression_loss": {"level": "low", "reason": "The original source contains a compact problem/solution statement; the explainer preserves that entire model while keeping AWS production details explicitly separate as verification."},
+    "selected_parts": []
+  }
+}

--- a/data/case-patches/idempotent-receiver.json
+++ b/data/case-patches/idempotent-receiver.json
@@ -1,0 +1,105 @@
+{
+  "patch_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-martinfowler-idempotent-receiver-html",
+  "intake_status": "review",
+  "updated_at": "2026-08-27",
+  "graph_version": "0.4.0",
+  "source": {
+    "id": "src-idempotent-receiver-2023",
+    "type": "article",
+    "title": "Idempotent Receiver",
+    "canonical_url": "https://martinfowler.com/articles/patterns-of-distributed-systems/idempotent-receiver.html",
+    "creators": ["Unmesh Joshi"],
+    "publisher": "martinfowler.com / Patterns of Distributed Systems",
+    "event": null,
+    "published_at": "2023-11-23",
+    "event_date": null,
+    "captured_at": "2026-08-27",
+    "analyzed_at": "2026-08-27",
+    "date_note": "Primary pattern page dated 23 November 2023. AWS Builders' Library guidance was inspected separately as verification for production idempotency boundaries.",
+    "verification": [
+      {"title": "Idempotent Receiver", "url": "https://martinfowler.com/articles/patterns-of-distributed-systems/idempotent-receiver.html", "accessed_at": "2026-08-27"},
+      {"title": "Making retries safe with idempotent APIs", "url": "https://aws.amazon.com/builders-library/making-retries-safe-with-idempotent-APIs/", "accessed_at": "2026-08-27"}
+    ],
+    "derived_records": ["idempotent-receiver-retry-deduplication"]
+  },
+  "insight": {
+    "id": "idempotent-receiver-retry-deduplication",
+    "source_id": "src-idempotent-receiver-2023",
+    "slug": "idempotent-receiver-retry-deduplication",
+    "status": "review",
+    "title": "Idempotent Receiver: retries need logical request identity",
+    "one_liner": "When a timeout leaves execution ambiguous, reuse the same logical request identity on retry so the receiver can return the earlier outcome instead of repeating the side effect.",
+    "why_this_matters": "Retries are one of the simplest reliability tools and one of the easiest ways to duplicate side effects. Idempotent Receiver turns the existing abstract rule 'make retries safe' into a concrete protocol between caller and receiver: stable request identity, durable duplicate detection and response reuse.",
+    "whole_source_map": {
+      "problem": "A client that receives no response cannot tell whether the server failed before processing or completed the operation and only lost the response; retrying can therefore repeat an already-completed mutation.",
+      "thesis": "Identify the client and logical request uniquely, detect previously processed requests at the receiver, and return the saved prior response without processing the same logical operation again.",
+      "core_topics": ["ambiguous failure after missing response", "duplicate delivery under retry", "client plus request identity", "receiver-side processed-request lookup", "saved response reuse", "atomicity and intent boundaries from verification"]
+    },
+    "derived_model": {
+      "problem": "A transport failure creates uncertainty about outcome, not proof of failure; blindly retrying converts that uncertainty into duplicate-side-effect risk.",
+      "mechanism": "Carry a stable identifier for the logical request across retries. The receiver records the processed request and outcome, recognizes the same identity later, and reuses the prior result instead of mutating again.",
+      "result": "Clients can retry ambiguous failures with an at-most-once-style business effect, provided the receiver's deduplication state is durable and consistent with the mutation it protects."
+    },
+    "coherence_review": {
+      "central_chain": ["A missing response leaves the caller uncertain whether the operation happened.", "Retrying the same logical operation can therefore create a duplicate side effect.", "Stable caller/request identity lets the receiver distinguish a retry from a new operation.", "The receiver can return the saved prior outcome rather than execute the mutation again.", "Production correctness still depends on durable/atomic deduplication state and on request identity representing caller intent rather than just matching parameters."],
+      "prerequisites_complete": true,
+      "source_vs_enrichment_clear": true,
+      "open_gaps": ["The primary pattern page does not specify retention windows for request identities or saved responses.", "Atomic token+mutation persistence and same-token/different-intent handling are verification-layer production concerns from AWS guidance, not claims made by the primary pattern page."],
+      "scores": {"coherence": 5, "prerequisite_completeness": 5, "evidence_confidence": 5, "practical_leverage": 5}
+    },
+    "visual_plan": {
+      "dominant": {
+        "type": "sequence",
+        "title": "Retry the request, not the side effect",
+        "nodes": [
+          {"label": "01 · Call", "title": "Logical request R1", "text": "The caller sends a mutation with a stable request identity."},
+          {"label": "02 · Ambiguity", "title": "Response is lost", "text": "The caller cannot know whether the mutation completed or the server failed before processing."},
+          {"label": "03 · Retry", "title": "Send R1 again", "text": "The retry keeps the same logical request identity rather than creating a new one."},
+          {"label": "04 · Detect", "title": "Receiver finds R1", "text": "The receiver sees that this logical request was already processed."},
+          {"label": "05 · Reuse", "title": "Return prior outcome", "text": "The saved response or semantically equivalent result is returned without repeating the mutation."}
+        ]
+      },
+      "supporting": ["comparison", "concept_grid", "examples", "limitations", "action_map", "source_map"],
+      "image": {"needed": false, "reason": "The useful information is the retry/duplicate-detection sequence and the identity boundary; a compact sequence explains it more precisely than an illustration."}
+    },
+    "concepts": [
+      {"name": "Idempotency under retry", "depth": "learn", "why_needed": "The reliability goal is that repeating an ambiguous request does not create an unintended second business effect."},
+      {"name": "Idempotent Receiver", "depth": "learn", "why_needed": "This is the concrete receiver-side mechanism that recognizes a repeated logical request and reuses its prior outcome."},
+      {"name": "Logical request identity", "depth": "learn", "why_needed": "The receiver needs a stable key that means 'this is the same intended operation', not merely a request that happens to have similar parameters."}
+    ],
+    "tool_map": [],
+    "examples": [
+      {"domain": "payments", "scenario": "A client times out while creating a payment and cannot tell whether the debit occurred.", "question": "Will retrying with the same logical request identity return the first payment outcome instead of creating another debit?"},
+      {"domain": "resource creation", "scenario": "A create request succeeds on the server but the network drops before the caller sees the response.", "question": "Can the caller repeat the same request identity and recover the original resource/result rather than creating a duplicate?"},
+      {"domain": "integration", "scenario": "An outbound interface retries a master-data write after a transport timeout.", "question": "What request identity survives the retry, and is the receiver's deduplication record committed consistently with the business update?"}
+    ],
+    "limitations": ["A deduplication key is not enough if recording the key and committing the protected mutation can diverge during a crash; AWS verification guidance calls for an atomic/ACID boundary around those changes.", "Inferring identity from request parameters can suppress legitimate repeated intent; caller-provided logical request IDs make intent more explicit.", "Idempotency does not make an operation globally exactly-once across every downstream dependency; each consequential boundary needs compatible semantics.", "Retention and late-arriving-request policy determine how long a retry remains recognizable as the same logical request."],
+    "action_map": {
+      "use_now": ["For every retryable mutation, define the logical request identity before defining retry count/backoff.", "Treat a timeout as an unknown outcome, not as proof that the remote mutation failed."],
+      "try": ["Add an idempotency key to one create/update API and test lost-response retry, concurrent duplicate delivery and replay of the saved result."],
+      "learn": ["idempotent API contracts", "request identity", "atomic deduplication state", "late-arriving retries"],
+      "build": ["A tiny receiver that stores request ID + outcome transactionally and returns the stored outcome for repeated IDs."],
+      "watch": ["How downstream APIs expose caller-provided idempotency tokens and how long they retain them."],
+      "ignore_for_now": ["Assuming identical request parameters are always sufficient proof of duplicate caller intent."]
+    },
+    "connections": ["idempotency-under-retry: this source concretizes the earlier Temporal boundary with a receiver-side protocol", "reconciliation-loop: retries and reconciliation both handle uncertainty, but deduplicating one logical mutation is not the same as continuously converging desired state"],
+    "supporting_sources": [
+      {"title": "Idempotent Receiver", "url": "https://martinfowler.com/articles/patterns-of-distributed-systems/idempotent-receiver.html", "publisher": "martinfowler.com", "purpose": "primary source for ambiguous failure, client/request identity and saved-response reuse", "accessed_at": "2026-08-27"},
+      {"title": "Making retries safe with idempotent APIs", "url": "https://aws.amazon.com/builders-library/making-retries-safe-with-idempotent-APIs/", "publisher": "Amazon Builders' Library", "purpose": "verification/enrichment for caller-provided intent identifiers, atomic token+mutation persistence and semantically equivalent retry responses", "accessed_at": "2026-08-27"}
+    ],
+    "tags": ["idempotency", "retries", "distributed-systems", "apis", "deduplication", "reliability"],
+    "provenance": {"source_linked": true, "source_dates_recorded": true, "full_transcript_stored": false, "analysis_type": "direct primary-pattern analysis with separately labeled AWS verification of production boundaries", "reviewed_at": "2026-08-27"}
+  },
+  "graph": {
+    "concepts": [
+      {"id": "idempotency-under-retry", "insight_ids": ["idempotent-receiver-retry-deduplication"]},
+      {"id": "idempotent-receiver", "label": "Idempotent Receiver", "summary": "A receiver-side pattern that recognizes a repeated logical request and reuses its prior outcome instead of repeating the protected side effect.", "domain": "distributed systems", "coverage": "explained", "insight_ids": ["idempotent-receiver-retry-deduplication"], "aliases": ["idempotent request receiver", "duplicate-safe receiver"], "tags": ["idempotency", "retry", "deduplication", "api"]},
+      {"id": "request-identity", "label": "Logical request identity", "summary": "A stable identifier reused across retries to express that several deliveries represent the same intended logical operation.", "domain": "distributed systems", "coverage": "explained", "insight_ids": ["idempotent-receiver-retry-deduplication"], "aliases": ["idempotency key", "client request identifier"], "tags": ["idempotency", "identity", "retry", "api"]}
+    ],
+    "relations": [
+      {"id": "rel-idempotent-receiver-refines-idempotency-under-retry", "from": "idempotent-receiver", "to": "idempotency-under-retry", "type": "refines", "rationale": "The receiver pattern turns the broad requirement for duplicate-safe retries into a concrete request-identity and prior-outcome reuse mechanism.", "evidence_insights": ["idempotent-receiver-retry-deduplication"]},
+      {"id": "rel-idempotent-receiver-depends-on-request-identity", "from": "idempotent-receiver", "to": "request-identity", "type": "depends_on", "rationale": "The receiver must distinguish a retry of the same intended operation from a genuinely new operation before it can suppress duplicate execution.", "evidence_insights": ["idempotent-receiver-retry-deduplication"]}
+    ]
+  }
+}

--- a/data/research-bundles/intake-2026-08-27-martinfowler-idempotent-receiver-html.json
+++ b/data/research-bundles/intake-2026-08-27-martinfowler-idempotent-receiver-html.json
@@ -5,23 +5,23 @@
   "source": {
     "type": "article",
     "canonical_url": "https://martinfowler.com/articles/patterns-of-distributed-systems/idempotent-receiver.html",
-    "title": null,
-    "creators": [],
-    "publisher": null,
-    "published_at": null,
+    "title": "Idempotent Receiver",
+    "creators": ["Unmesh Joshi"],
+    "publisher": "martinfowler.com / Patterns of Distributed Systems",
+    "published_at": "2023-11-23",
     "event_date": null,
     "version": null,
-    "language": null,
+    "language": "en",
     "duration": null,
-    "date_note": null
+    "date_note": "The pattern page identifies Unmesh Joshi and is dated 23 November 2023. AWS Builders' Library was used separately to verify practical idempotency boundaries, not as source-authored content."
   },
   "inspection": {
-    "method": "not inspected",
-    "full_content_used_ephemerally": false,
+    "method": "Direct inspection of the Idempotent Receiver pattern page plus separate verification against AWS Builders' Library guidance on idempotent APIs.",
+    "full_content_used_ephemerally": true,
     "full_content_committed": false,
-    "confidence": "metadata_only",
+    "confidence": "direct",
     "gaps": [
-      "Source content has not been mapped yet."
+      "The source page is deliberately compact and does not specify retention windows, atomic storage implementation, concurrency races or late-arriving-request policy."
     ]
   },
   "prior_knowledge": {
@@ -33,52 +33,51 @@
         "label": "Idempotency under retry",
         "coverage": "explained",
         "evidence_insights": [
-          {
-            "id": "temporal-durable-execution-mental-model",
-            "status": "review",
-            "title": "Temporal: the mental model behind durable execution"
-          }
+          {"id": "temporal-durable-execution-mental-model", "status": "review", "title": "Temporal: the mental model behind durable execution"}
         ],
-        "relationship_to_source": "unclassified"
+        "relationship_to_source": "refinement"
       },
       {
         "concept_id": "activity-execution",
         "label": "Activity Execution",
         "coverage": "explained",
         "evidence_insights": [
-          {
-            "id": "temporal-durable-execution-mental-model",
-            "status": "review",
-            "title": "Temporal: the mental model behind durable execution"
-          }
+          {"id": "temporal-durable-execution-mental-model", "status": "review", "title": "Temporal: the mental model behind durable execution"}
         ],
-        "relationship_to_source": "unclassified"
+        "relationship_to_source": "not_relevant"
       }
     ],
     "classification_required": true
   },
   "content_map": {
-    "problem": null,
-    "thesis": null,
-    "sections": [],
-    "concepts": [],
-    "mechanisms": [],
+    "problem": "After a timeout or lost response, a client cannot know whether the server never processed the request or processed it and only the response was lost; retrying can therefore deliver the same logical request more than once.",
+    "thesis": "Give the client and each logical request stable identity, let the receiver detect whether that request was already processed, and return the saved response instead of executing the operation again.",
+    "sections": ["Problem", "Solution", "Patterns of Distributed Systems context"],
+    "concepts": ["idempotent receiver", "client identity", "request identity", "duplicate request detection", "saved response replay"],
+    "mechanisms": ["assign a stable client identifier", "assign a request number/identifier to the logical request", "look up whether the same client/request pair was already processed", "reuse the saved response for duplicates", "skip repeated mutation when the logical request is already complete"],
     "tools": [],
-    "examples": [],
-    "claims": [],
-    "evidence": [],
-    "assumptions": [],
-    "limitations": [],
-    "open_questions": []
+    "examples": ["a client retries after receiving no response even though the first server attempt may already have completed"],
+    "claims": ["Ambiguous failures force clients to retry because a missing response does not reveal whether server-side processing happened.", "A retry can become a duplicate request when the first request was processed before the response was lost.", "The receiver can recognize duplicates using client plus request identity and return the earlier saved response without reprocessing the operation."],
+    "evidence": ["The source's Problem section distinguishes response loss from server failure before processing.", "The Solution section specifies client identity, request numbers, processed-request lookup and saved-response reuse."],
+    "assumptions": ["The same logical operation reuses the same request identity across retries.", "The receiver retains enough durable information to decide whether that identity was already processed.", "The saved result can be returned with semantics useful to the retrying client."],
+    "limitations": ["The source does not define how long request identities and saved results must be retained.", "A request identifier alone does not explain how deduplication state and the business mutation are made atomic under crashes or concurrency.", "Treating identical parameters as identical intent can be wrong; the caller may legitimately want two equivalent-looking operations."],
+    "open_questions": ["What is the correct deduplication retention window for the operation?", "How should the service atomically persist request identity and business outcome?", "What should happen when the same request identity arrives with different parameters or intent?"]
   },
   "selection": {
     "requested_focus": "Understand duplicate delivery under retries and the idempotent receiver pattern; connect it carefully to the existing idempotency-under-retry concept and identify where deduplication IDs are insufficient.",
-    "coherent_core": [],
-    "prerequisites": [],
-    "drop_notes": [],
-    "connections": []
+    "coherent_core": ["ambiguous failure makes retry necessary", "retry can duplicate an already-completed mutation", "stable logical request identity lets the receiver recognize a duplicate", "a duplicate should reuse prior outcome/response rather than repeat the mutation", "the deduplication record must be trustworthy enough to survive the same failures the retry mechanism is addressing"],
+    "prerequisites": ["idempotency under retry", "logical request identity"],
+    "drop_notes": ["Do not turn this into a Temporal Activity tutorial; Activity Execution was a retrieval match caused by the earlier idempotency case, not part of this source.", "Keep AWS atomicity and client-intent guidance visibly labeled as verification/enrichment rather than source content."],
+    "connections": ["refines idempotency-under-retry with a concrete receiver-side mechanism", "connects retries to stable request identity and durable duplicate detection"]
   },
-  "verification_candidates": [],
-  "source_locators": [],
+  "verification_candidates": [
+    {"question": "Must request-token storage and the business mutation be atomic?", "reason": "A token-only design can still fail if the token and mutation are persisted inconsistently; AWS Builders' Library provides concrete production guidance.", "priority": "high"},
+    {"question": "Should request identity be inferred from request parameters?", "reason": "Identical parameters can represent distinct caller intent, so inferred hashes can incorrectly suppress valid operations.", "priority": "medium"}
+  ],
+  "source_locators": [
+    {"label": "Ambiguous retry problem", "locator": "Idempotent Receiver → Problem"},
+    {"label": "Client and request identity", "locator": "Idempotent Receiver → Solution"},
+    {"label": "Saved response reuse", "locator": "Idempotent Receiver → Solution"}
+  ],
   "created_at": "2026-08-27"
 }


### PR DESCRIPTION
Second new case from the 20-source validation cohort.

Purpose: test whether cumulative knowledge refines an existing concept instead of creating a duplicate.

Adds:
- directly inspected Idempotent Receiver source bundle;
- `idempotency-under-retry` classified as a genuine refinement and Temporal `activity-execution` suppressed as source-irrelevant;
- review insight + graph with concrete `idempotent-receiver` and `request-identity` concepts;
- atomic companion Knowledge Delta, claim evidence, prerequisite map, retention/transfer prompt and Source Decision;
- AWS Builders' Library used only as registered verification for caller-intent identity and atomic token+mutation boundaries, never presented as source content.

No auto-publication; stops at review.