### PR TITLE
research: add MapReduce runtime-abstraction cohort case

### DIFF
--- a/data/case-contracts/mapreduce.json
+++ b/data/case-contracts/mapreduce.json
@@ -1,0 +1,56 @@
+{
+  "contract_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-research-mapreduce-simplified-data-processing-on-large-cl",
+  "insight_id": "mapreduce-runtime-abstraction-boundary",
+  "knowledge_delta": {
+    "insight_id": "mapreduce-runtime-abstraction-boundary",
+    "summary": "MapReduce adds a new abstraction-ownership model: a restricted user computation interface enables the runtime to own distribution, locality and task recovery. Existing workflow/durable-execution matches are suppressed because their persisted unit and semantics differ.",
+    "items": [
+      {"relationship":"new","concept_id":"restricted-programming-model","label":"Restricted programming model","source_basis":"The paper restricts user computation to Map and Reduce functions over key/value data.","prior_basis":"The graph contains domain-specific workflow and agent abstractions but no general concept for deliberately restricting a programming interface so the runtime can infer distributed execution.","interpretation":"The restriction is not merely API simplicity; it is what creates room for automatic parallelization and fault tolerance.","evidence_insights":[]},
+      {"relationship":"new","concept_id":"runtime-managed-distribution","label":"Runtime-managed distribution","source_basis":"The runtime handles input partitioning, scheduling, communication and intermediate-data movement.","prior_basis":"Existing orchestration concepts model other execution systems, not the MapReduce boundary that removes cluster mechanics from batch transformation code.","interpretation":"Distribution becomes a framework responsibility rather than application boilerplate.","evidence_insights":[]},
+      {"relationship":"new","concept_id":"task-reexecution-fault-recovery","label":"Task re-execution fault recovery","source_basis":"Failed worker tasks are reset/rescheduled, and map work may be re-executed as the primary recovery mechanism.","prior_basis":"Durable workflow progress and external-side-effect idempotency exist in the graph, but neither is the same as re-running deterministic batch tasks.","interpretation":"The source adds a distinct recovery model enabled by the restricted computation semantics.","evidence_insights":[]},
+      {"relationship":"new","concept_id":"data-locality-scheduling","label":"Data-locality scheduling","source_basis":"The master preferentially schedules map tasks on or near machines that hold input replicas.","prior_basis":"No existing graph concept represents scheduler-owned compute placement driven by data location.","interpretation":"The runtime can optimize physical placement while preserving the logical user program.","evidence_insights":[]}
+    ],
+    "suppressed_prior_matches": ["durable-execution", "activity-execution", "workflow-execution", "controlled-execution", "idempotency-under-retry"]
+  },
+  "claim_evidence": {
+    "insight_id": "mapreduce-runtime-abstraction-boundary",
+    "claims": [
+      {"id":"mapreduce-user-runtime-boundary","text":"MapReduce asks users to provide Map and Reduce functions while the runtime owns partitioning, scheduling, machine-failure handling and inter-machine communication.","impact":"high","origin":"source","status":"supported","evidence":[{"kind":"primary_source","source_id":"src-google-mapreduce-osdi-2004","url":"https://research.google/pubs/mapreduce-simplified-data-processing-on-large-clusters","locator":"Publication page → Abstract"},{"kind":"primary_source","source_id":"src-google-mapreduce-osdi-2004","url":"https://storage.googleapis.com/gweb-research2023-media/pubtools/4449.pdf","locator":"PDF §2 Programming Model and Figure 1 / §3.1 Execution Overview"}],"note":null},
+      {"id":"mapreduce-reexecution-fault-tolerance","text":"The Google implementation uses task rescheduling and re-execution as a primary mechanism for tolerating worker failures in large batch computations.","impact":"high","origin":"source","status":"supported","evidence":[{"kind":"primary_source","source_id":"src-google-mapreduce-osdi-2004","url":"https://storage.googleapis.com/gweb-research2023-media/pubtools/4449.pdf","locator":"PDF §3.3 Fault Tolerance → Worker Failure"}],"note":null},
+      {"id":"mapreduce-locality-scheduling","text":"The master uses input-location information to schedule map tasks on or near machines holding the required data, reducing network traffic.","impact":"medium","origin":"source","status":"supported","evidence":[{"kind":"primary_source","source_id":"src-google-mapreduce-osdi-2004","url":"https://storage.googleapis.com/gweb-research2023-media/pubtools/4449.pdf","locator":"PDF §3.4 Locality"}],"note":null},
+      {"id":"mapreduce-restriction-enables-runtime","text":"The transferable architectural lesson is that restricting the programming model gives the runtime enough structure to automate parallelization, distribution and fault recovery.","impact":"high","origin":"project_interpretation","status":"supported","evidence":[{"kind":"primary_source","source_id":"src-google-mapreduce-osdi-2004","url":"https://storage.googleapis.com/gweb-research2023-media/pubtools/4449.pdf","locator":"PDF Introduction and §8 Conclusions"}],"note":"This wording is the project's architecture synthesis of the authors' stated rationale, not a source-authored general framework law."}
+    ]
+  },
+  "prerequisite_map": {
+    "insight_id": "mapreduce-runtime-abstraction-boundary",
+    "summary": "The mental model needs the constrained user interface, runtime-owned distribution and re-execution recovery; locality is useful depth after those responsibilities are clear.",
+    "items": [
+      {"id":"mapreduce-prereq-restricted-model","label":"Restricted programming model","concept_id":"restricted-programming-model","priority":"must_know_now","prior_coverage":"absent","state":"explained_here","reason":"The source's leverage is impossible to understand if Map and Reduce are treated as mere convenience functions rather than a deliberate constraint.","resolution":{"kind":"explained_here","insight_id":"mapreduce-runtime-abstraction-boundary","target":null}},
+      {"id":"mapreduce-prereq-runtime-distribution","label":"Runtime-managed distribution","concept_id":"runtime-managed-distribution","priority":"must_know_now","prior_coverage":"absent","state":"explained_here","reason":"The user/runtime responsibility split is the central reason simple transformations can run across many machines without custom cluster code.","resolution":{"kind":"explained_here","insight_id":"mapreduce-runtime-abstraction-boundary","target":null}},
+      {"id":"mapreduce-prereq-reexecution","label":"Task re-execution fault recovery","concept_id":"task-reexecution-fault-recovery","priority":"must_know_now","prior_coverage":"absent","state":"explained_here","reason":"Failure handling demonstrates what the runtime can safely automate once tasks fit the constrained computation model.","resolution":{"kind":"explained_here","insight_id":"mapreduce-runtime-abstraction-boundary","target":null}},
+      {"id":"mapreduce-prereq-locality","label":"Data-locality scheduling","concept_id":"data-locality-scheduling","priority":"learn_next","prior_coverage":"absent","state":"explained_here","reason":"Locality shows how runtime ownership can optimize physical placement without expanding the user-facing abstraction.","resolution":{"kind":"explained_here","insight_id":"mapreduce-runtime-abstraction-boundary","target":null}}
+    ]
+  },
+  "learning_prompt": {
+    "insight_id": "mapreduce-runtime-abstraction-boundary",
+    "retention_prompt": "Without looking back, reconstruct the MapReduce responsibility boundary: what does the programmer specify, which distributed-execution responsibilities does the runtime take over, why does the restricted model make task re-execution practical, and what important workload boundary remains?",
+    "answer_key": {"problem_from":"whole_source_map.problem","mechanism_from":"whole_source_map.thesis","anchor_concept_ids":["restricted-programming-model","runtime-managed-distribution","task-reexecution-fault-recovery"],"boundary_limitation_index":0},
+    "transfer_prompt": {"prompt":"You are designing a framework for large repeatable file transformations. Which parts of the user API would you deliberately restrict so the runtime can own partitioning, scheduling and failure recovery, and where would that restriction become too limiting?","expected_concept_ids":["restricted-programming-model","runtime-managed-distribution","task-reexecution-fault-recovery"]}
+  },
+  "source_decision": {
+    "insight_id": "mapreduce-runtime-abstraction-boundary",
+    "decision": "skim_selected_parts",
+    "rationale": "The explainer preserves the abstraction boundary, but the original paper is worth a targeted skim because Figure 1 and the fault-tolerance/locality sections make the runtime responsibilities concrete. The historical performance sections are not required for the current architecture question.",
+    "novelty": {"level":"high","reason":"The source adds a general runtime-abstraction pattern not previously represented as a standalone concept in the graph."},
+    "source_quality": {"level":"high","reason":"This is the original Google OSDI paper and official Google Research publication page."},
+    "relevance": {"level":"high","reason":"The responsibility-boundary lesson transfers directly to data tooling, workflow runtimes and agent/framework design."},
+    "practical_leverage": {"level":"high","reason":"It provides a concrete design test for deciding which execution concerns should disappear behind a constrained framework interface."},
+    "compression_loss": {"level":"medium","reason":"The core model compresses well, but Figure 1 and failure/locality mechanisms add useful intuition about why the abstraction works."},
+    "selected_parts": [
+      {"label":"Programming model and execution overview","locator":"PDF §2 Programming Model and Figure 1 / §3.1 Execution Overview","why":"See the exact user/runtime split and how logical Map/Reduce becomes distributed tasks.","claim_refs":["mapreduce-user-runtime-boundary"]},
+      {"label":"Worker failure recovery","locator":"PDF §3.3 Fault Tolerance → Worker Failure","why":"Shows why runtime-owned scheduling can turn machine failure into task re-execution rather than application repair code.","claim_refs":["mapreduce-reexecution-fault-tolerance"]},
+      {"label":"Locality","locator":"PDF §3.4 Locality","why":"Shows the runtime optimizing physical placement without changing the user-level computation.","claim_refs":["mapreduce-locality-scheduling"]}
+    ]
+  }
+}

--- a/data/case-patches/mapreduce.json
+++ b/data/case-patches/mapreduce.json
@@ -1,0 +1,121 @@
+{
+  "patch_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-research-mapreduce-simplified-data-processing-on-large-cl",
+  "intake_status": "review",
+  "updated_at": "2026-08-27",
+  "graph_version": "0.4.0",
+  "source": {
+    "id": "src-google-mapreduce-osdi-2004",
+    "type": "paper",
+    "title": "MapReduce: Simplified Data Processing on Large Clusters",
+    "canonical_url": "https://research.google/pubs/mapreduce-simplified-data-processing-on-large-clusters",
+    "creators": ["Jeffrey Dean", "Sanjay Ghemawat"],
+    "publisher": "Google / OSDI'04",
+    "event": "OSDI'04",
+    "published_at": null,
+    "event_date": null,
+    "captured_at": "2026-08-27",
+    "analyzed_at": "2026-08-27",
+    "date_note": "Published in OSDI'04 (2004), pp. 137–150; exact publication day is not asserted.",
+    "verification": [
+      {"title":"Official Google-hosted OSDI paper PDF","url":"https://storage.googleapis.com/gweb-research2023-media/pubtools/4449.pdf","accessed_at":"2026-08-27"}
+    ],
+    "derived_records": ["mapreduce-runtime-abstraction-boundary"]
+  },
+  "insight": {
+    "id": "mapreduce-runtime-abstraction-boundary",
+    "source_id": "src-google-mapreduce-osdi-2004",
+    "slug": "mapreduce-runtime-abstraction-boundary",
+    "status": "review",
+    "title": "MapReduce: let the program define the transformation and the runtime own distribution",
+    "one_liner": "MapReduce gains leverage by restricting user code to Map and Reduce while the runtime owns partitioning, scheduling, communication, locality and task recovery.",
+    "why_this_matters": "The transferable idea is an architecture boundary: a framework becomes powerful when the user declares only the domain computation and the runtime has enough structure to automate distributed execution reliably.",
+    "whole_source_map": {
+      "problem": "Straightforward large-data computations become dominated by distribution code when programmers must explicitly parallelize work, partition data, schedule machines, move intermediate data and recover from failures.",
+      "thesis": "Restrict the user program to Map and Reduce functions over key/value data so a runtime can automatically partition, schedule, move data and re-execute tasks across a cluster.",
+      "core_topics": ["Map/Reduce user interface", "automatic partitioning and scheduling", "master/worker execution", "task re-execution after failure", "data locality", "restricted-model trade-off"]
+    },
+    "derived_model": {
+      "problem": "Distributed execution mechanics can overwhelm otherwise simple data transformations.",
+      "mechanism": "Constrain user logic to Map and Reduce over key/value data, then let the runtime derive task partitions, placement, shuffle, scheduling and failure recovery.",
+      "result": "Programmers can express large-scale batch computations without writing most cluster-control code, while the runtime can optimize and recover because the computation has a predictable structure."
+    },
+    "coherence_review": {
+      "central_chain": [
+        "User code expresses the transformation as Map and Reduce.",
+        "The restricted interface exposes enough structure for the runtime to split and distribute work.",
+        "The runtime schedules workers and moves intermediate data without changing the user-level functions.",
+        "When workers fail, tasks can be reset and re-executed.",
+        "Locality-aware scheduling reduces network cost while preserving the same programming model."
+      ],
+      "prerequisites_complete": true,
+      "source_vs_enrichment_clear": true,
+      "open_gaps": [
+        "The 2004 Google implementation is historical context, not a current architecture prescription.",
+        "MapReduce does not cover low-latency streaming, interactive queries or arbitrary distributed coordination."
+      ],
+      "scores": {"coherence":5,"prerequisite_completeness":5,"evidence_confidence":5,"practical_leverage":5}
+    },
+    "visual_plan": {
+      "dominant": {
+        "type": "layers",
+        "title": "The abstraction boundary",
+        "nodes": [
+          {"label":"USER","title":"Map + Reduce","text":"Define the domain transformation over key/value records."},
+          {"label":"RUNTIME","title":"Partition + schedule + shuffle","text":"Derive distributed tasks, assign workers and move intermediate data."},
+          {"label":"RELIABILITY","title":"Re-execute + place near data","text":"Recover failed tasks and reduce network cost without changing the user program."}
+        ]
+      },
+      "supporting": ["sequence", "concept_grid", "examples", "limitations", "action_map", "source_map"],
+      "image": {"needed":false,"reason":"The paper's Figure 1 is useful verification, but the product mental model is clearer as a compact responsibility-layer diagram rather than reproducing a source figure."}
+    },
+    "concepts": [
+      {"name":"Restricted programming model","depth":"learn","why_needed":"The runtime can automate distribution precisely because user programs fit a constrained Map/Reduce structure."},
+      {"name":"Runtime-managed distribution","depth":"learn","why_needed":"Partitioning, scheduling and communication are deliberately moved out of application code."},
+      {"name":"Task re-execution fault recovery","depth":"learn","why_needed":"Worker failures are handled by rescheduling/re-executing tasks rather than forcing user code to coordinate machine recovery."},
+      {"name":"Data-locality scheduling","depth":"know","why_needed":"The runtime can place map work near input replicas to reduce network traffic."}
+    ],
+    "tool_map": [],
+    "examples": [
+      {"domain":"log aggregation","scenario":"Terabytes of records must be grouped and aggregated by key.","question":"Can the business transformation be expressed as Map/Reduce while the runtime owns partitioning and recovery?"},
+      {"domain":"framework design","scenario":"A team is building a distributed transformation engine.","question":"Which responsibilities can be removed from user code if the framework intentionally restricts the computation model?"}
+    ],
+    "limitations": [
+      "A restricted Map/Reduce interface cannot express every distributed algorithm naturally.",
+      "Task re-execution is safe only when the computation semantics tolerate replay; it is not a blanket guarantee for arbitrary external side effects.",
+      "The paper describes batch processing on a 2004 Google cluster and should not be read as a current systems benchmark.",
+      "Automatic runtime ownership reduces control as well as complexity."
+    ],
+    "action_map": {
+      "use_now": ["When designing a framework, separate domain transformation from distribution mechanics and ask which runtime responsibilities become automatable if the user interface is deliberately constrained."],
+      "try": ["Take one batch transformation and specify only its logical partition/aggregation functions, then list every execution concern a runtime could own."],
+      "learn": ["restricted programming models", "runtime scheduling", "task re-execution", "data locality"],
+      "build": ["A small local Map/Reduce-style executor that partitions records, runs map tasks, groups intermediate keys and retries failed tasks."],
+      "watch": ["Where modern agent/data frameworks gain reliability by narrowing user-defined execution semantics."],
+      "ignore_for_now": ["Treating the 2004 master/worker implementation or hardware details as the essence of the MapReduce abstraction."]
+    },
+    "connections": [
+      "durable execution: adjacent reliability goal but different unit/semantics; MapReduce re-executes batch tasks rather than persisting long-running workflow progress",
+      "idempotency under retry: relevant implementation concern for side effects, but not identical to MapReduce's functional task-reexecution model"
+    ],
+    "supporting_sources": [
+      {"title":"Google Research publication page","url":"https://research.google/pubs/mapreduce-simplified-data-processing-on-large-clusters","publisher":"Google Research","purpose":"official metadata and abstract describing the user/runtime responsibility split","accessed_at":"2026-08-27"},
+      {"title":"Official OSDI paper PDF","url":"https://storage.googleapis.com/gweb-research2023-media/pubtools/4449.pdf","publisher":"Google","purpose":"primary evidence for execution overview, fault tolerance, locality and conclusions","accessed_at":"2026-08-27"}
+    ],
+    "tags": ["mapreduce", "distributed-systems", "batch-processing", "abstraction", "scheduling", "fault-tolerance"],
+    "provenance": {"source_linked":true,"source_dates_recorded":true,"full_transcript_stored":false,"analysis_type":"direct official publication/PDF analysis focused on abstraction ownership","reviewed_at":"2026-08-27"}
+  },
+  "graph": {
+    "concepts": [
+      {"id":"restricted-programming-model","label":"Restricted programming model","summary":"A deliberately constrained user-facing computation model that gives a runtime enough structure to automate execution responsibilities.","domain":"software architecture","coverage":"explained","insight_ids":["mapreduce-runtime-abstraction-boundary"],"aliases":["constrained programming interface"],"tags":["abstraction","runtime","framework"]},
+      {"id":"runtime-managed-distribution","label":"Runtime-managed distribution","summary":"Moving partitioning, scheduling and inter-machine data movement from application code into a framework runtime.","domain":"distributed systems","coverage":"explained","insight_ids":["mapreduce-runtime-abstraction-boundary"],"aliases":["automatic distributed execution"],"tags":["scheduling","partitioning","runtime"]},
+      {"id":"task-reexecution-fault-recovery","label":"Task re-execution fault recovery","summary":"Recovering worker failure by rescheduling or re-running deterministic batch tasks instead of requiring application code to repair individual machines.","domain":"distributed systems","coverage":"explained","insight_ids":["mapreduce-runtime-abstraction-boundary"],"aliases":["task replay recovery"],"tags":["fault-tolerance","retry","workers"]},
+      {"id":"data-locality-scheduling","label":"Data-locality scheduling","summary":"Placing computation on or near machines that already hold its input data to reduce network transfer.","domain":"distributed systems","coverage":"explained","insight_ids":["mapreduce-runtime-abstraction-boundary"],"aliases":["compute-near-data scheduling"],"tags":["locality","scheduling","network"]}
+    ],
+    "relations": [
+      {"id":"rel-restricted-programming-model-enables-runtime-managed-distribution","from":"restricted-programming-model","to":"runtime-managed-distribution","type":"enables","rationale":"A predictable Map/Reduce structure gives the runtime enough information to partition and schedule work automatically.","evidence_insights":["mapreduce-runtime-abstraction-boundary"]},
+      {"id":"rel-runtime-managed-distribution-enables-task-reexecution-fault-recovery","from":"runtime-managed-distribution","to":"task-reexecution-fault-recovery","type":"enables","rationale":"Runtime ownership of task scheduling lets failed work be reset, reassigned and executed again without rewriting the user computation.","evidence_insights":["mapreduce-runtime-abstraction-boundary"]},
+      {"id":"rel-runtime-managed-distribution-enables-data-locality-scheduling","from":"runtime-managed-distribution","to":"data-locality-scheduling","type":"enables","rationale":"The scheduler can use input-location metadata to place map tasks near their data while preserving the same user-facing program.","evidence_insights":["mapreduce-runtime-abstraction-boundary"]}
+    ]
+  }
+}

--- a/data/research-bundles/intake-2026-08-27-research-mapreduce-simplified-data-processing-on-large-cl.json
+++ b/data/research-bundles/intake-2026-08-27-research-mapreduce-simplified-data-processing-on-large-cl.json
@@ -1,138 +1,111 @@
 {
   "bundle_version": "1.1.0",
   "intake_id": "intake-2026-08-27-research-mapreduce-simplified-data-processing-on-large-cl",
-  "source_id": null,
+  "source_id": "src-google-mapreduce-osdi-2004",
   "source": {
     "type": "paper",
     "canonical_url": "https://research.google/pubs/mapreduce-simplified-data-processing-on-large-clusters",
-    "title": null,
-    "creators": [],
-    "publisher": null,
+    "title": "MapReduce: Simplified Data Processing on Large Clusters",
+    "creators": ["Jeffrey Dean", "Sanjay Ghemawat"],
+    "publisher": "Google / OSDI'04",
     "published_at": null,
     "event_date": null,
-    "version": null,
-    "language": null,
+    "version": "OSDI 2004 paper",
+    "language": "en",
     "duration": null,
-    "date_note": null
+    "date_note": "Published in OSDI'04 (2004), pp. 137–150; the publication page does not provide a more precise publication date."
   },
   "inspection": {
-    "method": "not inspected",
-    "full_content_used_ephemerally": false,
+    "method": "Direct inspection of the official Google Research publication page and official OSDI paper PDF, including programming model, execution overview, fault tolerance, locality and conclusions.",
+    "full_content_used_ephemerally": true,
     "full_content_committed": false,
-    "confidence": "metadata_only",
+    "confidence": "direct",
     "gaps": [
-      "Source content has not been mapped yet."
+      "This case preserves the abstraction boundary and representative runtime mechanisms; it does not treat the 2004 Google cluster implementation as a current implementation prescription.",
+      "Later systems that generalize or replace MapReduce are outside the source claim."
     ]
   },
   "prior_knowledge": {
     "captured_at": "2026-08-27",
     "query": "Understand the MapReduce abstraction boundary: what map/reduce lets the programmer specify, what the runtime takes over, and why hiding partitioning, scheduling and failure recovery created leverage.",
     "matches": [
-      {
-        "concept_id": "durable-execution",
-        "label": "Durable execution",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "enterprise-agents-production-substrate",
-            "status": "published",
-            "title": "Why enterprise AI agents fail after the POC"
-          },
-          {
-            "id": "temporal-durable-execution-mental-model",
-            "status": "review",
-            "title": "Temporal: the mental model behind durable execution"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "activity-execution",
-        "label": "Activity Execution",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "temporal-durable-execution-mental-model",
-            "status": "review",
-            "title": "Temporal: the mental model behind durable execution"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "workflow-execution",
-        "label": "Workflow Execution",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "temporal-durable-execution-mental-model",
-            "status": "review",
-            "title": "Temporal: the mental model behind durable execution"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "controlled-execution",
-        "label": "Controlled execution",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "enterprise-agents-production-substrate",
-            "status": "published",
-            "title": "Why enterprise AI agents fail after the POC"
-          },
-          {
-            "id": "open-policy-agent-decision-enforcement-model",
-            "status": "review",
-            "title": "Open Policy Agent: separate policy decisions from enforcement"
-          },
-          {
-            "id": "react-reason-act-observe-loop",
-            "status": "review",
-            "title": "ReAct: reason, act, observe — then update the plan"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "idempotency-under-retry",
-        "label": "Idempotency under retry",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "temporal-durable-execution-mental-model",
-            "status": "review",
-            "title": "Temporal: the mental model behind durable execution"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      }
+      {"concept_id":"durable-execution","label":"Durable execution","coverage":"explained","evidence_insights":[{"id":"enterprise-agents-production-substrate","status":"published","title":"Why enterprise AI agents fail after the POC"},{"id":"temporal-durable-execution-mental-model","status":"review","title":"Temporal: the mental model behind durable execution"},{"id":"langgraph-stateful-agent-orchestration","status":"review","title":"LangGraph: stateful orchestration is not the same as the agent loop"}],"relationship_to_source":"not_relevant"},
+      {"concept_id":"activity-execution","label":"Activity Execution","coverage":"explained","evidence_insights":[{"id":"temporal-durable-execution-mental-model","status":"review","title":"Temporal: the mental model behind durable execution"}],"relationship_to_source":"not_relevant"},
+      {"concept_id":"workflow-execution","label":"Workflow Execution","coverage":"explained","evidence_insights":[{"id":"temporal-durable-execution-mental-model","status":"review","title":"Temporal: the mental model behind durable execution"}],"relationship_to_source":"not_relevant"},
+      {"concept_id":"controlled-execution","label":"Controlled execution","coverage":"explained","evidence_insights":[{"id":"enterprise-agents-production-substrate","status":"published","title":"Why enterprise AI agents fail after the POC"},{"id":"open-policy-agent-decision-enforcement-model","status":"review","title":"Open Policy Agent: separate policy decisions from enforcement"},{"id":"react-reason-act-observe-loop","status":"review","title":"ReAct: reason, act, observe — then update the plan"},{"id":"langgraph-stateful-agent-orchestration","status":"review","title":"LangGraph: stateful orchestration is not the same as the agent loop"}],"relationship_to_source":"not_relevant"},
+      {"concept_id":"idempotency-under-retry","label":"Idempotency under retry","coverage":"explained","evidence_insights":[{"id":"temporal-durable-execution-mental-model","status":"review","title":"Temporal: the mental model behind durable execution"},{"id":"idempotent-receiver-retry-deduplication","status":"review","title":"Idempotent Receiver: retries need a stable logical request identity"}],"relationship_to_source":"not_relevant"}
     ],
     "classification_required": true
   },
   "content_map": {
-    "problem": null,
-    "thesis": null,
-    "sections": [],
-    "concepts": [],
-    "mechanisms": [],
-    "tools": [],
-    "examples": [],
-    "claims": [],
-    "evidence": [],
-    "assumptions": [],
-    "limitations": [],
-    "open_questions": []
+    "problem": "Straightforward large-data computations become dominated by distribution code when programmers must explicitly parallelize work, partition data, schedule machines, move intermediate data and recover from failures.",
+    "thesis": "Restrict the user program to Map and Reduce functions over key/value data so a runtime can automatically partition, schedule, move data and re-execute tasks across a cluster.",
+    "sections": ["Abstract and Introduction", "2 Programming Model", "3 Implementation and Execution Overview", "3.3 Fault Tolerance", "3.4 Locality", "8 Conclusions"],
+    "concepts": ["restricted programming model", "Map function", "Reduce function", "runtime-managed distribution", "task re-execution", "locality-aware scheduling"],
+    "mechanisms": [
+      "User code defines Map and Reduce transformations.",
+      "The library partitions input into map tasks and the intermediate key space into reduce partitions.",
+      "A master schedules work across workers and coordinates intermediate locations.",
+      "Failed worker tasks become eligible for rescheduling; map work may be re-executed.",
+      "Map tasks are preferentially scheduled near input replicas to reduce network traffic."
+    ],
+    "tools": ["MapReduce library", "master/worker runtime", "Google File System (implementation dependency in the paper)"],
+    "examples": ["word count", "distributed grep", "inverted index", "distributed sort"],
+    "claims": [
+      "Users specify Map and Reduce; the runtime handles parallelization and distribution.",
+      "The restricted model enables transparent fault tolerance through task re-execution.",
+      "Locality-aware scheduling reduces network transfer by moving computation toward input data.",
+      "The 2004 implementation details are one realization of the interface, not the definition of MapReduce itself."
+    ],
+    "evidence": [
+      "Google Research abstract separates user-specified functions from runtime-owned partitioning, scheduling, failures and communication.",
+      "Paper Figure 1 and Section 3 show the master/worker execution flow.",
+      "Section 3.3 describes worker failure and task rescheduling/re-execution.",
+      "Section 3.4 describes locality-aware map scheduling."
+    ],
+    "assumptions": [
+      "The workload can be expressed as map/reduce transformations over partitionable data.",
+      "Re-executing tasks is semantically safe for the computation model.",
+      "Batch throughput and large-scale data processing matter more than low-latency incremental updates."
+    ],
+    "limitations": [
+      "The programming model is intentionally restrictive and is not a fit for every distributed computation.",
+      "The paper's cluster, network, disk and GFS details are historical implementation context.",
+      "MapReduce is a batch model; later systems address interactive, streaming and iterative workloads differently."
+    ],
+    "open_questions": [
+      "Which modern workload classes still benefit from a similarly restrictive runtime abstraction?",
+      "Where should a framework expose control instead of hiding scheduling and failure recovery?"
+    ]
   },
   "selection": {
     "requested_focus": "Understand the MapReduce abstraction boundary: what map/reduce lets the programmer specify, what the runtime takes over, and why hiding partitioning, scheduling and failure recovery created leverage.",
-    "coherent_core": [],
-    "prerequisites": [],
-    "drop_notes": [],
-    "connections": []
+    "coherent_core": [
+      "The programmer specifies domain transformations, not distributed execution mechanics.",
+      "A restricted interface gives the runtime enough structure to partition and schedule work automatically.",
+      "The same restriction lets the runtime recover from worker failure by re-executing tasks.",
+      "Data locality is a runtime optimization that preserves the user-level model while reducing network cost."
+    ],
+    "prerequisites": ["key/value transformation", "task partitioning", "worker failure"],
+    "drop_notes": [
+      "Do not teach Hadoop or modern cloud products as if they were part of the 2004 source.",
+      "Do not equate MapReduce task re-execution with Temporal durable workflow execution or external-side-effect idempotency."
+    ],
+    "connections": [
+      "MapReduce illustrates a general abstraction principle: give a runtime fewer, clearer user-level responsibilities so it can own distribution and recovery.",
+      "This is adjacent to durable orchestration but the persisted unit and semantics are different."
+    ]
   },
-  "verification_candidates": [],
-  "source_locators": [],
+  "verification_candidates": [
+    {"question":"Which later systems retained the same abstraction ownership while relaxing the batch Map/Reduce model?","reason":"Useful historical follow-up, not required to understand this source.","priority":"low"}
+  ],
+  "source_locators": [
+    {"label":"Google Research abstract","locator":"Publication page → Abstract"},
+    {"label":"Programming model","locator":"PDF §2 Programming Model"},
+    {"label":"Execution overview","locator":"PDF Figure 1 and §3.1 Execution Overview"},
+    {"label":"Fault tolerance","locator":"PDF §3.3 Fault Tolerance"},
+    {"label":"Locality","locator":"PDF §3.4 Locality"},
+    {"label":"Conclusions","locator":"PDF §8 Conclusions"}
+  ],
   "created_at": "2026-08-27"
 }


### PR DESCRIPTION
Dogfood cohort case for #40 and source issue #61.

Adds a review-only MapReduce case grounded in the original Google OSDI'04 paper.

Key boundaries:
- programmer owns Map/Reduce domain transformations; runtime owns partitioning, scheduling, communication and worker recovery;
- task re-execution is modeled as a distinct batch fault-recovery concept, not silently merged with Temporal durable execution or external-side-effect idempotency;
- data locality is runtime-owned placement optimization, not part of the user programming model;
- 2004 Google master/worker/GFS details remain historical implementation context rather than the portable product lesson;
- Figure 1 and fault-tolerance/locality sections are retained as targeted source-reading recommendations.

Includes bundle, atomic case patch and full companion review contract. No publication transition.