### PR TITLE
research: add PostgreSQL MVCC cohort case

### DIFF
--- a/data/case-contracts/postgresql-mvcc.json
+++ b/data/case-contracts/postgresql-mvcc.json
@@ -1,0 +1,307 @@
+{
+  "contract_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-postgresql-mvcc-intro-html",
+  "insight_id": "postgresql-mvcc-snapshot-isolation",
+  "knowledge_delta": {
+    "insight_id": "postgresql-mvcc-snapshot-isolation",
+    "summary": "PostgreSQL opens a new database-concurrency branch: multiversion visibility snapshots, isolation-dependent snapshot scope and serialization retry. The existing SQLite WAL reader snapshot is explicitly rejected as the same concept because it is a WAL end-mark mechanism rather than PostgreSQL row-version visibility.",
+    "items": [
+      {
+        "relationship": "new",
+        "concept_id": "multiversion-concurrency-control",
+        "label": "Multiversion Concurrency Control (MVCC)",
+        "source_basis": "PostgreSQL maintains multiple data versions so statements can read a coherent snapshot while concurrent transactions continue to update data.",
+        "prior_basis": "The graph had database storage and WAL concepts but no general multiversion concurrency model.",
+        "interpretation": "MVCC becomes the reusable model for separating read visibility from concurrent physical updates without equating concurrency with absence of conflicts.",
+        "evidence_insights": []
+      },
+      {
+        "relationship": "new",
+        "concept_id": "mvcc-snapshot",
+        "label": "MVCC snapshot",
+        "source_basis": "Each PostgreSQL statement sees a snapshot of data, and stronger isolation levels extend the stability of that view across the transaction.",
+        "prior_basis": "SQLite WAL already had a reader end-mark concept, but it is specific to WAL visibility and is not a PostgreSQL MVCC row-version snapshot.",
+        "interpretation": "The new snapshot concept is kept separate so similar user-visible stability does not erase the different storage and visibility mechanisms.",
+        "evidence_insights": []
+      },
+      {
+        "relationship": "new",
+        "concept_id": "transaction-isolation-scope",
+        "label": "Transaction isolation scope",
+        "source_basis": "Read Committed takes a snapshot at each statement, while Repeatable Read keeps a transaction snapshot and Serializable adds stronger anomaly protection.",
+        "prior_basis": "No prior concept modeled snapshot lifetime and anomaly guarantees as an explicit isolation-level contract.",
+        "interpretation": "Isolation scope becomes the bridge between the abstract snapshot model and application-visible consistency behavior.",
+        "evidence_insights": []
+      },
+      {
+        "relationship": "new",
+        "concept_id": "serialization-failure-retry",
+        "label": "Serialization failure and retry",
+        "source_basis": "Repeatable Read and Serializable can abort transactions under concurrent conflicts, and Serializable applications must be prepared to retry transactions after serialization failure.",
+        "prior_basis": "The graph has retry/idempotency concepts for external side effects but no database concurrency concept where abort-and-retry is itself part of the isolation contract.",
+        "interpretation": "Database transaction retry is modeled separately from idempotent receiver or workflow retry so external side-effect safety is not inferred from database retry semantics.",
+        "evidence_insights": []
+      }
+    ],
+    "suppressed_prior_matches": [
+      "wal-reader-snapshot"
+    ]
+  },
+  "claim_evidence": {
+    "insight_id": "postgresql-mvcc-snapshot-isolation",
+    "claims": [
+      {
+        "id": "postgresql-mvcc-snapshot-visibility",
+        "text": "PostgreSQL MVCC gives each SQL statement a snapshot of data so it can see a coherent database version despite concurrent transactions changing underlying rows.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {
+            "kind": "primary_source",
+            "source_id": "src-postgresql-mvcc-docs-2026",
+            "url": "https://www.postgresql.org/docs/18/mvcc-intro.html",
+            "locator": "PostgreSQL 18 §13.1 Introduction"
+          }
+        ],
+        "note": null
+      },
+      {
+        "id": "postgresql-read-write-nonblocking-boundary",
+        "text": "Ordinary MVCC reads do not conflict with write locks, but this does not eliminate write-write waiting, explicit locks, or concurrency failures when transactions target the same data.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {
+            "kind": "primary_source",
+            "source_id": "src-postgresql-mvcc-docs-2026",
+            "url": "https://www.postgresql.org/docs/18/mvcc-intro.html",
+            "locator": "PostgreSQL 18 §13.1 Introduction"
+          },
+          {
+            "kind": "primary_source",
+            "source_id": "src-postgresql-mvcc-docs-2026",
+            "url": "https://www.postgresql.org/docs/18/transaction-iso.html",
+            "locator": "PostgreSQL 18 §13.2.1 Read Committed"
+          }
+        ],
+        "note": null
+      },
+      {
+        "id": "postgresql-read-committed-statement-snapshot",
+        "text": "Under Read Committed, each SELECT sees the committed database state as of that query's start, so successive statements inside one transaction can see different committed data.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {
+            "kind": "primary_source",
+            "source_id": "src-postgresql-mvcc-docs-2026",
+            "url": "https://www.postgresql.org/docs/18/transaction-iso.html",
+            "locator": "PostgreSQL 18 §13.2.1 Read Committed"
+          }
+        ],
+        "note": null
+      },
+      {
+        "id": "postgresql-repeatable-read-transaction-snapshot",
+        "text": "Under Repeatable Read, a transaction keeps a stable snapshot from its first non-control statement, while conflicting later updates can cause the transaction to abort with a serialization failure.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {
+            "kind": "primary_source",
+            "source_id": "src-postgresql-mvcc-docs-2026",
+            "url": "https://www.postgresql.org/docs/18/transaction-iso.html",
+            "locator": "PostgreSQL 18 §13.2.2 Repeatable Read"
+          }
+        ],
+        "note": null
+      },
+      {
+        "id": "postgresql-serializable-dependency-retry",
+        "text": "Serializable adds monitoring for dangerous read-write dependencies and can reject a transaction when the concurrent result cannot match any serial execution, requiring application-level transaction retry.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {
+            "kind": "primary_source",
+            "source_id": "src-postgresql-mvcc-docs-2026",
+            "url": "https://www.postgresql.org/docs/18/transaction-iso.html",
+            "locator": "PostgreSQL 18 §13.2.3 Serializable"
+          }
+        ],
+        "note": null
+      },
+      {
+        "id": "postgresql-mvcc-not-sqlite-wal-snapshot",
+        "text": "PostgreSQL MVCC snapshots and SQLite WAL reader snapshots should remain separate concepts: both stabilize what a reader sees, but one is multiversion row visibility and the other is a WAL end-mark mechanism.",
+        "impact": "high",
+        "origin": "project_interpretation",
+        "status": "supported",
+        "evidence": [
+          {
+            "kind": "primary_source",
+            "source_id": "src-postgresql-mvcc-docs-2026",
+            "url": "https://www.postgresql.org/docs/18/mvcc-intro.html",
+            "locator": "PostgreSQL 18 §13.1 Introduction"
+          },
+          {
+            "kind": "prior_insight",
+            "insight_id": "sqlite-write-ahead-log-checkpointing",
+            "locator": "SQLite WAL reader end mark and checkpoint model"
+          }
+        ],
+        "note": "This scope boundary is project synthesis comparing two database concurrency mechanisms; PostgreSQL documentation does not discuss SQLite WAL."
+      }
+    ]
+  },
+  "prerequisite_map": {
+    "insight_id": "postgresql-mvcc-snapshot-isolation",
+    "summary": "The MVCC model is coherent once the reader understands the multiversion model, the snapshot that controls visibility, the isolation rule that scopes that snapshot, and why stronger guarantees can intentionally fail a transaction.",
+    "items": [
+      {
+        "id": "postgresql-prereq-mvcc",
+        "label": "Multiversion Concurrency Control (MVCC)",
+        "concept_id": "multiversion-concurrency-control",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "The core concurrency benefit depends on separating visible row versions from one universally current physical value.",
+        "resolution": {
+          "kind": "explained_here",
+          "insight_id": "postgresql-mvcc-snapshot-isolation",
+          "target": null
+        }
+      },
+      {
+        "id": "postgresql-prereq-snapshot",
+        "label": "MVCC snapshot",
+        "concept_id": "mvcc-snapshot",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "Snapshot visibility is the concrete mechanism that lets a statement or transaction read a coherent database version while commits continue.",
+        "resolution": {
+          "kind": "explained_here",
+          "insight_id": "postgresql-mvcc-snapshot-isolation",
+          "target": null
+        }
+      },
+      {
+        "id": "postgresql-prereq-isolation-scope",
+        "label": "Transaction isolation scope",
+        "concept_id": "transaction-isolation-scope",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "Read Committed and Repeatable Read are easy to confuse unless snapshot lifetime is treated as an explicit part of the isolation contract.",
+        "resolution": {
+          "kind": "explained_here",
+          "insight_id": "postgresql-mvcc-snapshot-isolation",
+          "target": null
+        }
+      },
+      {
+        "id": "postgresql-prereq-serialization-retry",
+        "label": "Serialization failure and retry",
+        "concept_id": "serialization-failure-retry",
+        "priority": "learn_next",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "The strongest consistency story is incomplete unless transaction abort and whole-transaction retry are understood as expected concurrency behavior.",
+        "resolution": {
+          "kind": "explained_here",
+          "insight_id": "postgresql-mvcc-snapshot-isolation",
+          "target": null
+        }
+      }
+    ]
+  },
+  "learning_prompt": {
+    "insight_id": "postgresql-mvcc-snapshot-isolation",
+    "retention_prompt": "Without looking back, reconstruct PostgreSQL MVCC: explain what a snapshot controls, why ordinary reads can overlap writes, how Read Committed and Repeatable Read differ in snapshot lifetime, and why Serializable or conflicting updates can require a full transaction retry.",
+    "answer_key": {
+      "problem_from": "whole_source_map.problem",
+      "mechanism_from": "whole_source_map.thesis",
+      "anchor_concept_ids": [
+        "multiversion-concurrency-control",
+        "mvcc-snapshot",
+        "transaction-isolation-scope"
+      ],
+      "boundary_limitation_index": 0
+    },
+    "transfer_prompt": {
+      "prompt": "Two services read and update the same business data concurrently. One requires each statement to see the newest committed state; another must keep one stable transaction view and reject unsafe concurrent outcomes. Which PostgreSQL isolation behavior fits each requirement, and where must retry handling become part of the design?",
+      "expected_concept_ids": [
+        "mvcc-snapshot",
+        "transaction-isolation-scope",
+        "serialization-failure-retry"
+      ]
+    }
+  },
+  "source_decision": {
+    "insight_id": "postgresql-mvcc-snapshot-isolation",
+    "decision": "skim_selected_parts",
+    "rationale": "The explainer is enough for the MVCC mental model, but the official isolation sections are worth opening when database correctness matters because PostgreSQL's exact snapshot timing, conflicting-update behavior and Serializable retry semantics are the details most likely to be misremembered.",
+    "novelty": {
+      "level": "high",
+      "reason": "This source adds a new database-concurrency branch and introduces isolation-dependent snapshot scope rather than repeating the existing SQLite WAL storage model."
+    },
+    "source_quality": {
+      "level": "high",
+      "reason": "The source is the current official PostgreSQL 18 manual and is authoritative for transaction isolation behavior."
+    },
+    "relevance": {
+      "level": "high",
+      "reason": "Snapshot visibility and retry semantics directly affect correctness of concurrent application logic and data migrations, not just database internals."
+    },
+    "practical_leverage": {
+      "level": "high",
+      "reason": "The model provides a concrete checklist for choosing isolation levels, diagnosing concurrency assumptions and designing retry behavior."
+    },
+    "compression_loss": {
+      "level": "medium",
+      "reason": "A compact explainer preserves the model but cannot safely replace PostgreSQL's exact command-specific rules and edge cases when implementing complex concurrent updates."
+    },
+    "selected_parts": [
+      {
+        "label": "MVCC snapshot and nonblocking model",
+        "locator": "PostgreSQL 18 §13.1 Introduction",
+        "why": "Establishes what a snapshot is and the precise read-versus-write contention claim.",
+        "claim_refs": [
+          "postgresql-mvcc-snapshot-visibility",
+          "postgresql-read-write-nonblocking-boundary"
+        ]
+      },
+      {
+        "label": "Read Committed snapshot timing",
+        "locator": "PostgreSQL 18 §13.2.1 Read Committed",
+        "why": "Shows why two statements in one transaction can legitimately see different committed states and where same-row writers may wait.",
+        "claim_refs": [
+          "postgresql-read-committed-statement-snapshot",
+          "postgresql-read-write-nonblocking-boundary"
+        ]
+      },
+      {
+        "label": "Repeatable Read transaction view",
+        "locator": "PostgreSQL 18 §13.2.2 Repeatable Read",
+        "why": "Makes the transaction-wide snapshot and concurrent-update failure behavior explicit.",
+        "claim_refs": [
+          "postgresql-repeatable-read-transaction-snapshot"
+        ]
+      },
+      {
+        "label": "Serializable dependency detection",
+        "locator": "PostgreSQL 18 §13.2.3 Serializable",
+        "why": "Explains why stronger consistency can reject a transaction and why retry is part of the application contract.",
+        "claim_refs": [
+          "postgresql-serializable-dependency-retry"
+        ]
+      }
+    ]
+  }
+}

--- a/data/case-patches/postgresql-mvcc.json
+++ b/data/case-patches/postgresql-mvcc.json
@@ -1,0 +1,372 @@
+{
+  "patch_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-postgresql-mvcc-intro-html",
+  "intake_status": "review",
+  "updated_at": "2026-08-27",
+  "graph_version": "0.4.0",
+  "source": {
+    "id": "src-postgresql-mvcc-docs-2026",
+    "type": "documentation",
+    "title": "PostgreSQL 18: Multiversion Concurrency Control",
+    "canonical_url": "https://www.postgresql.org/docs/current/mvcc-intro.html",
+    "creators": [
+      "PostgreSQL Global Development Group"
+    ],
+    "publisher": "PostgreSQL Global Development Group",
+    "event": null,
+    "published_at": null,
+    "event_date": null,
+    "captured_at": "2026-08-27",
+    "analyzed_at": "2026-08-27",
+    "date_note": "Living documentation. The current manual resolves to PostgreSQL 18; PostgreSQL 18.6 was released on 2026-08-13. Stable PostgreSQL 18 documentation URLs were recorded as verification sources.",
+    "verification": [
+      {
+        "title": "PostgreSQL 18 — 13.1 Introduction",
+        "url": "https://www.postgresql.org/docs/18/mvcc-intro.html",
+        "accessed_at": "2026-08-27"
+      },
+      {
+        "title": "PostgreSQL 18 — 13.2 Transaction Isolation",
+        "url": "https://www.postgresql.org/docs/18/transaction-iso.html",
+        "accessed_at": "2026-08-27"
+      },
+      {
+        "title": "PostgreSQL 18 — 13.6 Caveats",
+        "url": "https://www.postgresql.org/docs/18/mvcc-caveats.html",
+        "accessed_at": "2026-08-27"
+      }
+    ],
+    "derived_records": [
+      "postgresql-mvcc-snapshot-isolation"
+    ]
+  },
+  "insight": {
+    "id": "postgresql-mvcc-snapshot-isolation",
+    "source_id": "src-postgresql-mvcc-docs-2026",
+    "slug": "postgresql-mvcc-snapshot-isolation",
+    "status": "review",
+    "title": "PostgreSQL MVCC: snapshots reduce blocking, isolation defines the boundary",
+    "one_liner": "PostgreSQL MVCC lets readers work from versioned snapshots while writes continue; Read Committed refreshes the snapshot per statement, Repeatable Read holds it for the transaction, and Serializable may reject work that cannot fit a serial order.",
+    "why_this_matters": "MVCC is often compressed into 'reads do not block writes,' which hides the part that matters for application correctness: every query sees a visibility boundary, that boundary changes with isolation level, concurrent writers can still wait or fail, and stronger consistency deliberately turns some conflicts into transaction retries.",
+    "whole_source_map": {
+      "problem": "Concurrent sessions need consistent views of changing data without serializing every reader and writer behind the same locking path.",
+      "thesis": "PostgreSQL uses multiple row versions and visibility snapshots to reduce read/write lock contention; transaction isolation determines snapshot lifetime and anomaly protection, while Serializable adds dependency detection that can abort transactions to preserve a serializable outcome.",
+      "core_topics": [
+        "MVCC snapshots",
+        "read/write nonblocking versus write/write conflicts",
+        "Read Committed statement snapshots",
+        "Repeatable Read transaction snapshots",
+        "Serializable Snapshot Isolation and retry",
+        "explicit-lock and transaction-visibility boundaries"
+      ]
+    },
+    "derived_model": {
+      "problem": "If every read must wait for current writers or every query simply sees the newest physical change, concurrent applications either block excessively or reason over inconsistent state.",
+      "mechanism": "Readers evaluate row visibility against an MVCC snapshot. Read Committed takes a new snapshot per statement; Repeatable Read keeps a stable transaction snapshot; Serializable additionally monitors dangerous read/write dependencies and aborts transactions when needed.",
+      "result": "Readers and writers can overlap without ordinary read/write lock conflicts, while applications choose how stable the view must be and accept waits or retries where stronger consistency requires them."
+    },
+    "coherence_review": {
+      "central_chain": [
+        "PostgreSQL keeps multiple row versions so a statement can read a coherent snapshot rather than whatever version happens to be physically newest.",
+        "Ordinary reads therefore do not conflict with the locks used for writes, which reduces one major source of contention.",
+        "Read Committed refreshes the snapshot for each statement, so later statements in one transaction can see newer commits.",
+        "Repeatable Read keeps one transaction view, but a transaction that collides with a later committed update can fail and require a full retry.",
+        "Serializable keeps the stable-view model and additionally rejects executions whose read/write dependencies cannot correspond to any serial ordering."
+      ],
+      "prerequisites_complete": true,
+      "source_vs_enrichment_clear": true,
+      "open_gaps": [
+        "The source pages explain visibility and isolation behavior but not tuple-header, VACUUM or storage-level implementation details.",
+        "The phrase 'reading never blocks writing' does not imply all concurrent operations are nonblocking: same-row writers can wait, explicit locks still exist, and Serializable/Repeatable Read can abort transactions."
+      ],
+      "scores": {
+        "coherence": 5,
+        "prerequisite_completeness": 5,
+        "evidence_confidence": 5,
+        "practical_leverage": 5
+      }
+    },
+    "visual_plan": {
+      "dominant": {
+        "type": "comparison",
+        "title": "One MVCC model, three snapshot contracts",
+        "nodes": [
+          {
+            "label": "READ COMMITTED",
+            "title": "Fresh snapshot per statement",
+            "text": "Each statement sees commits visible when that statement begins, so later statements in the same transaction can observe newer committed data."
+          },
+          {
+            "label": "REPEATABLE READ",
+            "title": "Stable transaction snapshot",
+            "text": "The transaction keeps one database view; conflicting updates committed after that view can force the transaction to abort and retry."
+          },
+          {
+            "label": "SERIALIZABLE",
+            "title": "Stable view + dependency checks",
+            "text": "PostgreSQL also tracks dangerous read/write dependencies and rejects a transaction when the concurrent result cannot match any serial order."
+          }
+        ]
+      },
+      "supporting": [
+        "sequence",
+        "concept_grid",
+        "examples",
+        "limitations",
+        "action_map",
+        "source_map"
+      ],
+      "image": {
+        "needed": false,
+        "reason": "The main learning is how snapshot lifetime and failure behavior change across isolation levels; a comparison is more precise than a decorative or physical illustration."
+      }
+    },
+    "concepts": [
+      {
+        "name": "Multiversion Concurrency Control (MVCC)",
+        "depth": "learn",
+        "why_needed": "The concurrency model works by letting readers choose visible row versions from a snapshot rather than treating one physical row value as universally current."
+      },
+      {
+        "name": "MVCC snapshot",
+        "depth": "learn",
+        "why_needed": "A snapshot is the visibility boundary that makes a statement or transaction see a coherent database version while concurrent commits continue."
+      },
+      {
+        "name": "Transaction isolation scope",
+        "depth": "learn",
+        "why_needed": "Read Committed, Repeatable Read and Serializable differ in when snapshots refresh and which anomalies or failures applications must handle."
+      },
+      {
+        "name": "Serialization failure and retry",
+        "depth": "learn",
+        "why_needed": "Stronger consistency can deliberately reject a transaction, so correctness depends on retrying the complete transaction rather than assuming every concurrent commit must succeed."
+      }
+    ],
+    "tool_map": [
+      {
+        "name": "SET TRANSACTION",
+        "category": "transaction isolation control",
+        "why_explore": "Makes the snapshot contract explicit in a small experiment by switching between Read Committed, Repeatable Read and Serializable.",
+        "url": "https://www.postgresql.org/docs/18/sql-set-transaction.html",
+        "relationship": "Source-native PostgreSQL command referenced by the transaction-isolation documentation.",
+        "status": "try"
+      },
+      {
+        "name": "pg_locks",
+        "category": "concurrency inspection",
+        "why_explore": "Useful after the mental model to inspect where PostgreSQL still uses locks instead of concluding that MVCC means 'no locking'.",
+        "url": "https://www.postgresql.org/docs/18/view-pg-locks.html",
+        "relationship": "Source-native PostgreSQL system view for lock inspection; supporting implementation detail beyond the core MVCC introduction.",
+        "status": "learn"
+      }
+    ],
+    "examples": [
+      {
+        "domain": "dashboard/reporting",
+        "scenario": "A transaction runs two SELECT statements while another session commits between them.",
+        "question": "Under Read Committed, should the second statement see the newer commit; under Repeatable Read, should it stay on the earlier transaction snapshot?"
+      },
+      {
+        "domain": "concurrent account update",
+        "scenario": "Two transactions try to update the same row after one has already changed it.",
+        "question": "Where does MVCC stop being 'nonblocking' and require a wait, re-evaluation or serialization failure?"
+      },
+      {
+        "domain": "business invariant",
+        "scenario": "Two transactions each read a different aggregate and write a result that is individually valid but jointly impossible in any serial order.",
+        "question": "Would Repeatable Read allow the anomaly, and should Serializable detect the dependency cycle and abort one transaction?"
+      }
+    ],
+    "limitations": [
+      "MVCC reduces ordinary read/write lock contention but does not eliminate write/write waits, explicit locks or deadlocks.",
+      "Read Committed provides a statement snapshot, not a stable transaction-wide view; successive queries can legitimately see different committed data.",
+      "Repeatable Read gives a stable view but can still allow serialization anomalies and can fail on concurrent updates.",
+      "Serializable improves anomaly protection by aborting transactions; applications must handle SQLSTATE 40001 and retry the whole transaction.",
+      "Some DDL and sequence behavior has visibility rules outside the simplified MVCC snapshot model."
+    ],
+    "action_map": {
+      "use_now": [
+        "When reviewing concurrent database logic, state the required visibility scope explicitly instead of saying only 'use a transaction'.",
+        "Treat serialization failure as part of the API contract when choosing Repeatable Read or Serializable, not as an unexpected infrastructure error."
+      ],
+      "try": [
+        "Run two psql sessions and repeat the same pair of SELECTs under Read Committed and Repeatable Read to observe statement-versus-transaction snapshot scope.",
+        "Create a simple Serializable conflict and verify that one transaction returns SQLSTATE 40001 and must be retried."
+      ],
+      "learn": [
+        "MVCC visibility snapshots",
+        "PostgreSQL transaction isolation levels",
+        "serialization anomalies",
+        "serialization failure handling"
+      ],
+      "build": [
+        "A small concurrency test harness that runs the same business invariant under Read Committed, Repeatable Read and Serializable and records observed values, waits and retries."
+      ],
+      "watch": [
+        "How long-running snapshots and retry rates interact with workload design before moving into VACUUM and storage internals."
+      ],
+      "ignore_for_now": [
+        "Treating SQLite WAL reader end marks as the same mechanism as PostgreSQL MVCC simply because both expose a stable reader view."
+      ]
+    },
+    "connections": [
+      "SQLite WAL reader snapshot: similar user-visible idea of a stable read boundary, but SQLite WAL and PostgreSQL MVCC use different storage/visibility mechanisms and should remain separate graph concepts.",
+      "idempotency under retry: retrying a database transaction is not a substitute for duplicate-safe semantics if the transaction coordinates external side effects."
+    ],
+    "supporting_sources": [
+      {
+        "title": "PostgreSQL 18 — 13.1 Introduction",
+        "url": "https://www.postgresql.org/docs/18/mvcc-intro.html",
+        "publisher": "PostgreSQL Global Development Group",
+        "purpose": "primary source for MVCC snapshot and read/write lock-contention model",
+        "accessed_at": "2026-08-27"
+      },
+      {
+        "title": "PostgreSQL 18 — 13.2 Transaction Isolation",
+        "url": "https://www.postgresql.org/docs/18/transaction-iso.html",
+        "publisher": "PostgreSQL Global Development Group",
+        "purpose": "primary source for Read Committed, Repeatable Read, Serializable behavior and retry boundaries",
+        "accessed_at": "2026-08-27"
+      },
+      {
+        "title": "PostgreSQL 18 — 13.6 Caveats",
+        "url": "https://www.postgresql.org/docs/18/mvcc-caveats.html",
+        "publisher": "PostgreSQL Global Development Group",
+        "purpose": "official caveats for operations that fall outside the simplified MVCC visibility model",
+        "accessed_at": "2026-08-27"
+      }
+    ],
+    "tags": [
+      "postgresql",
+      "mvcc",
+      "database",
+      "concurrency",
+      "snapshots",
+      "transaction-isolation",
+      "serializable"
+    ],
+    "provenance": {
+      "source_linked": true,
+      "source_dates_recorded": true,
+      "full_transcript_stored": false,
+      "analysis_type": "direct official PostgreSQL 18 documentation analysis with explicitly labeled comparison to existing SQLite knowledge",
+      "reviewed_at": "2026-08-27"
+    }
+  },
+  "graph": {
+    "concepts": [
+      {
+        "id": "multiversion-concurrency-control",
+        "label": "Multiversion Concurrency Control (MVCC)",
+        "summary": "A database concurrency model that maintains multiple row versions so transactions can read a coherent visibility snapshot while concurrent writes continue.",
+        "domain": "database concurrency",
+        "coverage": "explained",
+        "insight_ids": [
+          "postgresql-mvcc-snapshot-isolation"
+        ],
+        "aliases": [
+          "MVCC",
+          "multiversion concurrency"
+        ],
+        "tags": [
+          "database",
+          "concurrency",
+          "versions",
+          "transactions"
+        ]
+      },
+      {
+        "id": "mvcc-snapshot",
+        "label": "MVCC snapshot",
+        "summary": "A visibility boundary that determines which committed row versions a PostgreSQL statement or transaction can see while other transactions continue to commit.",
+        "domain": "database concurrency",
+        "coverage": "explained",
+        "insight_ids": [
+          "postgresql-mvcc-snapshot-isolation"
+        ],
+        "aliases": [
+          "database snapshot",
+          "visibility snapshot"
+        ],
+        "tags": [
+          "database",
+          "snapshot",
+          "visibility",
+          "transactions"
+        ]
+      },
+      {
+        "id": "transaction-isolation-scope",
+        "label": "Transaction isolation scope",
+        "summary": "The rules that determine snapshot lifetime and allowed concurrency phenomena, such as statement-level Read Committed versus transaction-level Repeatable Read or Serializable behavior.",
+        "domain": "database concurrency",
+        "coverage": "explained",
+        "insight_ids": [
+          "postgresql-mvcc-snapshot-isolation"
+        ],
+        "aliases": [
+          "isolation snapshot scope"
+        ],
+        "tags": [
+          "database",
+          "isolation",
+          "snapshot",
+          "transactions"
+        ]
+      },
+      {
+        "id": "serialization-failure-retry",
+        "label": "Serialization failure and retry",
+        "summary": "A concurrency-control outcome where PostgreSQL aborts a transaction that cannot safely commit under the requested isolation guarantee and the application retries the whole transaction.",
+        "domain": "database concurrency",
+        "coverage": "explained",
+        "insight_ids": [
+          "postgresql-mvcc-snapshot-isolation"
+        ],
+        "aliases": [
+          "serialization retry",
+          "SQLSTATE 40001 retry"
+        ],
+        "tags": [
+          "database",
+          "serializable",
+          "retry",
+          "transactions"
+        ]
+      }
+    ],
+    "relations": [
+      {
+        "id": "rel-multiversion-concurrency-control-depends-on-mvcc-snapshot",
+        "from": "multiversion-concurrency-control",
+        "to": "mvcc-snapshot",
+        "type": "depends_on",
+        "rationale": "The multiversion model becomes useful to readers only through visibility rules that select a coherent set of row versions for the current statement or transaction.",
+        "evidence_insights": [
+          "postgresql-mvcc-snapshot-isolation"
+        ]
+      },
+      {
+        "id": "rel-mvcc-snapshot-depends-on-transaction-isolation-scope",
+        "from": "mvcc-snapshot",
+        "to": "transaction-isolation-scope",
+        "type": "depends_on",
+        "rationale": "The effective snapshot boundary depends on the requested isolation level: Read Committed refreshes per statement while stronger levels keep a transaction-wide view.",
+        "evidence_insights": [
+          "postgresql-mvcc-snapshot-isolation"
+        ]
+      },
+      {
+        "id": "rel-transaction-isolation-scope-related-to-serialization-failure-retry",
+        "from": "transaction-isolation-scope",
+        "to": "serialization-failure-retry",
+        "type": "related_to",
+        "rationale": "Stronger PostgreSQL isolation guarantees can convert dangerous concurrent interactions into transaction aborts that the application must retry.",
+        "evidence_insights": [
+          "postgresql-mvcc-snapshot-isolation"
+        ]
+      }
+    ]
+  }
+}

--- a/data/case-patches/postgresql-mvcc.json
+++ b/data/case-patches/postgresql-mvcc.json
@@ -89,7 +89,7 @@
     "visual_plan": {
       "dominant": {
         "type": "comparison",
-        "title": "One MVCC model, three snapshot contracts",
+        "title": "One MVCC model, two snapshot scopes",
         "nodes": [
           {
             "label": "READ COMMITTED",
@@ -97,14 +97,9 @@
             "text": "Each statement sees commits visible when that statement begins, so later statements in the same transaction can observe newer committed data."
           },
           {
-            "label": "REPEATABLE READ",
+            "label": "REPEATABLE READ / SERIALIZABLE",
             "title": "Stable transaction snapshot",
-            "text": "The transaction keeps one database view; conflicting updates committed after that view can force the transaction to abort and retry."
-          },
-          {
-            "label": "SERIALIZABLE",
-            "title": "Stable view + dependency checks",
-            "text": "PostgreSQL also tracks dangerous read/write dependencies and rejects a transaction when the concurrent result cannot match any serial order."
+            "text": "Both keep a transaction-wide view. Serializable additionally tracks dangerous read/write dependencies and can reject a transaction when the outcome cannot match a serial order."
           }
         ]
       },
@@ -118,7 +113,7 @@
       ],
       "image": {
         "needed": false,
-        "reason": "The main learning is how snapshot lifetime and failure behavior change across isolation levels; a comparison is more precise than a decorative or physical illustration."
+        "reason": "The main learning is the difference between statement-scoped and transaction-scoped visibility; Serializable's additional dependency checks are clearer as a boundary inside the stable-view side than as a third visual category."
       }
     },
     "concepts": [

--- a/data/research-bundles/intake-2026-08-27-postgresql-mvcc-intro-html.json
+++ b/data/research-bundles/intake-2026-08-27-postgresql-mvcc-intro-html.json
@@ -5,53 +5,164 @@
   "source": {
     "type": "documentation",
     "canonical_url": "https://www.postgresql.org/docs/current/mvcc-intro.html",
-    "title": null,
-    "creators": [],
-    "publisher": null,
+    "title": "PostgreSQL 18: Multiversion Concurrency Control",
+    "creators": [
+      "PostgreSQL Global Development Group"
+    ],
+    "publisher": "PostgreSQL Global Development Group",
     "published_at": null,
     "event_date": null,
-    "version": null,
-    "language": null,
+    "version": "18.6 / PostgreSQL 18 documentation",
+    "language": "en",
     "duration": null,
-    "date_note": null
+    "date_note": "Living documentation. The current manual resolves to PostgreSQL 18; the PostgreSQL site reports 18.6 released on 2026-08-13. Analyzed as accessed on 2026-08-27."
   },
   "inspection": {
-    "method": "not inspected",
-    "full_content_used_ephemerally": false,
+    "method": "Direct inspection of the official PostgreSQL 18 MVCC introduction, transaction-isolation sections for Read Committed, Repeatable Read and Serializable, plus MVCC caveats.",
+    "full_content_used_ephemerally": true,
     "full_content_committed": false,
-    "confidence": "metadata_only",
+    "confidence": "direct",
     "gaps": [
-      "Source content has not been mapped yet."
+      "Tuple-version storage internals, VACUUM/dead-tuple lifecycle and predicate-lock implementation details are outside this first mental model."
     ]
   },
   "prior_knowledge": {
     "captured_at": "2026-08-27",
     "query": "Understand MVCC as a concurrency model: snapshots, read/write non-blocking behavior, isolation boundaries, and what the model does not eliminate.",
-    "matches": [],
+    "matches": [
+      {
+        "concept_id": "wal-reader-snapshot",
+        "label": "WAL reader snapshot",
+        "coverage": "explained",
+        "evidence_insights": [
+          {
+            "id": "sqlite-write-ahead-log-checkpointing",
+            "status": "review",
+            "title": "SQLite WAL: commit by append, consolidate by checkpoint"
+          }
+        ],
+        "relationship_to_source": "not_relevant"
+      }
+    ],
     "classification_required": true
   },
   "content_map": {
-    "problem": null,
-    "thesis": null,
-    "sections": [],
-    "concepts": [],
-    "mechanisms": [],
-    "tools": [],
-    "examples": [],
-    "claims": [],
-    "evidence": [],
-    "assumptions": [],
-    "limitations": [],
-    "open_questions": []
+    "problem": "Concurrent sessions need consistent views of data without forcing every reader and writer to serialize behind the same locks.",
+    "thesis": "PostgreSQL uses multiversion concurrency control so statements read a visibility snapshot of row versions; the isolation level determines how long that snapshot remains stable and which anomalies are prevented, while stronger guarantees can reject a transaction and require retry.",
+    "sections": [
+      "13.1 Introduction",
+      "13.2 Transaction Isolation",
+      "13.2.1 Read Committed",
+      "13.2.2 Repeatable Read",
+      "13.2.3 Serializable",
+      "13.6 Caveats"
+    ],
+    "concepts": [
+      "Multiversion Concurrency Control (MVCC)",
+      "MVCC snapshot",
+      "statement versus transaction snapshot scope",
+      "transaction isolation",
+      "serialization failure and retry"
+    ],
+    "mechanisms": [
+      "select visible committed row versions through a snapshot rather than reading every newest physical change",
+      "refresh the snapshot per statement in Read Committed",
+      "hold a stable transaction snapshot in Repeatable Read",
+      "wait or fail when concurrent writers conflict on the same target rows",
+      "monitor read/write dependencies in Serializable and abort transactions that would produce a non-serializable outcome"
+    ],
+    "tools": [
+      "SET TRANSACTION",
+      "pg_locks"
+    ],
+    "examples": [
+      "two SELECT statements in one Read Committed transaction can observe different committed states",
+      "a Repeatable Read transaction keeps one database view but may fail if it tries to update a row changed after its snapshot",
+      "Serializable can abort one of two transactions whose combined writes cannot match any serial execution"
+    ],
+    "claims": [
+      "Each SQL statement sees a snapshot of the database rather than an inconsistent mixture of concurrent updates.",
+      "MVCC lets ordinary reads and writes proceed without conflicting read/write locks, but it does not eliminate write/write waits or explicit locking.",
+      "Read Committed uses a fresh snapshot for each statement, while Repeatable Read holds a stable snapshot for the transaction.",
+      "Serializable adds dependency monitoring and can abort a transaction, so applications must be prepared to retry the whole transaction."
+    ],
+    "evidence": [
+      "PostgreSQL 18 §13.1 defines MVCC snapshots and the read-versus-write nonblocking advantage.",
+      "PostgreSQL 18 §13.2.1 states that Read Committed SELECT sees a snapshot as of query start and successive SELECTs can see newer commits.",
+      "PostgreSQL 18 §13.2.2 states that Repeatable Read sees the snapshot from the start of the transaction and can raise serialization failure on conflicting updates.",
+      "PostgreSQL 18 §13.2.3 describes Serializable Snapshot Isolation dependency monitoring and transaction retry."
+    ],
+    "assumptions": [
+      "Applications choose an isolation level appropriate to the consistency rules they need.",
+      "A stable snapshot is a visibility rule over committed versions, not a copy of the entire database.",
+      "Applications that use retrying isolation levels can safely restart the whole database transaction."
+    ],
+    "limitations": [
+      "MVCC minimizes read/write lock contention but does not make all database operations nonblocking.",
+      "Repeatable Read can still allow serialization anomalies even though it provides a stable snapshot.",
+      "Serializable can abort transactions and shifts part of correctness to a robust retry path.",
+      "Some DDL and sequence behaviors have transaction-visibility caveats outside the simple snapshot model."
+    ],
+    "open_questions": [
+      "How PostgreSQL stores tuple versions and reclaims obsolete versions through VACUUM.",
+      "How to choose between Serializable, explicit row/table locks and application-level coordination for a specific business invariant."
+    ]
   },
   "selection": {
     "requested_focus": "Understand MVCC as a concurrency model: snapshots, read/write non-blocking behavior, isolation boundaries, and what the model does not eliminate.",
-    "coherent_core": [],
-    "prerequisites": [],
-    "drop_notes": [],
-    "connections": []
+    "coherent_core": [
+      "MVCC separates the reader's visible snapshot from concurrent physical updates",
+      "Read Committed and Repeatable Read differ mainly in snapshot lifetime",
+      "same-row writers can still wait or conflict",
+      "Serializable protects serial outcomes by detecting dependencies and rejecting transactions",
+      "transaction retry is part of the consistency contract, not an exceptional afterthought"
+    ],
+    "prerequisites": [
+      "visibility snapshot",
+      "transaction isolation"
+    ],
+    "drop_notes": [
+      "Do not expand into VACUUM, tuple headers or index internals before the snapshot/isolation model is clear.",
+      "Do not merge PostgreSQL MVCC snapshots with SQLite WAL reader end marks: both give stable visibility but use different storage and concurrency mechanisms."
+    ],
+    "connections": [
+      "SQLite WAL reader snapshots are a useful contrast but not the same concept as PostgreSQL MVCC visibility snapshots.",
+      "Database transaction retry is not a substitute for idempotent receiver semantics around external side effects."
+    ]
   },
-  "verification_candidates": [],
-  "source_locators": [],
+  "verification_candidates": [
+    {
+      "question": "How do PostgreSQL tuple xmin/xmax visibility rules implement the snapshot model internally?",
+      "reason": "Useful implementation depth after the concurrency mental model is learned.",
+      "priority": "low"
+    },
+    {
+      "question": "Which workload patterns make Serializable Snapshot Isolation preferable to explicit locking?",
+      "reason": "Practical decision guidance requires workload-specific evidence beyond this conceptual source.",
+      "priority": "medium"
+    }
+  ],
+  "source_locators": [
+    {
+      "label": "MVCC snapshot and nonblocking reads/writes",
+      "locator": "PostgreSQL 18 §13.1 Introduction"
+    },
+    {
+      "label": "Read Committed snapshot scope",
+      "locator": "PostgreSQL 18 §13.2.1 Read Committed"
+    },
+    {
+      "label": "Repeatable Read snapshot scope",
+      "locator": "PostgreSQL 18 §13.2.2 Repeatable Read"
+    },
+    {
+      "label": "Serializable dependency detection and retry",
+      "locator": "PostgreSQL 18 §13.2.3 Serializable"
+    },
+    {
+      "label": "MVCC caveats",
+      "locator": "PostgreSQL 18 §13.6 Caveats"
+    }
+  ],
   "created_at": "2026-08-27"
 }


### PR DESCRIPTION
Dogfood cohort case for #40.

Adds one atomic research bundle + review case patch + companion review contract for the official PostgreSQL 18 MVCC/isolation documentation.

Key boundary tested: the new PostgreSQL MVCC snapshot is **not** merged with the existing SQLite WAL reader snapshot. The bundle refreshes prior knowledge at actual analysis time and classifies the lexical/semantic overlap as `not_relevant` for concept identity.

No publication transition is included; this remains review-only.