### PR TITLE
research: add Docker build-cache cohort case

### DIFF
--- a/data/case-contracts/docker-build-cache.json
+++ b/data/case-contracts/docker-build-cache.json
@@ -1,0 +1,50 @@
+{
+  "contract_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-docs-optimize",
+  "insight_id": "docker-cache-dependency-invalidation",
+  "knowledge_delta": {
+    "insight_id": "docker-cache-dependency-invalidation",
+    "summary": "Docker build caching adds a new build-systems domain to the graph. Prior retrieval correctly found no close concepts, so the case introduces cache dependency boundaries and invalidation cascades without merging them into workflow checkpoints, database checkpoints or agent memory.",
+    "items": [
+      {"relationship": "new", "concept_id": "build-cache-dependency-boundary", "label": "Build-cache dependency boundary", "source_basis": "Docker reuses a layer only while its instruction and dependent files remain unchanged, making cache reuse depend on explicit inputs.", "prior_basis": "The graph has persistence and checkpoint concepts in other domains, but no concept for build-result reuse controlled by instruction/input stability.", "interpretation": "Layer ordering and build-context design are best understood as editing the dependency boundary around expensive work.", "evidence_insights": []},
+      {"relationship": "new", "concept_id": "cache-invalidation-cascade", "label": "Cache invalidation cascade", "source_basis": "Docker documentation states that a changed step causes following steps to rebuild, so frequent changes early in a Dockerfile amplify downstream work.", "prior_basis": "No current concept captures downstream build-cost fan-out caused by an upstream cache miss.", "interpretation": "The optimization target is not maximal caching in general; it is minimizing unnecessary invalidation fan-out from volatile inputs.", "evidence_insights": []},
+      {"relationship": "new", "concept_id": "persistent-build-cache", "label": "Persistent build cache", "source_basis": "Cache mounts retain package caches across layer rebuilds, and external caches allow cache reuse across different builders/environments.", "prior_basis": "Existing durable-state concepts have different semantics and should not be reused merely because data persists across runs.", "interpretation": "Persistent build cache is a cost-reduction mechanism for recomputation/downloads, not authoritative workflow or business state.", "evidence_insights": []}
+    ],
+    "suppressed_prior_matches": []
+  },
+  "claim_evidence": {
+    "insight_id": "docker-cache-dependency-invalidation",
+    "claims": [
+      {"id": "docker-cache-reuse-rule", "text": "Docker reuses a build layer when the instruction and files it depends on have not changed since the previous build.", "impact": "high", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-docker-build-cache-2026", "url": "https://docs.docker.com/build/cache/optimize", "locator": "Optimize cache usage → cache reuse rule"}], "note": null},
+      {"id": "docker-layer-order-cascade", "text": "Because a changed step causes following steps to rebuild, stable expensive steps should generally precede frequently changing source steps when their true dependencies allow it.", "impact": "high", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-docker-build-cache-2026", "url": "https://docs.docker.com/build/cache/optimize", "locator": "Order your layers → change causes following steps to rebuild"}], "note": null},
+      {"id": "docker-cache-mount-behavior", "text": "BuildKit cache mounts persist reusable package cache data so a rebuilt layer can reuse unchanged packages instead of downloading everything again.", "impact": "medium", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-docker-build-cache-2026", "url": "https://docs.docker.com/build/cache/optimize", "locator": "Use cache mounts → persistent cache across builds"}], "note": null},
+      {"id": "docker-external-cache-ci", "text": "External build caches allow cache data to be reused across builders and are particularly useful when CI builders are ephemeral.", "impact": "medium", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-docker-build-cache-2026", "url": "https://docs.docker.com/build/cache/optimize", "locator": "Use an external cache → reuse across builders and CI"}], "note": null}
+    ]
+  },
+  "prerequisite_map": {
+    "insight_id": "docker-cache-dependency-invalidation",
+    "summary": "The cache model requires three ideas: what belongs to a cache dependency boundary, how invalidation propagates downstream, and how persistent build caches reduce rebuild cost without becoming authoritative state.",
+    "items": [
+      {"id": "docker-prereq-cache-boundary", "label": "Build-cache dependency boundary", "concept_id": "build-cache-dependency-boundary", "priority": "must_know_now", "prior_coverage": "absent", "state": "explained_here", "reason": "This explains why a file change affects some cached work and not other work.", "resolution": {"kind": "explained_here", "insight_id": "docker-cache-dependency-invalidation", "target": null}},
+      {"id": "docker-prereq-invalidation", "label": "Cache invalidation cascade", "concept_id": "cache-invalidation-cascade", "priority": "must_know_now", "prior_coverage": "absent", "state": "explained_here", "reason": "The cascade explains why an upstream volatile dependency multiplies downstream build cost.", "resolution": {"kind": "explained_here", "insight_id": "docker-cache-dependency-invalidation", "target": null}},
+      {"id": "docker-prereq-persistent-cache", "label": "Persistent build cache", "concept_id": "persistent-build-cache", "priority": "learn_next", "prior_coverage": "absent", "state": "explained_here", "reason": "Cache mounts and external caches solve reuse beyond exact layer hits and clarify the difference between cache and durable application state.", "resolution": {"kind": "explained_here", "insight_id": "docker-cache-dependency-invalidation", "target": null}}
+    ]
+  },
+  "learning_prompt": {
+    "insight_id": "docker-cache-dependency-invalidation",
+    "retention_prompt": "Without looking back, explain Docker build caching as a dependency problem: what makes a layer reusable, why can one early change cascade into expensive downstream work, and how do context, mounts and external caches change the dependency/reuse boundary?",
+    "answer_key": {"problem_from": "whole_source_map.problem", "mechanism_from": "whole_source_map.thesis", "anchor_concept_ids": ["build-cache-dependency-boundary", "cache-invalidation-cascade", "persistent-build-cache"], "boundary_limitation_index": 0},
+    "transfer_prompt": {"prompt": "A Dockerfile copies an entire repository before installing dependencies, and a one-line source change triggers a ten-minute dependency install. Redesign the dependency boundary and explain when a cache mount or external cache would solve a different part of the problem.", "expected_concept_ids": ["build-cache-dependency-boundary", "cache-invalidation-cascade", "persistent-build-cache"]}
+  },
+  "source_decision": {
+    "insight_id": "docker-cache-dependency-invalidation",
+    "decision": "explainer_is_enough",
+    "rationale": "For the requested mental model, the explainer preserves the source's complete dependency logic: exact layer reuse, invalidation cascade, context control and persistent/external caches. The original guide becomes useful when implementing Dockerfile syntax for a concrete package manager or CI environment, but additional reading is not required to reconstruct the central model.",
+    "novelty": {"level": "high", "reason": "The source introduces a build-cache dependency and invalidation model that has no close concept in the current knowledge graph."},
+    "source_quality": {"level": "high", "reason": "The source is official Docker documentation and directly explains the cache mechanisms retained in the explainer."},
+    "relevance": {"level": "medium", "reason": "The model is broadly useful for engineering/build workflows even though it is not central to every source-to-understanding or enterprise-systems task."},
+    "practical_leverage": {"level": "high", "reason": "The dependency model can immediately reduce build time by changing Dockerfile structure or cache boundaries in real projects."},
+    "compression_loss": {"level": "low", "reason": "The omitted material is mainly command/package-manager detail; the source's central causal model and important boundaries are retained."},
+    "selected_parts": []
+  }
+}

--- a/data/case-patches/docker-build-cache.json
+++ b/data/case-patches/docker-build-cache.json
@@ -1,0 +1,117 @@
+{
+  "patch_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-docs-optimize",
+  "intake_status": "review",
+  "updated_at": "2026-08-27",
+  "graph_version": "0.4.0",
+  "source": {
+    "id": "src-docker-build-cache-2026",
+    "type": "documentation",
+    "title": "Optimize cache usage in builds",
+    "canonical_url": "https://docs.docker.com/build/cache/optimize",
+    "creators": [],
+    "publisher": "Docker Inc.",
+    "event": null,
+    "published_at": null,
+    "event_date": null,
+    "captured_at": "2026-08-27",
+    "analyzed_at": "2026-08-27",
+    "date_note": "Living official Docker documentation inspected on 2026-08-27; no single publication date is asserted.",
+    "verification": [],
+    "derived_records": ["docker-cache-dependency-invalidation"]
+  },
+  "insight": {
+    "id": "docker-cache-dependency-invalidation",
+    "source_id": "src-docker-build-cache-2026",
+    "slug": "docker-cache-dependency-invalidation",
+    "status": "review",
+    "title": "Docker build cache: invalidation is a dependency-graph problem",
+    "one_liner": "Fast Docker builds come from drawing better dependency boundaries: keep stable expensive inputs early, volatile inputs late, and reusable/transient data out of ordinary layer invalidation when possible.",
+    "why_this_matters": "Build caching is often treated as a list of tricks. The stronger mental model is dependency propagation: each layer depends on an instruction and inputs, and an early invalidation can fan out into expensive downstream rebuilds. Once seen this way, layer order, context size and mounts become different ways to control the same dependency boundary.",
+    "whole_source_map": {
+      "problem": "Small or irrelevant input changes can invalidate a cached layer and amplify rebuild cost through later expensive Dockerfile steps.",
+      "thesis": "Design cache boundaries around dependency stability: isolate stable expensive work, minimize volatile inputs, and use build mounts/external caches when reusable data should outlive ordinary layer rebuilds.",
+      "core_topics": ["layer cache reuse", "invalidation cascade", "layer ordering", "build context", "bind mounts", "cache mounts", "external cache"]
+    },
+    "derived_model": {
+      "problem": "A build becomes slow when volatile inputs sit upstream of expensive steps or unnecessary files participate in cache dependencies.",
+      "mechanism": "Reorder layers by stability, shrink build context, keep transient inputs out of image layers with bind mounts, and separate package/external caches from exact layer reuse.",
+      "result": "Small source changes invalidate less expensive work, while reusable dependencies and CI cache state survive where semantically safe."
+    },
+    "coherence_review": {
+      "central_chain": [
+        "A cached layer is reusable only while the instruction and its dependent inputs still match.",
+        "Invalidating one layer forces following steps to rebuild, creating a downstream cost cascade.",
+        "Stable expensive dependencies should therefore be separated from frequently changing source inputs.",
+        "Build context and bind mounts control which files enter persistent cache/layer boundaries.",
+        "Cache mounts and external caches preserve reusable data even when exact layer reuse is unavailable or the builder changes."
+      ],
+      "prerequisites_complete": true,
+      "source_vs_enrichment_clear": true,
+      "open_gaps": [
+        "This mental model does not enumerate BuildKit cache-key behavior for every Dockerfile instruction.",
+        "A real optimization still needs build-time measurement to identify which invalidation paths dominate cost."
+      ],
+      "scores": {"coherence": 5, "prerequisite_completeness": 5, "evidence_confidence": 5, "practical_leverage": 5}
+    },
+    "visual_plan": {
+      "dominant": {
+        "type": "causal_chain",
+        "title": "One volatile input can multiply downstream rebuild cost",
+        "nodes": [
+          {"label": "01 · Change", "title": "Input crosses a cache boundary", "text": "An instruction or file dependency changes, so that cached layer can no longer be reused."},
+          {"label": "02 · Cascade", "title": "Later steps rebuild", "text": "Every downstream layer must execute again even when much of its logical work is unchanged."},
+          {"label": "03 · Design", "title": "Reduce dependency fan-out", "text": "Reorder stable work, shrink context and move reusable/transient data into appropriate mounts or external caches."}
+        ]
+      },
+      "supporting": ["sequence", "comparison", "concept_grid", "tool_map", "examples", "limitations", "action_map", "source_map"],
+      "image": {"needed": false, "reason": "The idea is a dependency cascade, which a simple causal diagram communicates better than an illustration."}
+    },
+    "concepts": [
+      {"name": "Build-cache dependency boundary", "depth": "learn", "why_needed": "Cache reuse is determined by an instruction and its dependent inputs, so the useful unit is a dependency boundary rather than a vague notion of previous build output."},
+      {"name": "Invalidation cascade", "depth": "learn", "why_needed": "A changed upstream layer forces downstream work to rebuild, explaining why layer ordering matters economically."},
+      {"name": "Persistent build cache", "depth": "know", "why_needed": "Cache mounts and external caches preserve reusable state outside exact image-layer reuse and therefore solve a different cache problem."}
+    ],
+    "tool_map": [
+      {"name": ".dockerignore", "category": "build-context control", "why_explore": "Keeps irrelevant files out of the build context so they cannot create avoidable transfer and invalidation pressure.", "url": "https://docs.docker.com/build/cache/optimize/#keep-the-context-small", "relationship": "Source-native Docker mechanism.", "status": "use_now"},
+      {"name": "BuildKit cache mounts", "category": "persistent build dependency cache", "why_explore": "Lets package-manager caches survive layer rebuilds so only new/changed dependencies need downloading.", "url": "https://docs.docker.com/build/cache/optimize/#use-cache-mounts", "relationship": "Source-native Docker/BuildKit mechanism.", "status": "try"},
+      {"name": "buildx external cache", "category": "cross-builder cache", "why_explore": "Useful when CI builders are ephemeral and cache should be shared across runs/environments.", "url": "https://docs.docker.com/build/cache/optimize/#use-an-external-cache", "relationship": "Source-native Docker/BuildKit mechanism.", "status": "watch"}
+    ],
+    "examples": [
+      {"domain": "Node.js image", "scenario": "COPY . . occurs before npm install, so editing one source file invalidates dependency installation.", "question": "Can package manifests be copied and dependencies installed before volatile application source is copied?"},
+      {"domain": "large build context", "scenario": "Temporary files, logs or node_modules are sent to the builder although they are not real inputs.", "question": "Can .dockerignore or a bind mount remove these files from persistent cache dependencies?"},
+      {"domain": "CI", "scenario": "Every build runs on a fresh builder with no local cache.", "question": "Would a remote cache reduce repeated compilation/download cost enough to justify the extra cache lifecycle?"}
+    ],
+    "limitations": [
+      "A cache optimization is valid only if the cache boundary still includes every input that semantically affects the result.",
+      "Layer reordering can create stale or confusing results if hidden dependencies are omitted merely to preserve cache hits.",
+      "External caches add access-control, storage and retention concerns and may be unnecessary for small local builds.",
+      "Package-manager cache mounts have tool-specific sharing and locking requirements."
+    ],
+    "action_map": {
+      "use_now": ["Inspect Dockerfiles as dependency graphs: identify which volatile inputs currently invalidate expensive downstream steps."],
+      "try": ["Split dependency manifests from application source in one slow Dockerfile and measure the second build after a source-only change.", "Add a cache mount to one package-install step and compare bytes/time on a layer rebuild."],
+      "learn": ["Docker build context", "layer cache invalidation", "BuildKit bind mounts", "cache mounts", "external cache exporters/importers"],
+      "build": ["A small build-cache diagnostic that explains which dependency boundary caused an expensive rebuild."],
+      "watch": ["Whether CI build duration is high enough to justify a remote external cache."],
+      "ignore_for_now": ["Adding remote cache infrastructure before measuring repeated build cost."]
+    },
+    "connections": ["General dependency-graph design: volatile inputs should have limited fan-out into expensive recomputation.", "Docker build cache is intentionally not merged with workflow checkpoints, database WAL/checkpoints or agent memory; the shared word 'cache/state' does not imply the same mechanism."],
+    "supporting_sources": [
+      {"title": "Optimize cache usage in builds", "url": "https://docs.docker.com/build/cache/optimize", "publisher": "Docker Inc.", "purpose": "primary source for layer ordering, context, bind/cache mounts and external cache", "accessed_at": "2026-08-27"}
+    ],
+    "tags": ["docker", "buildkit", "cache", "build-performance", "dependency-graph", "ci"],
+    "provenance": {"source_linked": true, "source_dates_recorded": true, "full_transcript_stored": false, "analysis_type": "direct official-documentation analysis with dependency-boundary synthesis", "reviewed_at": "2026-08-27"}
+  },
+  "graph": {
+    "concepts": [
+      {"id": "build-cache-dependency-boundary", "label": "Build-cache dependency boundary", "summary": "The set of instruction and input dependencies whose stability determines whether a build result can be reused from cache.", "domain": "build systems", "coverage": "explained", "insight_ids": ["docker-cache-dependency-invalidation"], "aliases": ["cache dependency boundary"], "tags": ["build", "cache", "dependencies"]},
+      {"id": "cache-invalidation-cascade", "label": "Cache invalidation cascade", "summary": "Downstream rebuild work triggered when an upstream build step or dependency changes and later cached steps can no longer be reused.", "domain": "build systems", "coverage": "explained", "insight_ids": ["docker-cache-dependency-invalidation"], "aliases": ["downstream cache invalidation"], "tags": ["build", "cache", "invalidation", "cost"]},
+      {"id": "persistent-build-cache", "label": "Persistent build cache", "summary": "Reusable build-time data kept outside exact image-layer cache hits, such as package cache mounts or cache exported for use by other builders.", "domain": "build systems", "coverage": "explained", "insight_ids": ["docker-cache-dependency-invalidation"], "aliases": ["build cache mount", "external build cache"], "tags": ["buildkit", "cache", "ci", "dependencies"]}
+    ],
+    "relations": [
+      {"id": "rel-build-cache-boundary-enables-invalidation-cascade", "from": "build-cache-dependency-boundary", "to": "cache-invalidation-cascade", "type": "enables", "rationale": "When an input inside a cache boundary changes, that step becomes a new execution point and invalidates downstream layer reuse.", "evidence_insights": ["docker-cache-dependency-invalidation"]},
+      {"id": "rel-persistent-build-cache-related-to-invalidation-cascade", "from": "persistent-build-cache", "to": "cache-invalidation-cascade", "type": "related_to", "rationale": "Persistent cache mounts or external caches reduce the cost of required rebuilds even when an exact layer cache hit is lost.", "evidence_insights": ["docker-cache-dependency-invalidation"]}
+    ]
+  }
+}

--- a/data/research-bundles/intake-2026-08-27-docs-optimize.json
+++ b/data/research-bundles/intake-2026-08-27-docs-optimize.json
@@ -1,27 +1,28 @@
 {
   "bundle_version": "1.1.0",
   "intake_id": "intake-2026-08-27-docs-optimize",
-  "source_id": null,
+  "source_id": "src-docker-build-cache-2026",
   "source": {
     "type": "documentation",
     "canonical_url": "https://docs.docker.com/build/cache/optimize",
-    "title": null,
+    "title": "Optimize cache usage in builds",
     "creators": [],
-    "publisher": null,
+    "publisher": "Docker Inc.",
     "published_at": null,
     "event_date": null,
     "version": null,
-    "language": null,
+    "language": "en",
     "duration": null,
-    "date_note": null
+    "date_note": "Living official Docker documentation inspected on 2026-08-27; no single publication date is asserted."
   },
   "inspection": {
-    "method": "not inspected",
-    "full_content_used_ephemerally": false,
+    "method": "Direct inspection of the official Docker build-cache optimization guide, including layer ordering, build context, bind/cache mounts and external caches.",
+    "full_content_used_ephemerally": true,
     "full_content_committed": false,
-    "confidence": "metadata_only",
+    "confidence": "direct",
     "gaps": [
-      "Source content has not been mapped yet."
+      "This case explains cache-dependency structure rather than Docker/BuildKit cache-key implementation details for every instruction type.",
+      "BuildKit features and cache exporters can evolve; command-level implementation details should be checked against current Docker docs before automation."
     ]
   },
   "prior_knowledge": {
@@ -31,27 +32,74 @@
     "classification_required": true
   },
   "content_map": {
-    "problem": null,
-    "thesis": null,
-    "sections": [],
-    "concepts": [],
-    "mechanisms": [],
-    "tools": [],
-    "examples": [],
-    "claims": [],
-    "evidence": [],
-    "assumptions": [],
-    "limitations": [],
-    "open_questions": []
+    "problem": "A small file or instruction change can invalidate a Docker build layer and force later expensive steps to rebuild even when their real logical inputs did not change.",
+    "thesis": "Treat build caching as dependency design: isolate stable expensive inputs early, keep volatile inputs late, minimize what enters the build context/cache key, and use specialized mounts or external caches for reusable data that should survive layer rebuilds.",
+    "sections": ["Cache reuse rule", "Order layers", "Keep build context small", "Bind mounts", "Cache mounts", "External cache"],
+    "concepts": ["cache dependency boundary", "invalidation cascade", "build context", "bind mount during build", "cache mount", "external build cache"],
+    "mechanisms": [
+      "A cached layer can be reused when its instruction and dependent files have not changed.",
+      "When a changed step invalidates a layer, following steps rebuild, so frequently changing inputs placed early amplify rebuild cost.",
+      "Reducing build context and using bind mounts can keep irrelevant or transient inputs out of persistent image/cache layers.",
+      "Cache mounts persist package/download caches independently so a rebuilt layer can still reuse unchanged packages.",
+      "External caches move cache reuse beyond one builder and are especially useful for ephemeral CI builders."
+    ],
+    "tools": ["Dockerfile", ".dockerignore", "BuildKit bind mounts", "BuildKit cache mounts", "buildx cache-from/cache-to"],
+    "examples": [
+      "Copy package manifests and install dependencies before copying frequently changed application source files.",
+      "Exclude node_modules, temp files and build artifacts from context when they are not build inputs.",
+      "Mount a package-manager cache so a layer rebuild downloads only new or changed packages.",
+      "Export cache to a registry so ephemeral CI builders can reuse previous build work."
+    ],
+    "claims": [
+      "Docker reuses a cached layer when the instruction and files it depends on have not changed.",
+      "A changed step causes later steps to rebuild, so expensive stable steps should generally precede frequently changing steps.",
+      "A smaller build context reduces transferred data and the chance that irrelevant file changes invalidate cache.",
+      "Cache mounts persist reusable package caches across layer rebuilds, while external caches allow reuse across builders/environments."
+    ],
+    "evidence": ["Official Docker build-cache optimization documentation inspected on 2026-08-27."],
+    "assumptions": [
+      "Build time is meaningfully affected by repeated dependency installation, compilation or artifact generation.",
+      "The Dockerfile can separate stable dependency inputs from frequently changing application inputs.",
+      "Cache reuse is desirable and does not conflict with intentional rebuild/freshness requirements."
+    ],
+    "limitations": [
+      "Cache optimization is not a reason to hide dependencies: every reused result must still be valid for the inputs that semantically affect it.",
+      "Moving steps earlier only helps when their true dependencies are stable; incorrect dependency boundaries can create stale or surprising build behavior.",
+      "External caches add storage, access and lifecycle concerns and may not be worth operating for small local builds.",
+      "Cache mounts have tool-specific concurrency and locking requirements; package-manager behavior must be respected."
+    ],
+    "open_questions": [
+      "Which expensive project steps currently rebuild because volatile files enter their dependency boundary too early?",
+      "Would an external cache save enough CI time to justify its storage and access complexity?"
+    ]
   },
   "selection": {
     "requested_focus": "Understand cache invalidation as a dependency problem: layer ordering, build context, mounts and why small input changes can amplify build cost.",
-    "coherent_core": [],
-    "prerequisites": [],
-    "drop_notes": [],
-    "connections": []
+    "coherent_core": [
+      "A Docker layer cache is dependency-sensitive, not merely chronological reuse.",
+      "Invalidating an early layer can cascade rebuild cost through later steps.",
+      "Layer order and context size determine which changes enter expensive cache boundaries.",
+      "Bind/cache mounts and external cache separate reusable/transient data from ordinary image-layer caching."
+    ],
+    "prerequisites": ["Dockerfile layers", "build context", "dependency invalidation", "difference between image layers and build-time mounts"],
+    "drop_notes": [
+      "Individual package-manager cache syntax is example-level detail rather than the central model.",
+      "OCI registry configuration and CI-provider specifics are deferred until external cache is actually needed.",
+      "General Docker image optimization outside build caching is out of scope."
+    ],
+    "connections": [
+      "The generalizable pattern is dependency-boundary design: reduce accidental fan-out from volatile inputs to expensive downstream work.",
+      "No existing graph concept was close enough to reuse; build-cache state is intentionally not conflated with workflow checkpoints or database WAL/checkpoints."
+    ]
   },
-  "verification_candidates": [],
-  "source_locators": [],
+  "verification_candidates": [
+    {"question": "Which project build steps dominate rebuild time and what exact files invalidate them today?", "reason": "The source provides the design model; measuring a real build is needed before choosing optimizations.", "priority": "medium"}
+  ],
+  "source_locators": [
+    {"label": "Cache reuse and layer ordering", "locator": "https://docs.docker.com/build/cache/optimize/#order-your-layers"},
+    {"label": "Build context", "locator": "https://docs.docker.com/build/cache/optimize/#keep-the-context-small"},
+    {"label": "Cache mounts", "locator": "https://docs.docker.com/build/cache/optimize/#use-cache-mounts"},
+    {"label": "External cache", "locator": "https://docs.docker.com/build/cache/optimize/#use-an-external-cache"}
+  ],
   "created_at": "2026-08-27"
 }


### PR DESCRIPTION
Dogfood cohort case for #40 and source issue #58.

Adds a review-only Docker documentation case that models build caching as dependency-boundary design rather than a list of optimization tricks.

Key tests:
- prior retrieval correctly returns no close concepts; build cache is not conflated with workflow checkpoints, WAL/checkpoints or agent memory;
- introduces dependency boundary, invalidation cascade and persistent build cache as a coherent new cluster;
- Source Decision intentionally uses `explainer_is_enough` to broaden calibration beyond repeated skim recommendations.

Includes updated research bundle, atomic case patch and all companion contracts. No publication transition.