### PR TITLE
Dogfood case: Terraform state as durable infrastructure identity

### DIFF
--- a/data/case-contracts/terraform-state.json
+++ b/data/case-contracts/terraform-state.json
@@ -1,0 +1,49 @@
+{
+  "contract_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-developer-purpose",
+  "insight_id": "terraform-state-identity-binding",
+  "knowledge_delta": {
+    "insight_id": "terraform-state-identity-binding",
+    "summary": "Terraform adds a distinct persistent-state model to the graph: declarative intent still requires durable managed-object identity, lifecycle metadata and shared coordination across runs rather than reconstructing infrastructure ownership from scratch.",
+    "items": [
+      {"relationship": "new", "concept_id": "terraform-state", "label": "Terraform state", "source_basis": "Terraform requires persistent state to map configuration to real resources, retain metadata and support future planning/synchronization.", "prior_basis": "The cumulative graph had desired-state, workflow and database-state concepts but no infrastructure-as-code state record with Terraform's ownership semantics.", "interpretation": "State becomes a separate reusable concept: declarative code is not sufficient operational memory when a tool must manage the same remote objects across runs.", "evidence_insights": []},
+      {"relationship": "new", "concept_id": "resource-identity-binding", "label": "Resource identity binding", "source_basis": "The primary purpose of Terraform state is binding a resource instance in configuration to the identity of a concrete remote object.", "prior_basis": "No prior concept represented a persistent address-to-remote-object ownership mapping for infrastructure lifecycle management.", "interpretation": "Identity binding explains why state is required even when desired configuration is complete and version-controlled.", "evidence_insights": []},
+      {"relationship": "new", "concept_id": "shared-state-coordination", "label": "Shared state coordination", "source_basis": "Terraform recommends a shared remote state so collaborators operate on the same mapping, with locking used to reduce simultaneous state mutation.", "prior_basis": "The graph did not yet model collaboration around one mutable infrastructure ownership record.", "interpretation": "State is not just local execution memory; in team use it becomes shared operational data requiring synchronization and access discipline.", "evidence_insights": []}
+    ],
+    "suppressed_prior_matches": []
+  },
+  "claim_evidence": {
+    "insight_id": "terraform-state-identity-binding",
+    "claims": [
+      {"id": "terraform-state-maps-real-objects", "text": "Terraform state is required to persist the mapping between resource instances declared in configuration and the concrete remote objects Terraform manages across runs.", "impact": "high", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-terraform-state-purpose-2026", "url": "https://developer.hashicorp.com/terraform/language/state/purpose", "locator": "Purpose of Terraform State → Mapping to the Real World"}], "note": null},
+      {"id": "terraform-state-keeps-metadata", "text": "Terraform state retains lifecycle metadata such as resource dependencies and provider configuration information in addition to remote object identities and cached attributes.", "impact": "medium", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-terraform-state-purpose-2026", "url": "https://developer.hashicorp.com/terraform/language/state/purpose", "locator": "Purpose of Terraform State → Metadata"}], "note": null},
+      {"id": "terraform-state-syncs-collaboration", "text": "For collaborative infrastructure management, Terraform needs participants to operate from the same state, and remote state with locking is used to coordinate access and reduce concurrent updates.", "impact": "high", "origin": "source", "status": "supported", "evidence": [{"kind": "primary_source", "source_id": "src-terraform-state-purpose-2026", "url": "https://developer.hashicorp.com/terraform/language/state/purpose", "locator": "Purpose of Terraform State → Syncing"}], "note": null}
+    ]
+  },
+  "prerequisite_map": {
+    "insight_id": "terraform-state-identity-binding",
+    "summary": "The minimum Terraform state model needs three pieces: the state record itself, the resource identity binding that gives it purpose, and shared coordination that becomes necessary when multiple actors mutate the same managed infrastructure.",
+    "items": [
+      {"id": "terraform-state-prereq-state", "label": "Terraform state", "concept_id": "terraform-state", "priority": "must_know_now", "prior_coverage": "absent", "state": "explained_here", "reason": "The source is specifically explaining why Terraform needs a persistent state layer alongside declarative configuration.", "resolution": {"kind": "explained_here", "insight_id": "terraform-state-identity-binding", "target": null}},
+      {"id": "terraform-state-prereq-binding", "label": "Resource identity binding", "concept_id": "resource-identity-binding", "priority": "must_know_now", "prior_coverage": "absent", "state": "explained_here", "reason": "Without the configuration-to-remote-object mapping, state is easily misread as only a cache of current values.", "resolution": {"kind": "explained_here", "insight_id": "terraform-state-identity-binding", "target": null}},
+      {"id": "terraform-state-prereq-coordination", "label": "Shared state coordination", "concept_id": "shared-state-coordination", "priority": "learn_next", "prior_coverage": "absent", "state": "explained_here", "reason": "Team use changes state from local operational memory into a synchronized shared asset whose mutation must be coordinated.", "resolution": {"kind": "explained_here", "insight_id": "terraform-state-identity-binding", "target": null}}
+    ]
+  },
+  "learning_prompt": {
+    "insight_id": "terraform-state-identity-binding",
+    "retention_prompt": "Without looking back, explain why declarative Terraform configuration is not enough by itself: identify what state remembers about remote objects, what additional metadata it keeps, how refresh changes current attributes without replacing identity, and why team use requires shared-state coordination.",
+    "answer_key": {"problem_from": "whole_source_map.problem", "mechanism_from": "whole_source_map.thesis", "anchor_concept_ids": ["terraform-state", "resource-identity-binding", "shared-state-coordination"], "boundary_limitation_index": 0},
+    "transfer_prompt": {"prompt": "A team keeps perfect Terraform code in Git but deletes the shared state and asks Terraform to infer ownership from the cloud APIs on every run. What information has been lost, why is rediscovery not equivalent to the old state, and what team coordination problem still remains?", "expected_concept_ids": ["terraform-state", "resource-identity-binding", "shared-state-coordination"]}
+  },
+  "source_decision": {
+    "insight_id": "terraform-state-identity-binding",
+    "decision": "explainer_is_enough",
+    "rationale": "For the conceptual question of why declarative infrastructure still needs state, the explainer preserves the complete identity-mapping, metadata, performance and synchronization model. Open the original mainly when backend-specific implementation details are the next task.",
+    "novelty": {"level": "high", "reason": "The source introduces a new persistent infrastructure-ownership model rather than repeating an existing workflow or database state concept."},
+    "source_quality": {"level": "high", "reason": "The primary source is current official Terraform documentation describing the state model the Terraform CLI itself relies on."},
+    "relevance": {"level": "high", "reason": "The distinction between declarative intent and durable managed identity is central to infrastructure-as-code design and operational safety."},
+    "practical_leverage": {"level": "high", "reason": "The model directly improves decisions about remote state, locking, state ownership, drift handling and the risks of treating state as disposable."},
+    "compression_loss": {"level": "low", "reason": "The official purpose page is compact and conceptual; its important mapping, metadata, performance and synchronization arguments can be retained without reproducing backend-specific details."},
+    "selected_parts": []
+  }
+}

--- a/data/case-patches/terraform-state.json
+++ b/data/case-patches/terraform-state.json
@@ -1,0 +1,124 @@
+{
+  "patch_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-developer-purpose",
+  "intake_status": "review",
+  "updated_at": "2026-08-27",
+  "graph_version": "0.4.0",
+  "source": {
+    "id": "src-terraform-state-purpose-2026",
+    "type": "documentation",
+    "title": "Purpose of Terraform State",
+    "canonical_url": "https://developer.hashicorp.com/terraform/language/state/purpose",
+    "creators": ["HashiCorp Terraform documentation contributors"],
+    "publisher": "HashiCorp",
+    "event": null,
+    "published_at": null,
+    "event_date": null,
+    "captured_at": "2026-08-27",
+    "analyzed_at": "2026-08-27",
+    "date_note": "Living Terraform documentation inspected on 2026-08-27; no standalone publication date is asserted.",
+    "verification": [
+      {"title": "Purpose of Terraform State", "url": "https://developer.hashicorp.com/terraform/language/state/purpose", "accessed_at": "2026-08-27"},
+      {"title": "Terraform State", "url": "https://developer.hashicorp.com/terraform/language/state", "accessed_at": "2026-08-27"}
+    ],
+    "derived_records": ["terraform-state-identity-binding"]
+  },
+  "insight": {
+    "id": "terraform-state-identity-binding",
+    "source_id": "src-terraform-state-purpose-2026",
+    "slug": "terraform-state-identity-binding",
+    "status": "review",
+    "title": "Terraform state: declarative intent still needs durable identity",
+    "one_liner": "Terraform state is the durable mapping and metadata layer that tells declarative configuration which real remote objects it already manages across runs.",
+    "why_this_matters": "A common mental shortcut is that declarative systems should be stateless because the desired configuration already exists in code. Terraform shows why that is incomplete: configuration describes desired resources, while persistent state preserves identity, metadata and shared operational coordination needed to manage the same remote objects over time.",
+    "whole_source_map": {
+      "problem": "Configuration resource addresses do not by themselves identify the concrete remote objects created in earlier runs, and reconstructing every mapping from provider APIs is incomplete, ambiguous or expensive.",
+      "thesis": "Persist the configuration-to-remote-object binding plus lifecycle metadata and cached attributes in state, refresh that state against reality during planning, and coordinate team operations around one shared state.",
+      "core_topics": ["configuration-to-object identity binding", "state metadata", "cached attributes and refresh", "shared remote state", "state locking", "staleness and sensitive state boundaries"]
+    },
+    "derived_model": {
+      "problem": "Declarative intent says what should exist but cannot reliably answer which existing remote object a resource address means on the next run.",
+      "mechanism": "Terraform records a durable one-to-one resource binding, retains provider/dependency metadata and refreshed/cached attributes, and shares that state between collaborators with coordination around mutation.",
+      "result": "Plans can reason about changing managed objects rather than rediscovering infrastructure from scratch, but the state itself becomes a sensitive synchronized operational asset."
+    },
+    "coherence_review": {
+      "central_chain": [
+        "A configuration address names a desired resource instance but does not contain the remote object's provider-side identity.",
+        "When Terraform creates or imports an object, state binds that resource instance to the concrete remote object.",
+        "Later plans use the binding plus metadata and refreshed attributes to decide which object should be changed, replaced or removed.",
+        "For teams, everyone must operate against the same state mapping; remote state and locking reduce concurrent mutation risk.",
+        "Therefore declarative configuration and persistent state are complementary: code carries intent, state carries managed identity and operational continuity."
+      ],
+      "prerequisites_complete": true,
+      "source_vs_enrichment_clear": true,
+      "open_gaps": [
+        "Backend-specific locking, encryption and availability semantics require separate current documentation.",
+        "The source explains why state exists, not how to partition large Terraform estates into optimal state/workspace boundaries."
+      ],
+      "scores": {"coherence": 5, "prerequisite_completeness": 5, "evidence_confidence": 5, "practical_leverage": 5}
+    },
+    "visual_plan": {
+      "dominant": {
+        "type": "sequence",
+        "title": "Intent becomes manageable through persistent identity",
+        "nodes": [
+          {"label": "01 · Declare", "title": "Configuration address", "text": "Code says which resource instance should exist and how it should be configured."},
+          {"label": "02 · Bind", "title": "Remote object identity", "text": "State records which concrete provider-side object corresponds to that resource instance."},
+          {"label": "03 · Refresh", "title": "Observe current attributes", "text": "Terraform synchronizes managed-object data so planning starts from an updated view of reality."},
+          {"label": "04 · Plan", "title": "Compute the change", "text": "Desired configuration and managed state are compared to decide the lifecycle action for the same object."}
+        ]
+      },
+      "supporting": ["comparison", "concept_grid", "examples", "limitations", "action_map", "source_map"],
+      "image": {"needed": false, "reason": "The key distinction is the flow from declarative address to persistent remote identity and refreshed planning state; a sequence is clearer than decorative imagery."}
+    },
+    "concepts": [
+      {"name": "Terraform state", "depth": "learn", "why_needed": "State is the persistent knowledge layer Terraform requires between configuration and managed infrastructure."},
+      {"name": "Resource identity binding", "depth": "learn", "why_needed": "The primary purpose of state is preserving which remote object a configured resource instance means across runs."},
+      {"name": "Shared state coordination", "depth": "learn", "why_needed": "Team operations need one synchronized state and protection against concurrent state mutation."}
+    ],
+    "tool_map": [
+      {"name": "terraform plan", "category": "change planning", "why_explore": "Makes the relationship between desired configuration, refreshed state and proposed remote changes visible.", "url": "https://developer.hashicorp.com/terraform/cli/commands/plan", "relationship": "Source-native Terraform operation that consumes state to determine planned changes.", "status": "try"},
+      {"name": "remote state backend", "category": "state storage and coordination", "why_explore": "Needed when multiple operators or automation runs must share the same managed-object mapping safely.", "url": "https://developer.hashicorp.com/terraform/language/state/remote", "relationship": "Source-native Terraform mechanism for shared state.", "status": "learn"}
+    ],
+    "examples": [
+      {"domain": "cloud infrastructure", "scenario": "Configuration still contains aws_instance.foo one week after the original apply.", "question": "How does Terraform know which concrete provider instance ID that address should update rather than creating or touching a different object?"},
+      {"domain": "team operations", "scenario": "Two engineers run changes against the same infrastructure at nearly the same time.", "question": "Are both runs using one synchronized state mapping, and what prevents concurrent mutation of that shared operational record?"},
+      {"domain": "drift", "scenario": "A managed object's attributes are changed outside Terraform.", "question": "Which part comes from durable identity in state and which part must be refreshed from the real provider before the next plan is trustworthy?"}
+    ],
+    "limitations": [
+      "State can become stale relative to external reality until Terraform refreshes managed objects.",
+      "State may contain sensitive resource attributes and therefore requires stronger storage/access discipline than ordinary source code.",
+      "Shared state coordination reduces concurrent update risk but does not make every backend or external provider operation transactional.",
+      "Cached attributes improve performance, but treating state mainly as a cache misses its primary role as the identity binding between configuration and real objects."
+    ],
+    "action_map": {
+      "use_now": ["When reviewing infrastructure-as-code architecture, ask separately where desired intent lives and where durable managed-object identity lives.", "Treat Terraform state as operational data with explicit ownership, access and concurrency rules rather than as a disposable build artifact."],
+      "try": ["Create one disposable resource, inspect its state binding, change one remote attribute out of band and observe how refresh plus plan separate identity from current attributes."],
+      "learn": ["state backends", "state locking", "resource import/move", "state sensitivity and access control"],
+      "build": ["A small demo showing the same configuration address across create, external drift, refresh and planned repair while the remote object identity remains stable."],
+      "watch": ["Backend-specific locking changes and state security guidance as Terraform evolves."],
+      "ignore_for_now": ["Direct manual editing of terraform.tfstate as a normal operating model."]
+    },
+    "connections": [
+      "reconciliation-loop: both compare declared intent with observed reality, but Terraform state adds durable identity/metadata needed to know which real objects are being reconciled",
+      "desired-state: Terraform configuration expresses desired infrastructure while state preserves the managed binding to remote objects"
+    ],
+    "supporting_sources": [
+      {"title": "Purpose of Terraform State", "url": "https://developer.hashicorp.com/terraform/language/state/purpose", "publisher": "HashiCorp", "purpose": "primary source for mapping, metadata, performance and syncing", "accessed_at": "2026-08-27"},
+      {"title": "Terraform State", "url": "https://developer.hashicorp.com/terraform/language/state", "publisher": "HashiCorp", "purpose": "verification for current storage, remote-state and locking/security guidance", "accessed_at": "2026-08-27"}
+    ],
+    "tags": ["terraform", "infrastructure-as-code", "state", "identity", "declarative", "coordination"],
+    "provenance": {"source_linked": true, "source_dates_recorded": true, "full_transcript_stored": false, "analysis_type": "direct official Terraform documentation analysis", "reviewed_at": "2026-08-27"}
+  },
+  "graph": {
+    "concepts": [
+      {"id": "terraform-state", "label": "Terraform state", "summary": "Terraform's persistent managed-infrastructure record containing resource bindings, metadata and refreshed/cached attributes used across runs.", "domain": "infrastructure as code", "coverage": "explained", "insight_ids": ["terraform-state-identity-binding"], "aliases": ["Terraform state file"], "tags": ["terraform", "state", "infrastructure-as-code"]},
+      {"id": "resource-identity-binding", "label": "Resource identity binding", "summary": "A durable mapping from a declarative resource instance address to the concrete remote object Terraform manages for that address.", "domain": "infrastructure as code", "coverage": "explained", "insight_ids": ["terraform-state-identity-binding"], "aliases": ["configuration-to-remote-object binding"], "tags": ["identity", "mapping", "terraform", "lifecycle"]},
+      {"id": "shared-state-coordination", "label": "Shared state coordination", "summary": "Keeping collaborators and automation on one synchronized infrastructure state while controlling concurrent mutation of that shared record.", "domain": "infrastructure operations", "coverage": "explained", "insight_ids": ["terraform-state-identity-binding"], "aliases": ["remote state coordination"], "tags": ["state", "locking", "collaboration", "operations"]}
+    ],
+    "relations": [
+      {"id": "rel-resource-identity-binding-realized-by-terraform-state", "from": "resource-identity-binding", "to": "terraform-state", "type": "realized_by", "rationale": "Terraform persists the resource-instance to remote-object identity mapping in its state structure so the same managed object can be addressed on future runs.", "evidence_insights": ["terraform-state-identity-binding"]},
+      {"id": "rel-terraform-state-enables-shared-state-coordination", "from": "terraform-state", "to": "shared-state-coordination", "type": "enables", "rationale": "A shared state backend gives collaborators a common mapping, while locking/coordination protects that mapping from overlapping mutation.", "evidence_insights": ["terraform-state-identity-binding"]}
+    ]
+  }
+}

--- a/data/research-bundles/intake-2026-08-27-developer-purpose.json
+++ b/data/research-bundles/intake-2026-08-27-developer-purpose.json
@@ -5,23 +5,24 @@
   "source": {
     "type": "documentation",
     "canonical_url": "https://developer.hashicorp.com/terraform/language/state/purpose",
-    "title": null,
-    "creators": [],
-    "publisher": null,
+    "title": "Purpose of Terraform State",
+    "creators": ["HashiCorp Terraform documentation contributors"],
+    "publisher": "HashiCorp",
     "published_at": null,
     "event_date": null,
     "version": null,
-    "language": null,
+    "language": "en",
     "duration": null,
-    "date_note": null
+    "date_note": "Living Terraform documentation inspected on 2026-08-27; no standalone publication date is asserted."
   },
   "inspection": {
-    "method": "not inspected",
-    "full_content_used_ephemerally": false,
+    "method": "Direct inspection of the official HashiCorp Purpose of Terraform State page, with the parent State documentation used only to verify storage/locking/security boundaries.",
+    "full_content_used_ephemerally": true,
     "full_content_committed": false,
-    "confidence": "metadata_only",
+    "confidence": "direct",
     "gaps": [
-      "Source content has not been mapped yet."
+      "Backend-specific locking, encryption and HCP Terraform behavior are outside this source-focused mental model.",
+      "State file internals and state surgery commands are intentionally excluded."
     ]
   },
   "prior_knowledge": {
@@ -31,27 +32,80 @@
     "classification_required": true
   },
   "content_map": {
-    "problem": null,
-    "thesis": null,
-    "sections": [],
-    "concepts": [],
-    "mechanisms": [],
-    "tools": [],
-    "examples": [],
-    "claims": [],
-    "evidence": [],
-    "assumptions": [],
-    "limitations": [],
-    "open_questions": []
+    "problem": "A declarative configuration names resource instances, but remote systems expose concrete object identities that Terraform must remember across runs; rediscovering every relationship from provider APIs is incomplete, ambiguous or expensive.",
+    "thesis": "Terraform state is the persistent identity and metadata layer between configuration and real infrastructure: it binds resource instances to remote objects, keeps provider/dependency metadata, caches attributes for planning performance, and gives collaborators one synchronized operational view.",
+    "sections": ["Mapping to the Real World", "Metadata", "Performance", "Syncing"],
+    "concepts": ["Terraform state", "resource identity binding", "state metadata", "state synchronization", "remote state locking"],
+    "mechanisms": [
+      "Record a one-to-one binding between a configured resource instance and the identity of the corresponding remote object.",
+      "Retain metadata such as dependency and provider information that cannot always be reconstructed from the remote API alone.",
+      "Refresh remote attributes before planning by default while retaining cached state to avoid treating every run as full discovery from zero.",
+      "Use shared remote state and locking so collaborators operate against the same mapping and avoid concurrent state mutation."
+    ],
+    "tools": ["terraform plan", "terraform apply", "remote state backend", "state locking"],
+    "examples": [
+      "A configuration address such as aws_instance.foo must continue referring to the same remote instance ID on later runs.",
+      "Two operators changing the same workspace need one synchronized state rather than independent local mappings.",
+      "Large infrastructures benefit from cached attributes because querying every remote object on every run can be slow and rate-limited."
+    ],
+    "claims": [
+      "Terraform requires persistent state because declarative resource addresses alone do not identify the concrete remote objects created in previous runs.",
+      "State stores more than current values: it also keeps metadata needed to manage resources and their provider/dependency relationships.",
+      "State participates in synchronization and planning performance, so team use introduces coordination, locking and secure-storage concerns.",
+      "Declarative configuration and persistent state are complementary responsibilities rather than competing alternatives."
+    ],
+    "evidence": [
+      "Official Purpose page states that the primary purpose of state is mapping resource instances in configuration to remote objects.",
+      "The Metadata section explains that Terraform retains resource dependencies and provider configuration information.",
+      "The Performance and Syncing sections explain cached attributes, refresh behavior, shared remote state and locking."
+    ],
+    "assumptions": [
+      "Terraform remains the authority managing the resource binding recorded in its state.",
+      "A remote object should be bound to only one resource instance within the managed configuration unless an explicit migration/import changes that relationship.",
+      "Collaborating operators can access a shared state backend with appropriate coordination and access controls."
+    ],
+    "limitations": [
+      "State can be stale relative to real infrastructure until refresh/reconciliation occurs.",
+      "Shared state is operationally sensitive because it can contain resource attributes and must be protected and coordinated.",
+      "State does not remove provider/API limits or external changes; it gives Terraform a durable mapping from which to detect and plan around them.",
+      "Caching attributes improves performance but should not be confused with the primary identity-binding purpose of state."
+    ],
+    "open_questions": [
+      "Which backend and locking model is appropriate for a particular team and trust boundary?",
+      "Which state contents are sensitive for a given provider and therefore need stricter access controls?",
+      "How should state ownership be partitioned when one large workspace creates excessive coordination or blast radius?"
+    ]
   },
   "selection": {
     "requested_focus": "Understand why declarative infrastructure still needs state: mapping configuration to remote objects, metadata, synchronization and the operational risks of shared state.",
-    "coherent_core": [],
-    "prerequisites": [],
-    "drop_notes": [],
-    "connections": []
+    "coherent_core": [
+      "Configuration says what resource instance should exist; state remembers which concrete remote object that instance means.",
+      "The mapping is the primary purpose; metadata and cached attributes support future planning and lifecycle operations.",
+      "Because state is persistent shared operational knowledge, collaboration needs one synchronized copy and locking.",
+      "State can become stale or sensitive, so it is not the same thing as ground-truth reality even though Terraform depends on it."
+    ],
+    "prerequisites": ["declarative resource configuration", "remote object identity", "planning versus applying changes"],
+    "drop_notes": [
+      "Do not reduce state to a cache; identity binding is the central responsibility.",
+      "Do not expand into backend/vendor comparison until a concrete collaboration or security requirement exists."
+    ],
+    "connections": [
+      "The model is conceptually adjacent to reconciliation: declared configuration is compared with observed infrastructure, but Terraform state adds persistent identity/metadata required to know which remote objects are under management.",
+      "State locking is coordination around shared mutable operational knowledge, not a general distributed-consensus guarantee."
+    ]
   },
-  "verification_candidates": [],
-  "source_locators": [],
+  "verification_candidates": [
+    {
+      "question": "Which current Terraform backends provide locking and what are their failure semantics?",
+      "reason": "The source establishes why coordination matters but backend-specific implementation changes over time.",
+      "priority": "medium"
+    }
+  ],
+  "source_locators": [
+    {"label": "Identity binding", "locator": "Purpose of Terraform State → Mapping to the Real World"},
+    {"label": "Metadata", "locator": "Purpose of Terraform State → Metadata"},
+    {"label": "Planning performance", "locator": "Purpose of Terraform State → Performance"},
+    {"label": "Shared state and locking", "locator": "Purpose of Terraform State → Syncing"}
+  ],
   "created_at": "2026-08-27"
 }


### PR DESCRIPTION
Continues the 20-source cohort with Terraform's official state-purpose documentation.

The case preserves the key boundary: declarative configuration expresses intent, while state persistently binds resource addresses to concrete remote objects and carries lifecycle metadata/coordination across runs.

Adds:
- directly inspected research bundle;
- review-only source/insight/graph case;
- new `terraform-state`, `resource-identity-binding` and `shared-state-coordination` concepts;
- atomic Knowledge Delta, claim evidence, prerequisite map, reconstruction/transfer prompt and Source Decision;
- no auto-publication.

Source Decision is `explainer_is_enough` for the conceptual model; backend-specific details remain a separate follow-up.