### PR TITLE
Dogfood case: SQLite WAL on current cumulative graph

### DIFF
--- a/data/case-contracts/sqlite-wal.json
+++ b/data/case-contracts/sqlite-wal.json
@@ -1,0 +1,54 @@
+{
+  "contract_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-sqlite-wal-html",
+  "insight_id": "sqlite-write-ahead-log-checkpointing",
+  "knowledge_delta": {
+    "insight_id": "sqlite-write-ahead-log-checkpointing",
+    "summary": "SQLite WAL opens a new database-storage branch: append-first commit, checkpointing and reader snapshot boundaries. All retrieved execution/audit-history matches are suppressed because shared log vocabulary does not imply the same mechanism or purpose.",
+    "items": [
+      {"relationship": "new", "concept_id": "write-ahead-log", "label": "Write-ahead log", "source_basis": "SQLite preserves the database file during commit and appends changed pages plus a commit record to a separate WAL.", "prior_basis": "The project graph had execution and workflow histories but no transactional database write-ahead-log concept.", "interpretation": "The log is a storage/commit mechanism that separates foreground append from later consolidation, not a business audit record.", "evidence_insights": []},
+      {"relationship": "new", "concept_id": "checkpointing", "label": "Checkpointing", "source_basis": "SQLite later transfers committed WAL content into the database through a distinct checkpoint operation that can pause behind active readers.", "prior_basis": "No earlier concept represented WAL-to-database consolidation as a separate maintenance phase.", "interpretation": "Checkpointing makes the cost shift explicit: fast append-oriented commits still require later consolidation and coordination with readers.", "evidence_insights": []},
+      {"relationship": "new", "concept_id": "wal-reader-snapshot", "label": "WAL reader snapshot", "source_basis": "Each read transaction fixes an end mark and ignores newer WAL commits for the duration of that transaction.", "prior_basis": "Existing graph concepts did not model SQLite's point-in-time reader boundary over a concurrently growing WAL.", "interpretation": "The end mark explains why a reader can stay stable while a writer continues to append new commits.", "evidence_insights": []}
+    ],
+    "suppressed_prior_matches": ["execution-history", "event-history", "controlled-execution", "replayable-evaluation"]
+  },
+  "claim_evidence": {
+    "insight_id": "sqlite-write-ahead-log-checkpointing",
+    "claims": [
+      {"id": "sqlite-wal-append-commit", "text": "In SQLite WAL mode, changes are appended to a separate WAL and a transaction commits when a commit record is appended, without requiring the original database file to be updated at that moment.", "impact": "high", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-sqlite-wal-docs-2026", "url": "https://www.sqlite.org/wal.html", "locator": "Write-Ahead Logging → How WAL Works"}], "note": null},
+      {"id": "sqlite-wal-reader-concurrency", "text": "A WAL reader keeps a fixed end mark for its transaction, allowing readers to coexist with an appending writer, while SQLite still permits only one writer at a time.", "impact": "high", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-sqlite-wal-docs-2026", "url": "https://www.sqlite.org/wal.html", "locator": "Write-Ahead Logging → Concurrency"}], "note": null},
+      {"id": "sqlite-wal-checkpoint-starvation", "text": "Checkpointing copies committed WAL pages back into the database but can be prevented from completing by long-running or continuously overlapping readers, causing the WAL to keep growing.", "impact": "high", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-sqlite-wal-docs-2026", "url": "https://www.sqlite.org/wal.html", "locator": "Write-Ahead Logging → Checkpointing; Avoiding Excessively Large WAL Files"}], "note": null},
+      {"id": "sqlite-wal-not-execution-history", "text": "SQLite WAL should not be treated as the same concept as an application execution history or Temporal Event History merely because all are log-like records; WAL is database commit and recovery machinery with different evidence semantics.", "impact": "high", "origin": "project_interpretation", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-sqlite-wal-docs-2026", "url": "https://www.sqlite.org/wal.html", "locator": "Write-Ahead Logging → How WAL Works and WAL File"}, {"kind": "prior_insight", "insight_id": "enterprise-agents-production-substrate", "locator": "Execution history as reconstructable evidence of consequential work"}, {"kind": "prior_insight", "insight_id": "temporal-durable-execution-mental-model", "locator": "Temporal Event History as persisted workflow execution progress"}], "note": "This is a project-level scope comparison used to reject lexical retrieval noise; the SQLite source itself does not discuss the project's execution-history concepts."}
+    ]
+  },
+  "prerequisite_map": {
+    "insight_id": "sqlite-write-ahead-log-checkpointing",
+    "summary": "Three concepts are sufficient for the first mental model: append-first WAL commit, checkpointing as a separate consolidation step, and the reader end-mark snapshot that makes concurrent reads understandable.",
+    "items": [
+      {"id": "sqlite-wal-prereq-log", "label": "Write-ahead log", "concept_id": "write-ahead-log", "priority": "must_know_now", "prior_coverage": "absent", "state": "explained_here", "reason": "The inversion from overwriting the database to appending committed changes is the central storage mechanism.", "resolution": {"kind": "explained_here", "insight_id": "sqlite-write-ahead-log-checkpointing", "target": null}},
+      {"id": "sqlite-wal-prereq-checkpoint", "label": "Checkpointing", "concept_id": "checkpointing", "priority": "must_know_now", "prior_coverage": "absent", "state": "explained_here", "reason": "The model is incomplete if append-only commit is understood without the later operation that consolidates WAL pages into the database.", "resolution": {"kind": "explained_here", "insight_id": "sqlite-write-ahead-log-checkpointing", "target": null}},
+      {"id": "sqlite-wal-prereq-snapshot", "label": "WAL reader snapshot", "concept_id": "wal-reader-snapshot", "priority": "must_know_now", "prior_coverage": "absent", "state": "explained_here", "reason": "The reader end mark is what makes stable reads alongside newer appended commits coherent.", "resolution": {"kind": "explained_here", "insight_id": "sqlite-write-ahead-log-checkpointing", "target": null}}
+    ]
+  },
+  "learning_prompt": {
+    "insight_id": "sqlite-write-ahead-log-checkpointing",
+    "retention_prompt": "Without looking back, reconstruct SQLite WAL as a three-part model: explain where a write commits before the database file is updated, how a reader's end mark gives it a stable view, what checkpointing does later, and one way active readers can turn that separation into an operational problem.",
+    "answer_key": {"problem_from": "whole_source_map.problem", "mechanism_from": "whole_source_map.thesis", "anchor_concept_ids": ["write-ahead-log", "checkpointing", "wal-reader-snapshot"], "boundary_limitation_index": 2},
+    "transfer_prompt": {"prompt": "An embedded service has frequent small writes and some long analytical reads. If you switch it to SQLite WAL, explain which foreground work becomes cheaper, what snapshot behavior readers get, and what checkpoint/WAL-growth failure mode you would monitor.", "expected_concept_ids": ["write-ahead-log", "checkpointing", "wal-reader-snapshot"]}
+  },
+  "source_decision": {
+    "insight_id": "sqlite-write-ahead-log-checkpointing",
+    "decision": "skim_selected_parts",
+    "rationale": "The explainer is enough for the core mental model, but the official SQLite page contains implementation and operational details that matter before real tuning. Skim the mechanism, concurrency and checkpoint-starvation sections when adopting WAL or diagnosing a concrete workload.",
+    "novelty": {"level": "high", "reason": "The source creates a new database-storage branch; apparent links to execution history were retrieval noise rather than prior coverage."},
+    "source_quality": {"level": "high", "reason": "The source is the official SQLite WAL documentation and directly defines the implementation semantics being explained."},
+    "relevance": {"level": "medium", "reason": "The mechanism is highly reusable for understanding embedded-database concurrency, but it is less broadly applicable than the retry or reconciliation patterns."},
+    "practical_leverage": {"level": "high", "reason": "Knowing the end-mark and checkpoint model changes how WAL growth, long readers, commit latency and durability settings are diagnosed."},
+    "compression_loss": {"level": "medium", "reason": "The explainer intentionally omits WAL format, checkpoint modes, configuration APIs and several edge cases that become relevant during production tuning."},
+    "selected_parts": [
+      {"label": "How WAL Works", "locator": "Write-Ahead Logging → How WAL Works", "why": "Confirms the append-first commit inversion and commit-record boundary.", "claim_refs": ["sqlite-wal-append-commit"]},
+      {"label": "Concurrency", "locator": "Write-Ahead Logging → Concurrency", "why": "Shows reader end marks, WAL page lookup, reader/writer coexistence and the one-writer limit.", "claim_refs": ["sqlite-wal-reader-concurrency"]},
+      {"label": "Checkpoint starvation", "locator": "Write-Ahead Logging → Checkpointing; Avoiding Excessively Large WAL Files", "why": "Explains why overlapping long reads can prevent WAL reset and create file growth/performance problems.", "claim_refs": ["sqlite-wal-checkpoint-starvation"]}
+    ]
+  }
+}

--- a/data/case-patches/sqlite-wal.json
+++ b/data/case-patches/sqlite-wal.json
@@ -1,0 +1,101 @@
+{
+  "patch_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-sqlite-wal-html",
+  "intake_status": "review",
+  "updated_at": "2026-08-27",
+  "graph_version": "0.4.0",
+  "source": {
+    "id": "src-sqlite-wal-docs-2026",
+    "type": "documentation",
+    "title": "Write-Ahead Logging",
+    "canonical_url": "https://www.sqlite.org/wal.html",
+    "creators": ["SQLite project"],
+    "publisher": "SQLite",
+    "event": null,
+    "published_at": null,
+    "event_date": null,
+    "captured_at": "2026-08-27",
+    "analyzed_at": "2026-08-27",
+    "date_note": "Living documentation. WAL mode was introduced in SQLite 3.7.0 on 2010-07-21; page publication date is not asserted.",
+    "verification": [{"title": "SQLite Write-Ahead Logging", "url": "https://www.sqlite.org/wal.html", "accessed_at": "2026-08-27"}],
+    "derived_records": ["sqlite-write-ahead-log-checkpointing"]
+  },
+  "insight": {
+    "id": "sqlite-write-ahead-log-checkpointing",
+    "source_id": "src-sqlite-wal-docs-2026",
+    "slug": "sqlite-write-ahead-log-checkpointing",
+    "status": "review",
+    "title": "SQLite WAL: commit by append, consolidate by checkpoint",
+    "one_liner": "SQLite WAL keeps the database file stable during commit, appends changed pages to a log, gives readers fixed end marks, and moves committed changes back later through checkpointing.",
+    "why_this_matters": "WAL is a useful mental model for separating foreground commit from later consolidation. The separation improves reader/writer concurrency but introduces a third operation—checkpointing—with its own blocking, durability and file-growth trade-offs.",
+    "whole_source_map": {
+      "problem": "Rollback journaling writes old pages aside and then changes the database file, coupling commit behavior to the main database and limiting concurrency.",
+      "thesis": "Append changed pages and a commit record to a WAL, let each reader read through a stable end mark, and checkpoint committed WAL pages back into the database later.",
+      "core_topics": ["append-first WAL commit", "checkpointing", "reader end marks", "reader/writer concurrency", "single writer", "checkpoint starvation", "durability and performance trade-offs"]
+    },
+    "derived_model": {
+      "problem": "Foreground writes, concurrent reads and durable consolidation compete when every commit immediately mutates the primary database file.",
+      "mechanism": "SQLite records committed changes sequentially in a WAL while readers keep stable snapshot boundaries; checkpointing later transfers committed pages into the database when readers allow it.",
+      "result": "Readers and a writer can overlap and commits can be fast, but the system must manage checkpoint cost, WAL growth and a one-writer-at-a-time boundary."
+    },
+    "coherence_review": {
+      "central_chain": ["WAL preserves the original database file while a writer appends changed pages and a commit marker.", "Each reader records an end mark and therefore sees a stable point-in-time view even as later commits are appended.", "Because the writer only appends, readers and one writer can proceed concurrently.", "Checkpointing later copies committed WAL pages back to the database and may have to stop at pages still needed by readers.", "The design shifts cost rather than eliminating it: checkpoint frequency trades read performance, write latency, durability work and WAL growth."],
+      "prerequisites_complete": true,
+      "source_vs_enrichment_clear": true,
+      "open_gaps": ["Binary WAL format, locking/VFS internals and application-specific checkpoint tuning are outside this first model.", "The word 'log' here describes transaction storage and recovery state; it should not be conflated with the project's execution-history/audit concepts."],
+      "scores": {"coherence": 5, "prerequisite_completeness": 5, "evidence_confidence": 5, "practical_leverage": 4}
+    },
+    "visual_plan": {
+      "dominant": {
+        "type": "sequence",
+        "title": "Commit now, checkpoint later",
+        "nodes": [
+          {"label": "01 · Write", "title": "Append changed pages", "text": "The writer appends new page versions to the WAL instead of overwriting the database file."},
+          {"label": "02 · Commit", "title": "Append commit record", "text": "The transaction becomes committed when the WAL receives its commit marker."},
+          {"label": "03 · Read", "title": "Freeze an end mark", "text": "Each reader uses a fixed end mark and sees page versions no newer than that snapshot boundary."},
+          {"label": "04 · Consolidate", "title": "Checkpoint", "text": "Committed WAL pages are copied back to the database when active readers permit it."},
+          {"label": "05 · Reuse", "title": "Recycle WAL space", "text": "After checkpoint progress and reader release allow it, SQLite can rewind/reuse the WAL instead of growing forever."}
+        ]
+      },
+      "supporting": ["comparison", "concept_grid", "examples", "limitations", "action_map", "source_map"],
+      "image": {"needed": false, "reason": "The key learning is the ordering and concurrency relationship among database file, WAL, readers and checkpointing; a data-flow sequence is more precise than decorative imagery."}
+    },
+    "concepts": [
+      {"name": "Write-ahead log", "depth": "learn", "why_needed": "Committed changes live first in an append-only WAL rather than immediately overwriting the database file."},
+      {"name": "Checkpointing", "depth": "learn", "why_needed": "Checkpointing is the separate maintenance operation that transfers committed WAL content back into the database."},
+      {"name": "Reader end mark", "depth": "learn", "why_needed": "A fixed end mark gives each read transaction a stable snapshot while newer commits continue to append."}
+    ],
+    "tool_map": [
+      {"name": "PRAGMA journal_mode=WAL", "category": "SQLite configuration", "why_explore": "Enables WAL mode and makes the mental model concrete on a local database.", "url": "https://www.sqlite.org/pragma.html#pragma_journal_mode", "relationship": "Source-native SQLite configuration entry point.", "status": "try"},
+      {"name": "sqlite3_wal_checkpoint_v2", "category": "checkpoint control", "why_explore": "Useful after the conceptual model when an application needs explicit checkpoint policy beyond the default auto-checkpoint.", "url": "https://www.sqlite.org/c3ref/wal_checkpoint_v2.html", "relationship": "Source-native SQLite checkpoint interface.", "status": "learn"}
+    ],
+    "examples": [
+      {"domain": "embedded application", "scenario": "A UI reads data while a background task commits small updates.", "question": "Can readers keep stable snapshots while the writer appends commits, and what checkpoint policy prevents the WAL from becoming the new latency problem?"},
+      {"domain": "long-running report", "scenario": "A read transaction stays open while writes continue.", "question": "Will the reader's end mark prevent checkpoint completion and cause WAL growth or slower later reads?"}
+    ],
+    "limitations": ["WAL requires shared-memory coordination and therefore normally keeps all database processes on the same host rather than a network filesystem.", "Readers do not block the writer, but SQLite still has one writer at a time.", "Long-running readers can starve checkpoint completion and let the WAL grow.", "Checkpoint and synchronous settings trade foreground latency against durability after power loss; WAL is not a free universal speed-up."],
+    "action_map": {
+      "use_now": ["When evaluating SQLite concurrency, separate transaction commit from checkpoint work instead of treating them as one write path.", "Look for long-lived reads before blaming WAL growth on write volume alone."],
+      "try": ["Enable WAL on a disposable SQLite database and observe concurrent read/write behavior plus WAL size before and after checkpoints."],
+      "learn": ["WAL reader end marks", "checkpoint modes", "checkpoint starvation", "SQLite synchronous durability settings"],
+      "build": ["A small benchmark that varies reader duration and checkpoint frequency while measuring commit latency and WAL size."],
+      "watch": ["Whether workload shape makes checkpoint policy a visible operational concern rather than relying on the default threshold."],
+      "ignore_for_now": ["Treating SQLite WAL as an application audit log or business execution ledger."]
+    },
+    "connections": ["execution-history: deliberately different scope — SQLite WAL stores transactional page changes, not human-readable evidence of business execution", "event-history: different mechanism — Temporal history reconstructs workflow state, whereas SQLite WAL is database commit/recovery machinery"],
+    "supporting_sources": [{"title": "SQLite Write-Ahead Logging", "url": "https://www.sqlite.org/wal.html", "publisher": "SQLite", "purpose": "primary source for WAL commit, checkpoints, reader end marks, concurrency and operational trade-offs", "accessed_at": "2026-08-27"}],
+    "tags": ["sqlite", "wal", "database", "checkpointing", "concurrency", "storage"],
+    "provenance": {"source_linked": true, "source_dates_recorded": true, "full_transcript_stored": false, "analysis_type": "direct official SQLite documentation analysis", "reviewed_at": "2026-08-27"}
+  },
+  "graph": {
+    "concepts": [
+      {"id": "write-ahead-log", "label": "Write-ahead log", "summary": "A commit mechanism where changed data is appended to a separate log before later consolidation into the primary data store.", "domain": "database storage", "coverage": "explained", "insight_ids": ["sqlite-write-ahead-log-checkpointing"], "aliases": ["WAL"], "tags": ["database", "storage", "commit", "append"]},
+      {"id": "checkpointing", "label": "Checkpointing", "summary": "Moving committed changes from the write-ahead log back into the primary database while respecting active readers and durability constraints.", "domain": "database storage", "coverage": "explained", "insight_ids": ["sqlite-write-ahead-log-checkpointing"], "aliases": ["WAL checkpoint"], "tags": ["database", "wal", "maintenance", "consolidation"]},
+      {"id": "wal-reader-snapshot", "label": "WAL reader snapshot", "summary": "A read transaction's stable end mark that limits which WAL commits it can observe for the duration of that transaction.", "domain": "database concurrency", "coverage": "explained", "insight_ids": ["sqlite-write-ahead-log-checkpointing"], "aliases": ["reader end mark"], "tags": ["sqlite", "snapshot", "reader", "concurrency"]}
+    ],
+    "relations": [
+      {"id": "rel-write-ahead-log-depends-on-checkpointing", "from": "write-ahead-log", "to": "checkpointing", "type": "depends_on", "rationale": "SQLite's WAL lifecycle requires committed pages to be transferred back into the database so the WAL can be bounded and reused over time.", "evidence_insights": ["sqlite-write-ahead-log-checkpointing"]},
+      {"id": "rel-write-ahead-log-enables-wal-reader-snapshot", "from": "write-ahead-log", "to": "wal-reader-snapshot", "type": "enables", "rationale": "Appending newer commits to WAL lets an existing reader keep its own end mark and stable snapshot without blocking the writer.", "evidence_insights": ["sqlite-write-ahead-log-checkpointing"]}
+    ]
+  }
+}

--- a/data/research-bundles/intake-2026-08-27-sqlite-wal-html.json
+++ b/data/research-bundles/intake-2026-08-27-sqlite-wal-html.json
@@ -5,121 +5,62 @@
   "source": {
     "type": "documentation",
     "canonical_url": "https://www.sqlite.org/wal.html",
-    "title": null,
-    "creators": [],
-    "publisher": null,
+    "title": "Write-Ahead Logging",
+    "creators": ["SQLite project"],
+    "publisher": "SQLite",
     "published_at": null,
     "event_date": null,
     "version": null,
-    "language": null,
+    "language": "en",
     "duration": null,
-    "date_note": null
+    "date_note": "Living SQLite documentation. WAL mode was introduced in SQLite 3.7.0 on 2010-07-21; this analysis uses documentation accessed on 2026-08-27 rather than inventing a page publication date."
   },
   "inspection": {
-    "method": "not inspected",
-    "full_content_used_ephemerally": false,
+    "method": "Direct inspection of official SQLite WAL documentation: Overview, How WAL Works, Checkpointing, Concurrency, Performance Considerations and WAL-file lifecycle.",
+    "full_content_used_ephemerally": true,
     "full_content_committed": false,
-    "confidence": "metadata_only",
-    "gaps": [
-      "Source content has not been mapped yet."
-    ]
+    "confidence": "direct",
+    "gaps": ["Low-level WAL file format, locking protocol and VFS implementation details are outside the mental model retained here."]
   },
   "prior_knowledge": {
     "captured_at": "2026-08-27",
     "query": "Understand the WAL mental model, read/write concurrency, checkpointing, failure boundaries, and when append-first persistence changes system behavior.",
     "matches": [
-      {
-        "concept_id": "execution-history",
-        "label": "Execution history",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "enterprise-agents-production-substrate",
-            "status": "published",
-            "title": "Why enterprise AI agents fail after the POC"
-          },
-          {
-            "id": "temporal-durable-execution-mental-model",
-            "status": "review",
-            "title": "Temporal: the mental model behind durable execution"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "event-history",
-        "label": "Event History",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "temporal-durable-execution-mental-model",
-            "status": "review",
-            "title": "Temporal: the mental model behind durable execution"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "controlled-execution",
-        "label": "Controlled execution",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "enterprise-agents-production-substrate",
-            "status": "published",
-            "title": "Why enterprise AI agents fail after the POC"
-          },
-          {
-            "id": "open-policy-agent-decision-enforcement-model",
-            "status": "review",
-            "title": "Open Policy Agent: separate policy decisions from enforcement"
-          },
-          {
-            "id": "react-reason-act-observe-loop",
-            "status": "review",
-            "title": "ReAct: reason, act, observe — then update the plan"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "replayable-evaluation",
-        "label": "Replayable evaluation",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "enterprise-agents-production-substrate",
-            "status": "published",
-            "title": "Why enterprise AI agents fail after the POC"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      }
+      {"concept_id": "execution-history", "label": "Execution history", "coverage": "explained", "evidence_insights": [{"id": "enterprise-agents-production-substrate", "status": "published", "title": "Why enterprise AI agents fail after the POC"}, {"id": "temporal-durable-execution-mental-model", "status": "review", "title": "Temporal: the mental model behind durable execution"}], "relationship_to_source": "not_relevant"},
+      {"concept_id": "event-history", "label": "Event History", "coverage": "explained", "evidence_insights": [{"id": "temporal-durable-execution-mental-model", "status": "review", "title": "Temporal: the mental model behind durable execution"}], "relationship_to_source": "not_relevant"},
+      {"concept_id": "controlled-execution", "label": "Controlled execution", "coverage": "explained", "evidence_insights": [{"id": "enterprise-agents-production-substrate", "status": "published", "title": "Why enterprise AI agents fail after the POC"}, {"id": "open-policy-agent-decision-enforcement-model", "status": "review", "title": "Open Policy Agent: separate policy decisions from enforcement"}, {"id": "react-reason-act-observe-loop", "status": "review", "title": "ReAct: reason, act, observe — then update the plan"}], "relationship_to_source": "not_relevant"},
+      {"concept_id": "replayable-evaluation", "label": "Replayable evaluation", "coverage": "explained", "evidence_insights": [{"id": "enterprise-agents-production-substrate", "status": "published", "title": "Why enterprise AI agents fail after the POC"}], "relationship_to_source": "not_relevant"}
     ],
     "classification_required": true
   },
   "content_map": {
-    "problem": null,
-    "thesis": null,
-    "sections": [],
-    "concepts": [],
-    "mechanisms": [],
-    "tools": [],
-    "examples": [],
-    "claims": [],
-    "evidence": [],
-    "assumptions": [],
-    "limitations": [],
-    "open_questions": []
+    "problem": "Traditional rollback journaling writes original pages aside before changing the database file, which limits read/write concurrency and makes commit behavior different from an append-first design.",
+    "thesis": "WAL inverts the write path: keep the database file unchanged during commit, append changed pages and a commit record to a WAL, let readers use a stable end mark, and later checkpoint committed WAL content back into the database.",
+    "sections": ["Overview", "How WAL Works", "Checkpointing", "Concurrency", "Performance Considerations", "WAL File lifecycle"],
+    "concepts": ["write-ahead log", "append-first commit", "checkpointing", "reader end mark/snapshot", "single writer", "checkpoint starvation"],
+    "mechanisms": ["append changed pages to WAL instead of overwriting the database during commit", "append a commit marker to make the transaction committed", "assign each reader a fixed end mark for its read transaction", "read newest page version before that end mark from WAL or fall back to database", "checkpoint WAL pages back into the database", "pause checkpoint when active readers still depend on later WAL pages"],
+    "tools": ["PRAGMA journal_mode=WAL", "wal-index", "sqlite3_wal_checkpoint interfaces"],
+    "examples": ["readers continue from their snapshot while a writer appends new commits", "a long-lived read can prevent checkpoint completion and allow WAL growth"],
+    "claims": ["WAL commits by appending changes and a commit record without first writing the original database file.", "Readers and a writer can proceed concurrently because readers use stable end marks while the writer appends to WAL, but SQLite still permits only one writer at a time.", "Checkpointing transfers WAL content back into the database and can be blocked from completing by active readers.", "WAL trades commit latency, checkpoint cost, read performance and durability settings rather than being universally faster in every workload."],
+    "evidence": ["Official How WAL Works section describes append-first changes and commit record.", "Concurrency section defines reader end marks, WAL lookup and one-writer constraint.", "Checkpointing and performance sections describe checkpoint progress, reader blocking and performance trade-offs."],
+    "assumptions": ["All processes sharing WAL mode use compatible shared-memory mechanisms on the same host unless exclusive locking removes that need.", "Applications accept WAL-specific checkpoint and durability semantics.", "One-writer-at-a-time fits the workload even though readers can coexist with that writer."],
+    "limitations": ["WAL does not work over a normal network filesystem because SQLite's wal-index requires shared memory between processes.", "Only one writer can append at a time.", "Long-running readers can delay checkpoint completion and allow WAL growth.", "Durability and latency depend on synchronous/checkpoint configuration; NORMAL mode can trade power-loss durability for lower foreground sync cost."],
+    "open_questions": ["Which checkpoint policy matches a specific read/write workload?", "When is rollback journal preferable despite WAL's concurrency benefits?", "How should long-lived readers be detected before checkpoint starvation becomes operationally significant?"]
   },
   "selection": {
     "requested_focus": "Understand the WAL mental model, read/write concurrency, checkpointing, failure boundaries, and when append-first persistence changes system behavior.",
-    "coherent_core": [],
-    "prerequisites": [],
-    "drop_notes": [],
-    "connections": []
+    "coherent_core": ["commit appends changed pages rather than overwriting the database", "a reader keeps a fixed WAL end mark and therefore sees a stable snapshot", "checkpointing is a separate third operation that moves committed pages back", "readers can coexist with a writer but only one writer exists", "checkpoint frequency creates explicit read/write latency and file-growth trade-offs"],
+    "prerequisites": ["transaction commit", "write-ahead log", "checkpoint", "snapshot boundary"],
+    "drop_notes": ["Do not connect WAL to execution-history or audit evidence simply because both use log/history vocabulary; the source is about transactional storage state.", "Do not expand into WAL binary format or VFS internals unless implementation work requires them."],
+    "connections": ["append-first persistence can separate foreground commit from later consolidation work", "checkpoint starvation is an example of a background maintenance task constrained by active readers"]
   },
   "verification_candidates": [],
-  "source_locators": [],
+  "source_locators": [
+    {"label": "WAL versus rollback journal", "locator": "Write-Ahead Logging → How WAL Works"},
+    {"label": "Checkpoint model", "locator": "Write-Ahead Logging → Checkpointing"},
+    {"label": "Reader end mark and writer concurrency", "locator": "Write-Ahead Logging → Concurrency"},
+    {"label": "Performance/durability trade-offs", "locator": "Write-Ahead Logging → Performance Considerations"},
+    {"label": "Checkpoint starvation", "locator": "Write-Ahead Logging → Avoiding Excessively Large WAL Files"}
+  ],
   "created_at": "2026-08-27"
 }


### PR DESCRIPTION
Recreates the validated SQLite WAL cohort case from current `main` after Idempotent Receiver and the publication self-test fix landed.

The knowledge decision remains intentional:
- `execution-history`, Temporal `event-history`, controlled execution and replayable evaluation are suppressed as lexical retrieval noise;
- WAL creates a separate database-storage branch: append-first commit, checkpointing and reader end marks;
- Source Decision is `skim_selected_parts`, with every locator backed by the same claim-evidence trace.

This branch contains the already-corrected case contract and no unrelated pipeline changes. Stops at review; no publication.