### PR TITLE
Superseded: PostgreSQL MVCC duplicate branch

### DIFF
--- a/data/case-contracts/postgresql-mvcc.json
+++ b/data/case-contracts/postgresql-mvcc.json
@@ -1,0 +1,50 @@
+{
+  "contract_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-postgresql-mvcc-intro-html",
+  "insight_id": "postgresql-mvcc-snapshot-isolation",
+  "knowledge_delta": {
+    "insight_id": "postgresql-mvcc-snapshot-isolation",
+    "summary": "PostgreSQL adds a multiversion concurrency model with row-version visibility, MVCC snapshots and isolation-level boundaries. The existing SQLite WAL reader snapshot is suppressed as a different implementation mechanism rather than merged by shared snapshot vocabulary.",
+    "items": [
+      {"relationship": "new", "concept_id": "multiversion-concurrency-control", "label": "Multiversion Concurrency Control", "source_basis": "PostgreSQL maintains data consistency using a multiversion model so statements can see a database snapshot while concurrent updates create other versions.", "prior_basis": "The graph already contains workflow state and SQLite WAL storage concepts but no general multiversion database-concurrency mechanism.", "interpretation": "MVCC becomes a distinct concurrency model for separating read visibility from the latest in-place value and thereby reducing reader/writer lock contention.", "evidence_insights": []},
+      {"relationship": "new", "concept_id": "mvcc-snapshot", "label": "MVCC snapshot", "source_basis": "A PostgreSQL statement or transaction sees row versions through a snapshot whose lifetime depends on the isolation level.", "prior_basis": "SQLite WAL already has a reader end-mark snapshot, but that is tied to WAL commit position rather than PostgreSQL row-version visibility.", "interpretation": "The new snapshot concept is kept separate because the implementation mechanism and isolation semantics differ even though both stabilize what a reader can observe.", "evidence_insights": []},
+      {"relationship": "new", "concept_id": "transaction-isolation", "label": "Transaction isolation", "source_basis": "PostgreSQL isolation levels change which concurrent effects can be observed and when unsafe histories become waits or serialization failures.", "prior_basis": "No prior graph concept represented database isolation levels as the boundary around snapshot lifetime and concurrency anomalies.", "interpretation": "Isolation level becomes the correctness dial around MVCC: snapshot visibility is necessary but not sufficient to describe concurrent transaction behavior.", "evidence_insights": []}
+    ],
+    "suppressed_prior_matches": ["wal-reader-snapshot"]
+  },
+  "claim_evidence": {
+    "insight_id": "postgresql-mvcc-snapshot-isolation",
+    "claims": [
+      {"id": "postgresql-mvcc-snapshot-model", "text": "PostgreSQL uses Multiversion Concurrency Control so each SQL statement sees a snapshot/database version rather than an inconsistent mixture of concurrent updates.", "impact": "high", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-postgresql-mvcc-docs-2026", "url": "https://www.postgresql.org/docs/current/mvcc-intro.html", "locator": "PostgreSQL 18 → 13.1 Introduction"}], "note": null},
+      {"id": "postgresql-mvcc-read-write-nonblocking", "text": "Under PostgreSQL MVCC, ordinary reads do not conflict with locks acquired for writing, so reading does not block writing and writing does not block reading, although explicit lock facilities remain available.", "impact": "high", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-postgresql-mvcc-docs-2026", "url": "https://www.postgresql.org/docs/current/mvcc-intro.html", "locator": "PostgreSQL 18 → 13.1 Introduction"}], "note": null},
+      {"id": "postgresql-isolation-snapshot-lifetime", "text": "PostgreSQL Read Committed gives each SELECT a statement-start snapshot, while Repeatable Read keeps a transaction-stable snapshot and Serializable adds dependency monitoring that can abort transactions to prevent serialization anomalies.", "impact": "high", "origin": "verification", "status": "supported", "evidence": [{"kind": "verification", "source_id": "src-postgresql-mvcc-docs-2026", "url": "https://www.postgresql.org/docs/current/transaction-iso.html", "locator": "PostgreSQL 18 → 13.2.1 Read Committed; 13.2.2 Repeatable Read; 13.2.3 Serializable"}], "note": "The detailed isolation-level behavior comes from the linked official Transaction Isolation documentation, not from the short supplied introduction page."},
+      {"id": "postgresql-mvcc-not-sqlite-wal-snapshot", "text": "PostgreSQL MVCC snapshots and SQLite WAL reader end marks both give readers stable visibility boundaries, but they should not be merged as one mechanism: PostgreSQL selects visible row versions under transaction isolation while SQLite WAL fixes a reader's position in an append-oriented WAL.", "impact": "high", "origin": "project_interpretation", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-postgresql-mvcc-docs-2026", "url": "https://www.postgresql.org/docs/current/mvcc-intro.html", "locator": "PostgreSQL 18 → 13.1 Introduction"}, {"kind": "verification", "source_id": "src-postgresql-mvcc-docs-2026", "url": "https://www.postgresql.org/docs/current/transaction-iso.html", "locator": "PostgreSQL 18 → 13.2 Transaction Isolation"}, {"kind": "prior_insight", "insight_id": "sqlite-write-ahead-log-checkpointing", "locator": "SQLite WAL reader end-mark snapshot model"}], "note": "This scope distinction is project synthesis across two database sources; neither vendor documentation makes this cross-product comparison."}
+    ]
+  },
+  "prerequisite_map": {
+    "insight_id": "postgresql-mvcc-snapshot-isolation",
+    "summary": "The first PostgreSQL concurrency model needs three pieces: MVCC as the versioning mechanism, snapshots as visibility boundaries and transaction isolation as the rule set governing snapshot lifetime and remaining anomalies.",
+    "items": [
+      {"id": "postgresql-prereq-mvcc", "label": "Multiversion Concurrency Control", "concept_id": "multiversion-concurrency-control", "priority": "must_know_now", "prior_coverage": "absent", "state": "explained_here", "reason": "Without multiple row versions, the snapshot and reduced reader/writer contention model has no mechanism.", "resolution": {"kind": "explained_here", "insight_id": "postgresql-mvcc-snapshot-isolation", "target": null}},
+      {"id": "postgresql-prereq-snapshot", "label": "MVCC snapshot", "concept_id": "mvcc-snapshot", "priority": "must_know_now", "prior_coverage": "absent", "state": "explained_here", "reason": "A snapshot defines which row versions are visible and is the direct mental model behind consistent reads during concurrent changes.", "resolution": {"kind": "explained_here", "insight_id": "postgresql-mvcc-snapshot-isolation", "target": null}},
+      {"id": "postgresql-prereq-isolation", "label": "Transaction isolation", "concept_id": "transaction-isolation", "priority": "must_know_now", "prior_coverage": "absent", "state": "explained_here", "reason": "Snapshot visibility alone does not state which anomalies are allowed or when a transaction must wait, fail or retry.", "resolution": {"kind": "explained_here", "insight_id": "postgresql-mvcc-snapshot-isolation", "target": null}}
+    ]
+  },
+  "learning_prompt": {
+    "insight_id": "postgresql-mvcc-snapshot-isolation",
+    "retention_prompt": "Without looking back, reconstruct PostgreSQL MVCC: explain why multiple row versions reduce reader/writer contention, what an MVCC snapshot controls, how Read Committed and Repeatable Read differ in snapshot lifetime, and one conflict that MVCC still resolves with waiting, failure or explicit locking.",
+    "answer_key": {"problem_from": "whole_source_map.problem", "mechanism_from": "whole_source_map.thesis", "anchor_concept_ids": ["multiversion-concurrency-control", "mvcc-snapshot", "transaction-isolation"], "boundary_limitation_index": 0},
+    "transfer_prompt": {"prompt": "Two sessions read and update business data concurrently. Decide whether Read Committed, Repeatable Read or Serializable is the relevant starting point: what view must stay stable, which anomaly must be prevented, and what transaction-retry behavior must the application be prepared to handle?", "expected_concept_ids": ["multiversion-concurrency-control", "mvcc-snapshot", "transaction-isolation"]}
+  },
+  "source_decision": {
+    "insight_id": "postgresql-mvcc-snapshot-isolation",
+    "decision": "explainer_is_enough",
+    "rationale": "The supplied MVCC introduction is very short and the explainer preserves its complete snapshot/read-write contention model while adding clearly labeled official isolation-document verification. Reopen the PostgreSQL isolation documentation when choosing an isolation level for real code, but the original introduction is not required to retain the mental model.",
+    "novelty": {"level": "high", "reason": "MVCC introduces a new database-concurrency mechanism; the existing SQLite snapshot is explicitly rejected as a same-concept match."},
+    "source_quality": {"level": "high", "reason": "The primary and verification material are official PostgreSQL 18 documentation from the PostgreSQL Global Development Group."},
+    "relevance": {"level": "high", "reason": "Snapshot and isolation semantics are directly useful when reasoning about concurrent reads, updates and transactional business invariants."},
+    "practical_leverage": {"level": "high", "reason": "The model prevents the common mistake of equating MVCC with conflict-free concurrency and makes isolation/retry choices explicit."},
+    "compression_loss": {"level": "low", "reason": "The supplied introduction itself is compact; omitted internals such as tuple visibility and VACUUM are not necessary for the requested first mental model."},
+    "selected_parts": []
+  }
+}

--- a/data/case-patches/postgresql-mvcc.json
+++ b/data/case-patches/postgresql-mvcc.json
@@ -1,0 +1,106 @@
+{
+  "patch_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-postgresql-mvcc-intro-html",
+  "intake_status": "review",
+  "updated_at": "2026-08-27",
+  "graph_version": "0.4.0",
+  "source": {
+    "id": "src-postgresql-mvcc-docs-2026",
+    "type": "documentation",
+    "title": "PostgreSQL 18 Documentation: 13.1 Introduction",
+    "canonical_url": "https://www.postgresql.org/docs/current/mvcc-intro.html",
+    "creators": ["PostgreSQL Global Development Group"],
+    "publisher": "PostgreSQL",
+    "event": null,
+    "published_at": null,
+    "event_date": null,
+    "captured_at": "2026-08-27",
+    "analyzed_at": "2026-08-27",
+    "date_note": "Living documentation. `current` resolves to PostgreSQL 18 on 2026-08-27; no standalone page publication date is asserted.",
+    "verification": [
+      {"title": "PostgreSQL 18: 13.1 Introduction", "url": "https://www.postgresql.org/docs/current/mvcc-intro.html", "accessed_at": "2026-08-27"},
+      {"title": "PostgreSQL 18: 13.2 Transaction Isolation", "url": "https://www.postgresql.org/docs/current/transaction-iso.html", "accessed_at": "2026-08-27"}
+    ],
+    "derived_records": ["postgresql-mvcc-snapshot-isolation"]
+  },
+  "insight": {
+    "id": "postgresql-mvcc-snapshot-isolation",
+    "source_id": "src-postgresql-mvcc-docs-2026",
+    "slug": "postgresql-mvcc-snapshot-isolation",
+    "status": "review",
+    "title": "PostgreSQL MVCC: snapshots reduce contention, isolation defines the boundary",
+    "one_liner": "PostgreSQL MVCC lets readers see a version-consistent snapshot while concurrent writers create newer versions; isolation level controls snapshot scope and which anomalies turn into waits or transaction retries.",
+    "why_this_matters": "MVCC is often compressed into 'reads don't block writes'. The useful model is deeper: readers operate against visible row versions, snapshot lifetime changes by isolation level, conflicting writers can still wait or fail, and Serializable correctness can require retrying entire transactions.",
+    "whole_source_map": {
+      "problem": "Concurrent database sessions need consistent views without making every reader and writer serialize through blocking locks.",
+      "thesis": "Maintain multiple row versions so statements read a consistent snapshot while writers create newer versions; use transaction isolation to choose snapshot scope and anomaly guarantees, with explicit locks and retries still available where concurrency creates real conflicts.",
+      "core_topics": ["Multiversion Concurrency Control", "snapshot visibility", "read/write non-blocking", "Read Committed statement snapshots", "Repeatable Read transaction snapshots", "Serializable Snapshot Isolation", "explicit locking and serialization failure boundaries"]
+    },
+    "derived_model": {
+      "problem": "If concurrent reads and writes must always exclude one another, consistency is purchased with unnecessary lock contention; if they never coordinate at all, applications can observe or create invalid histories.",
+      "mechanism": "PostgreSQL keeps multiple row versions and evaluates visibility through snapshots. Read Committed refreshes the snapshot per statement, Repeatable Read keeps a transaction-stable snapshot, and Serializable additionally detects unsafe read/write dependency patterns and aborts transactions when needed.",
+      "result": "Ordinary reads and writes can overlap with low contention while the application chooses how much isolation it needs and handles the remaining write conflicts or serialization retries explicitly."
+    },
+    "coherence_review": {
+      "central_chain": ["MVCC keeps multiple row versions instead of making readers depend on the newest in-place value.", "A SQL statement sees a snapshot/database version and therefore does not read partially changing concurrent data.", "Ordinary reads do not block ordinary writes and writes do not block reads, reducing lock contention.", "Isolation level changes the lifetime and guarantees of that snapshot: Read Committed can refresh between statements while Repeatable Read stays stable for the transaction.", "Stronger isolation does not make concurrency disappear; PostgreSQL can wait on conflicting row changes or abort a transaction so the application retries rather than committing an unsafe history."],
+      "prerequisites_complete": true,
+      "source_vs_enrichment_clear": true,
+      "open_gaps": ["The introduction explains the multiversion model but not tuple visibility metadata or VACUUM mechanics.", "Detailed isolation-level behavior is taken from the linked official Transaction Isolation documentation and is recorded as verification/enrichment rather than silently attributed to the short introduction page.", "SQLite WAL reader end marks also create stable reads, but they are a different implementation mechanism and are not merged with PostgreSQL MVCC snapshots."],
+      "scores": {"coherence": 5, "prerequisite_completeness": 5, "evidence_confidence": 5, "practical_leverage": 5}
+    },
+    "visual_plan": {
+      "dominant": {
+        "type": "comparison",
+        "title": "Snapshot lifetime changes the isolation behavior",
+        "nodes": [
+          {"label": "Read Committed", "title": "New snapshot per statement", "text": "Each SELECT sees committed data as of that statement's start, so later statements in the same transaction can see newer commits."},
+          {"label": "Repeatable Read", "title": "Stable transaction snapshot", "text": "Successive reads keep the same transaction view, but conflicting updates can force a serialization-style retry."},
+          {"label": "Serializable", "title": "Stable view + dependency checks", "text": "PostgreSQL also detects read/write dependency patterns that would make committed results inconsistent with any serial order."}
+        ]
+      },
+      "supporting": ["sequence", "concept_grid", "examples", "limitations", "action_map", "source_map"],
+      "image": {"needed": false, "reason": "The source is about visibility and concurrency semantics; a snapshot/isolation comparison communicates the mechanism more precisely than an illustration."}
+    },
+    "concepts": [
+      {"name": "Multiversion Concurrency Control", "depth": "learn", "why_needed": "MVCC is the mechanism that lets readers use visible row versions while writers create newer versions instead of forcing every read/write pair through conflicting locks."},
+      {"name": "MVCC snapshot", "depth": "learn", "why_needed": "A snapshot defines which committed row versions a statement or transaction is allowed to see."},
+      {"name": "Transaction isolation", "depth": "learn", "why_needed": "Isolation level determines snapshot lifetime, allowed anomalies and when PostgreSQL must wait or abort rather than accept a concurrent history."}
+    ],
+    "tool_map": [
+      {"name": "SET TRANSACTION", "category": "transaction isolation control", "why_explore": "Makes the isolation-level choice explicit for one transaction and is the fastest way to test statement versus transaction snapshot behavior.", "url": "https://www.postgresql.org/docs/current/sql-set-transaction.html", "relationship": "Source-native PostgreSQL command linked from the official Transaction Isolation documentation.", "status": "try"},
+      {"name": "SELECT FOR UPDATE / SHARE", "category": "explicit row locking", "why_explore": "Useful when the application needs to control a specific write-conflict boundary rather than relying only on snapshot visibility.", "url": "https://www.postgresql.org/docs/current/explicit-locking.html", "relationship": "Source-native PostgreSQL locking mechanism referenced by the concurrency-control documentation.", "status": "learn"}
+    ],
+    "examples": [
+      {"domain": "dashboard read", "scenario": "A long transaction executes several SELECT statements while other sessions commit updates.", "question": "Should later statements see those newer commits, or must the whole transaction retain one snapshot?"},
+      {"domain": "business invariant", "scenario": "Two concurrent transactions each make a decision based on rows the other transaction is changing.", "question": "Is Repeatable Read sufficient, or must Serializable detect a read/write dependency and force one transaction to retry?"},
+      {"domain": "concurrent update", "scenario": "Two transactions attempt to update the same row.", "question": "Where does MVCC stop being 'non-blocking' and a writer need to wait, re-evaluate the row or abort?"}
+    ],
+    "limitations": ["MVCC reduces reader/writer contention but does not mean writers never wait on conflicting row updates.", "Read Committed can present different snapshots to successive statements in the same transaction.", "Repeatable Read provides a stable snapshot but can still allow serialization anomalies; applications enforcing multi-row business rules may need stronger isolation or explicit locking.", "Serializable can abort transactions with SQLSTATE 40001, so applications need a whole-transaction retry strategy and must avoid duplicating nontransactional external side effects during retry."],
+    "action_map": {
+      "use_now": ["When discussing database concurrency, separate snapshot visibility from write-conflict behavior; 'reads don't block writes' is not the whole isolation contract.", "For a business invariant, state which isolation anomalies are acceptable before adding explicit locks by habit."],
+      "try": ["Run the same two-session experiment under Read Committed and Repeatable Read and observe whether a second SELECT in the transaction sees a concurrent commit.", "Trigger a Serializable conflict and verify that the application retries the entire transaction rather than only the failed statement."],
+      "learn": ["MVCC visibility", "statement versus transaction snapshots", "serialization anomalies", "Serializable Snapshot Isolation", "explicit row locks"],
+      "build": ["A small two-session concurrency fixture that demonstrates snapshot lifetime and serialization retry behavior across PostgreSQL isolation levels."],
+      "watch": ["Where transaction retries cross into external side effects that PostgreSQL cannot roll back."],
+      "ignore_for_now": ["Treating MVCC snapshot internals as the same mechanism as SQLite WAL reader end marks simply because both provide stable reads."]
+    },
+    "connections": ["wal-reader-snapshot: both models stabilize what a reader can see, but SQLite WAL uses an end mark over appended commits while PostgreSQL MVCC chooses visible row versions", "idempotency-under-retry: database serialization retry and API idempotency are separate boundaries; transaction retry does not automatically deduplicate external calls"],
+    "supporting_sources": [
+      {"title": "PostgreSQL 18: 13.1 Introduction", "url": "https://www.postgresql.org/docs/current/mvcc-intro.html", "publisher": "PostgreSQL", "purpose": "primary source for MVCC snapshots, lock contention and read/write non-blocking guarantee", "accessed_at": "2026-08-27"},
+      {"title": "PostgreSQL 18: 13.2 Transaction Isolation", "url": "https://www.postgresql.org/docs/current/transaction-iso.html", "publisher": "PostgreSQL", "purpose": "verification/enrichment for Read Committed, Repeatable Read and Serializable snapshot/retry boundaries", "accessed_at": "2026-08-27"}
+    ],
+    "tags": ["postgresql", "mvcc", "database", "concurrency", "transactions", "isolation", "snapshots"],
+    "provenance": {"source_linked": true, "source_dates_recorded": true, "full_transcript_stored": false, "analysis_type": "direct PostgreSQL 18 MVCC introduction analysis with separately registered official isolation-document verification", "reviewed_at": "2026-08-27"}
+  },
+  "graph": {
+    "concepts": [
+      {"id": "multiversion-concurrency-control", "label": "Multiversion Concurrency Control", "summary": "A concurrency model that keeps multiple data versions so transactions can read version-consistent snapshots while concurrent writers create newer versions.", "domain": "database concurrency", "coverage": "explained", "insight_ids": ["postgresql-mvcc-snapshot-isolation"], "aliases": ["MVCC"], "tags": ["database", "concurrency", "versions", "transactions"]},
+      {"id": "mvcc-snapshot", "label": "MVCC snapshot", "summary": "A visibility boundary that determines which committed row versions a PostgreSQL statement or transaction can observe.", "domain": "database concurrency", "coverage": "explained", "insight_ids": ["postgresql-mvcc-snapshot-isolation"], "aliases": ["database snapshot", "transaction snapshot"], "tags": ["postgresql", "snapshot", "visibility", "transactions"]},
+      {"id": "transaction-isolation", "label": "Transaction isolation", "summary": "The concurrency guarantee that determines snapshot lifetime, prohibited anomalies and how conflicts are resolved for a transaction.", "domain": "database concurrency", "coverage": "explained", "insight_ids": ["postgresql-mvcc-snapshot-isolation"], "aliases": ["isolation level"], "tags": ["transactions", "isolation", "concurrency", "anomalies"]}
+    ],
+    "relations": [
+      {"id": "rel-mvcc-enables-mvcc-snapshot", "from": "multiversion-concurrency-control", "to": "mvcc-snapshot", "type": "enables", "rationale": "Keeping multiple row versions lets a reader select the versions visible to its statement or transaction snapshot without blocking ordinary concurrent writes.", "evidence_insights": ["postgresql-mvcc-snapshot-isolation"]},
+      {"id": "rel-mvcc-snapshot-related-to-transaction-isolation", "from": "mvcc-snapshot", "to": "transaction-isolation", "type": "related_to", "rationale": "PostgreSQL isolation levels change the lifetime and guarantees of MVCC snapshots and add conflict detection or retry requirements where snapshot visibility alone is insufficient.", "evidence_insights": ["postgresql-mvcc-snapshot-isolation"]}
+    ]
+  }
+}

--- a/data/research-bundles/intake-2026-08-27-postgresql-mvcc-intro-html.json
+++ b/data/research-bundles/intake-2026-08-27-postgresql-mvcc-intro-html.json
@@ -5,53 +5,67 @@
   "source": {
     "type": "documentation",
     "canonical_url": "https://www.postgresql.org/docs/current/mvcc-intro.html",
-    "title": null,
-    "creators": [],
-    "publisher": null,
+    "title": "PostgreSQL 18 Documentation: 13.1 Introduction",
+    "creators": ["PostgreSQL Global Development Group"],
+    "publisher": "PostgreSQL",
     "published_at": null,
     "event_date": null,
-    "version": null,
-    "language": null,
+    "version": "18",
+    "language": "en",
     "duration": null,
-    "date_note": null
+    "date_note": "Living documentation. `current` resolves to PostgreSQL 18 on 2026-08-27; the page itself does not provide a standalone publication date."
   },
   "inspection": {
-    "method": "not inspected",
-    "full_content_used_ephemerally": false,
+    "method": "Direct inspection of PostgreSQL 18 Concurrency Control introduction and the official Transaction Isolation section for snapshot lifetime, anomaly and retry boundaries.",
+    "full_content_used_ephemerally": true,
     "full_content_committed": false,
-    "confidence": "metadata_only",
-    "gaps": [
-      "Source content has not been mapped yet."
-    ]
+    "confidence": "direct",
+    "gaps": ["Tuple visibility metadata, VACUUM, xmin/xmax internals and predicate-lock implementation details are outside this first MVCC mental model."]
   },
   "prior_knowledge": {
     "captured_at": "2026-08-27",
     "query": "Understand MVCC as a concurrency model: snapshots, read/write non-blocking behavior, isolation boundaries, and what the model does not eliminate.",
-    "matches": [],
+    "matches": [
+      {
+        "concept_id": "wal-reader-snapshot",
+        "label": "WAL reader snapshot",
+        "coverage": "explained",
+        "evidence_insights": [
+          {"id": "sqlite-write-ahead-log-checkpointing", "status": "review", "title": "SQLite WAL: commit by append, consolidate by checkpoint"}
+        ],
+        "relationship_to_source": "not_relevant"
+      }
+    ],
     "classification_required": true
   },
   "content_map": {
-    "problem": null,
-    "thesis": null,
-    "sections": [],
-    "concepts": [],
-    "mechanisms": [],
-    "tools": [],
-    "examples": [],
-    "claims": [],
-    "evidence": [],
-    "assumptions": [],
-    "limitations": [],
-    "open_questions": []
+    "problem": "Concurrent database sessions need consistent views without turning every read/write interaction into blocking lock contention or exposing partially changing data.",
+    "thesis": "PostgreSQL uses Multiversion Concurrency Control so statements read a snapshot/database version while concurrent writers create newer versions; isolation levels determine snapshot scope and anomaly guarantees, and explicit locks remain available for conflicts MVCC does not remove.",
+    "sections": ["13.1 Introduction", "13.2 Transaction Isolation", "Read Committed", "Repeatable Read", "Serializable"],
+    "concepts": ["Multiversion Concurrency Control", "MVCC snapshot", "transaction isolation", "read/write non-blocking", "serialization anomaly", "explicit locking boundary"],
+    "mechanisms": ["present each statement or transaction with a version-consistent snapshot", "let readers access older visible row versions while writers create newer versions", "choose snapshot lifetime and anomaly guarantees through transaction isolation level", "abort/retry transactions when stronger isolation detects incompatible concurrent histories", "use explicit row/table/advisory locks where the application must control particular conflicts"],
+    "tools": ["SET TRANSACTION", "SELECT FOR UPDATE / SHARE", "pg_locks"],
+    "examples": ["Read Committed gives each SELECT a fresh statement-start snapshot", "Repeatable Read keeps one stable transaction snapshot but can still require retries", "Serializable monitors read/write dependencies and aborts transactions that would produce a serialization anomaly"],
+    "claims": ["PostgreSQL MVCC gives SQL statements snapshot-based views and minimizes read/write lock contention.", "Ordinary reads do not block writes and writes do not block ordinary reads under PostgreSQL MVCC.", "Snapshot lifetime differs by isolation level: Read Committed can change between statements while Repeatable Read keeps a transaction-stable snapshot.", "MVCC does not eliminate every conflict: updates can wait or fail, stronger isolation can require transaction retries, and explicit locks are still available."],
+    "evidence": ["The official MVCC introduction explicitly defines snapshots and the read-does-not-block-write guarantee.", "The Transaction Isolation documentation defines statement-level versus transaction-level snapshot behavior and serialization failures."],
+    "assumptions": ["The application selects an isolation level whose anomalies and retry behavior fit its correctness requirements.", "A snapshot is understood as visibility of row versions, not a physical copy of the whole database.", "Application code can retry whole transactions when PostgreSQL reports serialization failures under stronger isolation."],
+    "limitations": ["MVCC reduces lock contention but does not mean writers never wait on conflicting row updates.", "A stable Repeatable Read snapshot can still permit serialization anomalies and therefore does not by itself guarantee all business invariants.", "Serializable provides stronger guarantees by detecting dangerous read/write dependency patterns and can abort transactions that the application must retry.", "Explicit row, table and advisory locks remain useful when an application needs to control particular conflict points."],
+    "open_questions": ["Which isolation level is sufficient for a specific business invariant?", "Which update patterns require explicit locking rather than relying on snapshot isolation?", "How should transaction retry be designed around serialization failures without duplicating external side effects?"]
   },
   "selection": {
     "requested_focus": "Understand MVCC as a concurrency model: snapshots, read/write non-blocking behavior, isolation boundaries, and what the model does not eliminate.",
-    "coherent_core": [],
-    "prerequisites": [],
-    "drop_notes": [],
-    "connections": []
+    "coherent_core": ["multiple row versions let readers see a consistent visible version while writers proceed", "snapshot scope is controlled by isolation level", "read/write non-blocking does not mean conflict-free updates", "stronger isolation converts some unsafe concurrent histories into transaction abort/retry instead of silently accepting them"],
+    "prerequisites": ["Multiversion Concurrency Control", "snapshot visibility", "transaction isolation"],
+    "drop_notes": ["Do not merge PostgreSQL MVCC snapshots with SQLite WAL reader end marks merely because both use the word snapshot; they arise from different storage/concurrency mechanisms.", "Do not expand into VACUUM or tuple-header internals until implementation depth is needed."],
+    "connections": ["SQLite WAL reader snapshots and PostgreSQL MVCC snapshots both stabilize a reader view but through different mechanisms and scopes", "transaction retry appears again at Serializable/Repeatable Read boundaries but is a database transaction concern, not an idempotent API guarantee"]
   },
   "verification_candidates": [],
-  "source_locators": [],
+  "source_locators": [
+    {"label": "MVCC snapshot model", "locator": "PostgreSQL 18 → 13.1 Introduction"},
+    {"label": "Read/write non-blocking and lock boundary", "locator": "PostgreSQL 18 → 13.1 Introduction"},
+    {"label": "Read Committed snapshot lifetime", "locator": "PostgreSQL 18 → 13.2.1 Read Committed Isolation Level"},
+    {"label": "Repeatable Read snapshot and retry boundary", "locator": "PostgreSQL 18 → 13.2.2 Repeatable Read Isolation Level"},
+    {"label": "Serializable anomaly detection", "locator": "PostgreSQL 18 → 13.2.3 Serializable Isolation Level"}
+  ],
   "created_at": "2026-08-27"
 }


### PR DESCRIPTION
Superseded by the already-merged PostgreSQL MVCC cohort implementation on `main` (`9e762b7` plus materialization). The current main case already resolves the visual-contract issue and is followed by DuckDB/LangGraph/Docker/NIST/Transformer cohort work. This divergent PR is intentionally not merged.