### PR TITLE
research: OpenTelemetry causal telemetry + safe public freeze

### DIFF
--- a/data/case-contracts/opentelemetry-traces.json
+++ b/data/case-contracts/opentelemetry-traces.json
@@ -1,0 +1,168 @@
+{
+  "contract_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-opentelemetry-traces",
+  "insight_id": "opentelemetry-distributed-trace-causality",
+  "knowledge_delta": {
+    "insight_id": "opentelemetry-distributed-trace-causality",
+    "summary": "OpenTelemetry refines the project's broad observability concept into a concrete causal telemetry model: spans share trace identity, context propagation carries correlation across boundaries, and links preserve asynchronous causality without turning telemetry into an authoritative execution ledger.",
+    "items": [
+      {
+        "relationship": "refines",
+        "concept_id": "observability",
+        "label": "Observability",
+        "source_basis": "OpenTelemetry traces assemble distributed operations from spans connected by trace identity, hierarchy, propagated context and causal links.",
+        "prior_basis": "The enterprise-agent case introduced observability only as structured telemetry around consequential execution, without a detailed distributed tracing mechanism.",
+        "interpretation": "The source makes observability operational at the trace layer while preserving the earlier boundary that telemetry is not automatically the authoritative record of business execution.",
+        "evidence_insights": ["enterprise-agents-production-substrate"]
+      },
+      {
+        "relationship": "new",
+        "concept_id": "distributed-trace",
+        "label": "Distributed trace",
+        "source_basis": "Spans sharing a trace ID and parent relationships are assembled into one distributed view of observed work across components.",
+        "prior_basis": "The graph had a broad observability concept but no explicit end-to-end causal trace structure.",
+        "interpretation": "A trace becomes the reusable diagnostic structure for reconstructing an observed distributed path rather than a generic collection of logs.",
+        "evidence_insights": []
+      },
+      {
+        "relationship": "new",
+        "concept_id": "trace-context-propagation",
+        "label": "Trace context propagation",
+        "source_basis": "Trace and span identity are propagated across process/network boundaries so downstream spans can remain correlated with upstream work.",
+        "prior_basis": "No prior graph concept modeled transport of tracing identity across distributed boundaries.",
+        "interpretation": "Propagation is the mechanism that turns local spans into a distributed causal view instead of disconnected component telemetry.",
+        "evidence_insights": []
+      },
+      {
+        "relationship": "new",
+        "concept_id": "span-link",
+        "label": "Span link",
+        "source_basis": "OpenTelemetry links spans when operations are causally associated but do not fit a normal parent-child relationship, especially for asynchronous work.",
+        "prior_basis": "The graph had no tracing-specific representation for asynchronous causal association outside a direct tree hierarchy.",
+        "interpretation": "Links prevent asynchronous work from being forced into misleading synchronous parent-child semantics.",
+        "evidence_insights": []
+      }
+    ],
+    "suppressed_prior_matches": ["controlled-execution", "execution-history", "open-policy-agent", "durable-execution"]
+  },
+  "claim_evidence": {
+    "insight_id": "opentelemetry-distributed-trace-causality",
+    "claims": [
+      {
+        "id": "otel-trace-span-hierarchy",
+        "text": "OpenTelemetry represents a distributed trace as spans correlated by trace identity, with parent relationships used to reconstruct nested observed operations across the traced path.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-opentelemetry-traces-2026", "url": "https://opentelemetry.io/docs/concepts/signals/traces", "locator": "Traces → example trace and shared trace_id / parent_id hierarchy"}
+        ],
+        "note": null
+      },
+      {
+        "id": "otel-context-propagation-correlates-spans",
+        "text": "Trace context propagation carries tracing identity across service or process boundaries so downstream spans can be correlated with the originating distributed operation.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-opentelemetry-traces-2026", "url": "https://opentelemetry.io/docs/concepts/signals/traces", "locator": "Traces → Context Propagation"}
+        ],
+        "note": null
+      },
+      {
+        "id": "otel-span-links-async-causality",
+        "text": "Span links can record causal association between operations when asynchronous work does not fit a normal direct parent-child span relationship.",
+        "impact": "medium",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-opentelemetry-traces-2026", "url": "https://opentelemetry.io/docs/concepts/signals/traces", "locator": "Traces → Span Links"}
+        ],
+        "note": null
+      },
+      {
+        "id": "otel-trace-not-authoritative-ledger",
+        "text": "A distributed trace is diagnostic telemetry for observed causality, not by itself an authoritative ledger proving authorization, complete side effects or durable business-state outcomes.",
+        "impact": "high",
+        "origin": "project_interpretation",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-opentelemetry-traces-2026", "url": "https://opentelemetry.io/docs/concepts/signals/traces", "locator": "Traces → Spans; Span Context; Span Links"},
+          {"kind": "prior_insight", "insight_id": "enterprise-agents-production-substrate", "locator": "Execution history as reconstructable evidence of consequential work"}
+        ],
+        "note": "OpenTelemetry defines telemetry correlation semantics, while the distinction from authoritative execution evidence is project synthesis using the existing controlled-execution/execution-history model."
+      }
+    ]
+  },
+  "prerequisite_map": {
+    "insight_id": "opentelemetry-distributed-trace-causality",
+    "summary": "The first useful tracing model needs three tightly connected concepts: a distributed trace as the overall causal view, spans as its observed work units, and context propagation as the mechanism that preserves correlation across boundaries; span links add asynchronous depth next.",
+    "items": [
+      {
+        "id": "otel-prereq-trace",
+        "label": "Distributed trace",
+        "concept_id": "distributed-trace",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "The trace is the end-to-end structure being reconstructed from distributed telemetry.",
+        "resolution": {"kind": "explained_here", "insight_id": "opentelemetry-distributed-trace-causality", "target": null}
+      },
+      {
+        "id": "otel-prereq-span",
+        "label": "Telemetry span",
+        "concept_id": "telemetry-span",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "A trace is composed from spans, so the unit of observed work must be clear before hierarchy and timing make sense.",
+        "resolution": {"kind": "explained_here", "insight_id": "opentelemetry-distributed-trace-causality", "target": null}
+      },
+      {
+        "id": "otel-prereq-propagation",
+        "label": "Trace context propagation",
+        "concept_id": "trace-context-propagation",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "Without propagation, spans created in downstream processes cannot reliably remain part of the same distributed trace.",
+        "resolution": {"kind": "explained_here", "insight_id": "opentelemetry-distributed-trace-causality", "target": null}
+      },
+      {
+        "id": "otel-prereq-link",
+        "label": "Span link",
+        "concept_id": "span-link",
+        "priority": "learn_next",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "Links become important once queued or asynchronous work no longer fits a direct parent-child lifetime.",
+        "resolution": {"kind": "explained_here", "insight_id": "opentelemetry-distributed-trace-causality", "target": null}
+      }
+    ]
+  },
+  "learning_prompt": {
+    "insight_id": "opentelemetry-distributed-trace-causality",
+    "retention_prompt": "Without looking back, reconstruct how OpenTelemetry tracing follows one distributed operation: define a span, explain how trace and parent identity organize spans, state what context propagation changes at a service boundary, explain when a span link is preferable to direct parenting, and name one thing a successful trace still does not prove.",
+    "answer_key": {"problem_from": "whole_source_map.problem", "mechanism_from": "whole_source_map.thesis", "anchor_concept_ids": ["distributed-trace", "telemetry-span", "trace-context-propagation", "span-link"], "boundary_limitation_index": 0},
+    "transfer_prompt": {
+      "prompt": "A web request calls two services and enqueues a job processed later. Sketch the tracing structure that preserves the synchronous path and the queued causal relationship, then state what this telemetry can reconstruct without claiming it is the authoritative business ledger.",
+      "expected_concept_ids": ["distributed-trace", "trace-context-propagation", "span-link"]
+    }
+  },
+  "source_decision": {
+    "insight_id": "opentelemetry-distributed-trace-causality",
+    "decision": "skim_selected_parts",
+    "rationale": "The explainer is sufficient for the tracing mental model, but the official page is worth opening at three precise sections when implementing or reviewing distributed telemetry: trace hierarchy, context propagation and span links. Those sections preserve the exact correlation semantics without requiring the whole documentation site.",
+    "novelty": {"level": "high", "reason": "The source turns an existing broad observability concept into a concrete distributed causal model and adds new propagation/link semantics."},
+    "source_quality": {"level": "high", "reason": "The primary source is current official OpenTelemetry documentation for the tracing concepts being modeled."},
+    "relevance": {"level": "high", "reason": "Distributed tracing is directly useful for diagnosing cross-service integrations, agents, workflows and asynchronous systems."},
+    "practical_leverage": {"level": "high", "reason": "The model changes instrumentation and incident-analysis decisions by making trace identity, propagation and async causal links explicit."},
+    "compression_loss": {"level": "medium", "reason": "The explainer omits SDK/export/sampling implementation detail that matters when deploying tracing or reasoning about completeness."},
+    "selected_parts": [
+      {"label": "Trace hierarchy", "locator": "Traces → example trace and shared trace_id / parent_id hierarchy", "why": "Shows how spans are correlated into one distributed trace rather than read as isolated events.", "claim_refs": ["otel-trace-span-hierarchy"]},
+      {"label": "Context propagation", "locator": "Traces → Context Propagation", "why": "Defines how trace identity survives service and process boundaries.", "claim_refs": ["otel-context-propagation-correlates-spans"]},
+      {"label": "Span links", "locator": "Traces → Span Links", "why": "Shows the causal-link mechanism for asynchronous work that should not be forced into direct parent-child nesting.", "claim_refs": ["otel-span-links-async-causality"]}
+    ]
+  }
+}

--- a/data/case-patches/opentelemetry-traces.json
+++ b/data/case-patches/opentelemetry-traces.json
@@ -1,0 +1,128 @@
+{
+  "patch_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-opentelemetry-traces",
+  "intake_status": "review",
+  "updated_at": "2026-08-27",
+  "graph_version": "0.4.0",
+  "source": {
+    "id": "src-opentelemetry-traces-2026",
+    "type": "documentation",
+    "title": "Traces",
+    "canonical_url": "https://opentelemetry.io/docs/concepts/signals/traces",
+    "creators": ["OpenTelemetry documentation contributors"],
+    "publisher": "OpenTelemetry / CNCF",
+    "event": null,
+    "published_at": null,
+    "event_date": null,
+    "captured_at": "2026-08-27",
+    "analyzed_at": "2026-08-27",
+    "date_note": "Living OpenTelemetry documentation inspected on 2026-08-27; page reports last modification on 2026-01-14.",
+    "verification": [
+      {"title": "OpenTelemetry Traces", "url": "https://opentelemetry.io/docs/concepts/signals/traces", "accessed_at": "2026-08-27"},
+      {"title": "OpenTelemetry Context propagation", "url": "https://opentelemetry.io/docs/concepts/context-propagation/", "accessed_at": "2026-08-27"}
+    ],
+    "derived_records": ["opentelemetry-distributed-trace-causality"]
+  },
+  "insight": {
+    "id": "opentelemetry-distributed-trace-causality",
+    "source_id": "src-opentelemetry-traces-2026",
+    "slug": "opentelemetry-distributed-trace-causality",
+    "status": "review",
+    "title": "OpenTelemetry traces: reconstruct observed causality, not business truth",
+    "one_liner": "OpenTelemetry correlates timed spans through trace identity, propagated context, hierarchy and links so distributed work can be reconstructed diagnostically across service boundaries.",
+    "why_this_matters": "A trace is more than a list of logs: it carries correlation and causal structure across processes. But that structure is telemetry, not an automatic execution ledger. The distinction matters when observability data is used to debug work versus prove authorization, side effects or durable business outcomes.",
+    "whole_source_map": {
+      "problem": "Distributed operations cross service/process boundaries, making isolated component logs insufficient for reconstructing the observed end-to-end path and causal relationships.",
+      "thesis": "Represent operations as spans, propagate trace/span context across boundaries, assemble parent-child hierarchy under shared trace identity, and use span links for causal relationships that do not fit normal nesting.",
+      "core_topics": ["distributed trace", "span", "trace ID and span ID", "parent-child hierarchy", "context propagation", "span events and attributes", "span links", "producer/consumer async work", "telemetry versus authoritative execution evidence"]
+    },
+    "derived_model": {
+      "problem": "Without propagated correlation, a distributed request fragments into local records whose ordering and relationship must be guessed after failure.",
+      "mechanism": "Each operation emits a span with identity/timing/context; downstream boundaries propagate trace context so new spans join the same trace; parent relationships encode nested work and links associate async causal work across trace/lifetime boundaries.",
+      "result": "Operators can reconstruct an observed causal path across services and async work, while still needing separate system-of-record evidence for authority, completeness and business outcomes."
+    },
+    "coherence_review": {
+      "central_chain": [
+        "A span represents one observed unit of work with timing, identity and metadata.",
+        "Spans sharing a trace ID can be assembled into one distributed trace; parent IDs add nested operation hierarchy.",
+        "Context propagation carries trace identity across process/network boundaries so downstream spans remain correlated.",
+        "Span links encode causal association when asynchronous work does not fit a normal direct parent-child lifetime.",
+        "The resulting trace reconstructs observed telemetry causality, but its completeness and business authority depend on instrumentation/export semantics outside the trace model itself."
+      ],
+      "prerequisites_complete": true,
+      "source_vs_enrichment_clear": true,
+      "open_gaps": [
+        "Sampling/export failure can make a trace incomplete; the conceptual page does not establish authoritative completeness guarantees.",
+        "Business authorization and durable side-effect evidence remain outside OpenTelemetry trace semantics."
+      ],
+      "scores": {"coherence": 5, "prerequisite_completeness": 5, "evidence_confidence": 5, "practical_leverage": 5}
+    },
+    "visual_plan": {
+      "dominant": {
+        "type": "sequence",
+        "title": "Causality survives the service boundary",
+        "nodes": [
+          {"label": "01 · Start", "title": "Root span", "text": "A request begins with a trace ID and root span describing the first observed operation."},
+          {"label": "02 · Propagate", "title": "Carry trace context", "text": "Trace/span context crosses the network boundary with the downstream request."},
+          {"label": "03 · Continue", "title": "Child span", "text": "The downstream service creates a new span in the same trace and records the parent relationship."},
+          {"label": "04 · Decouple", "title": "Async span link", "text": "Queued work that starts later can be causally associated through a link even when direct nesting is inappropriate."}
+        ]
+      },
+      "supporting": ["comparison", "concept_grid", "examples", "limitations", "action_map", "source_map"],
+      "image": {"needed": false, "reason": "The teaching value is in correlation and causal flow across process boundaries, which a sequence shows more precisely than an illustration."}
+    },
+    "concepts": [
+      {"name": "Distributed trace", "depth": "learn", "why_needed": "The trace is the correlated end-to-end telemetry structure assembled from spans across boundaries."},
+      {"name": "Span", "depth": "learn", "why_needed": "A span is the timed unit of observed work from which a trace is constructed."},
+      {"name": "Trace context propagation", "depth": "learn", "why_needed": "Propagation carries trace identity across service/process boundaries so downstream work remains part of the same causal view."},
+      {"name": "Span link", "depth": "learn", "why_needed": "Links express causal association for async operations that do not fit a normal parent-child lifetime."}
+    ],
+    "tool_map": [
+      {"name": "OpenTelemetry SDK", "category": "instrumentation runtime", "why_explore": "Creates and propagates spans in application code once the conceptual trace model is clear.", "url": "https://opentelemetry.io/docs/languages/", "relationship": "Source-native implementation surface for tracing.", "status": "try"},
+      {"name": "OpenTelemetry Collector", "category": "telemetry pipeline", "why_explore": "Receives/processes/exports trace telemetry without making the application depend directly on one backend.", "url": "https://opentelemetry.io/docs/collector/", "relationship": "Source-native telemetry pipeline component.", "status": "learn"}
+    ],
+    "examples": [
+      {"domain": "synchronous request", "scenario": "A frontend calls a catalog service and then a payment service.", "question": "Does propagated trace context let the downstream spans join one hierarchy that explains where latency and failure occurred?"},
+      {"domain": "asynchronous work", "scenario": "A request enqueues a job that is processed minutes later by another consumer.", "question": "Should the later work be represented with a span link rather than pretending it has a normal synchronous parent-child lifetime?"},
+      {"domain": "business execution evidence", "scenario": "A trace shows a successful span for updating a customer record.", "question": "What separate evidence proves who authorized the change, which version actually committed and what the authoritative system now stores?"}
+    ],
+    "limitations": [
+      "Missing instrumentation, sampling or exporter loss can create gaps, so a trace should not automatically be treated as complete execution history.",
+      "Span status and attributes describe telemetry observations; they do not by themselves prove authorization, idempotent side effects or durable business truth.",
+      "Parent-child hierarchy is tree-shaped and cannot represent every async causal relationship; links are required for some producer/consumer flows.",
+      "Trace attributes can carry sensitive or high-cardinality data and need explicit governance rather than indiscriminate capture."
+    ],
+    "action_map": {
+      "use_now": ["When designing observability, distinguish correlation/diagnosis evidence from authoritative business execution evidence.", "For asynchronous boundaries, explicitly decide whether causal association belongs in parent-child context or a span link."],
+      "try": ["Instrument a two-service request, inspect trace/span IDs and parent relationships, then add one queued operation and compare direct parenting with a span-link model."],
+      "learn": ["context propagation", "span links", "sampling", "semantic conventions", "trace-log correlation"],
+      "build": ["A small request + queue demo showing one synchronous trace path and one asynchronously linked follow-up operation."],
+      "watch": ["Sampling/export policy when trace data is used for incident reconstruction rather than only performance analysis."],
+      "ignore_for_now": ["Treating successful spans as a substitute for system-of-record audit or business-state verification."]
+    },
+    "connections": [
+      "observability: OpenTelemetry makes the earlier broad observability concept concrete through distributed causal correlation",
+      "execution-history: related operationally but intentionally different evidence semantics — telemetry reconstruction is not automatically an authoritative ledger"
+    ],
+    "supporting_sources": [
+      {"title": "OpenTelemetry Traces", "url": "https://opentelemetry.io/docs/concepts/signals/traces", "publisher": "OpenTelemetry / CNCF", "purpose": "primary source for spans, trace hierarchy, context, links and span kinds", "accessed_at": "2026-08-27"},
+      {"title": "OpenTelemetry Context propagation", "url": "https://opentelemetry.io/docs/concepts/context-propagation/", "publisher": "OpenTelemetry / CNCF", "purpose": "source-linked depth for how trace context crosses process/network boundaries", "accessed_at": "2026-08-27"}
+    ],
+    "tags": ["opentelemetry", "tracing", "observability", "distributed-systems", "causality", "context-propagation"],
+    "provenance": {"source_linked": true, "source_dates_recorded": true, "full_transcript_stored": false, "analysis_type": "direct official OpenTelemetry documentation analysis with explicit evidence-scope boundary", "reviewed_at": "2026-08-27"}
+  },
+  "graph": {
+    "concepts": [
+      {"id": "observability", "insight_ids": ["opentelemetry-distributed-trace-causality"]},
+      {"id": "distributed-trace", "label": "Distributed trace", "summary": "A correlated telemetry view of distributed work assembled from spans sharing trace identity, hierarchy and causal associations across boundaries.", "domain": "observability", "coverage": "explained", "insight_ids": ["opentelemetry-distributed-trace-causality"], "aliases": ["trace"], "tags": ["tracing", "observability", "distributed-systems"]},
+      {"id": "telemetry-span", "label": "Telemetry span", "summary": "A timed unit of observed work carrying span identity, parent context, attributes, events, links and status within distributed tracing.", "domain": "observability", "coverage": "explained", "insight_ids": ["opentelemetry-distributed-trace-causality"], "aliases": ["span"], "tags": ["tracing", "operation", "telemetry"]},
+      {"id": "trace-context-propagation", "label": "Trace context propagation", "summary": "Serializing and carrying trace/span identity across process and network boundaries so downstream spans can join the same distributed causal view.", "domain": "observability", "coverage": "explained", "insight_ids": ["opentelemetry-distributed-trace-causality"], "aliases": ["distributed context propagation"], "tags": ["context", "propagation", "tracing"]},
+      {"id": "span-link", "label": "Span link", "summary": "A tracing association that records causal relationship between spans when direct parent-child hierarchy is not appropriate, especially for asynchronous work.", "domain": "observability", "coverage": "explained", "insight_ids": ["opentelemetry-distributed-trace-causality"], "aliases": ["trace link"], "tags": ["tracing", "causality", "async"]}
+    ],
+    "relations": [
+      {"id": "rel-distributed-trace-depends-on-telemetry-span", "from": "distributed-trace", "to": "telemetry-span", "type": "depends_on", "rationale": "A distributed trace is assembled from the spans that represent the observed operations in the traced path.", "evidence_insights": ["opentelemetry-distributed-trace-causality"]},
+      {"id": "rel-distributed-trace-depends-on-trace-context-propagation", "from": "distributed-trace", "to": "trace-context-propagation", "type": "depends_on", "rationale": "Distributed service boundaries require trace context to cross processes so downstream spans retain correlation with the original trace.", "evidence_insights": ["opentelemetry-distributed-trace-causality"]},
+      {"id": "rel-span-link-related-to-distributed-trace", "from": "span-link", "to": "distributed-trace", "type": "related_to", "rationale": "Span links preserve causal associations across async operations or trace boundaries where a normal parent-child hierarchy cannot express the relationship cleanly.", "evidence_insights": ["opentelemetry-distributed-trace-causality"]}
+    ]
+  }
+}

--- a/data/research-bundles/intake-2026-08-27-opentelemetry-traces.json
+++ b/data/research-bundles/intake-2026-08-27-opentelemetry-traces.json
@@ -5,139 +5,111 @@
   "source": {
     "type": "documentation",
     "canonical_url": "https://opentelemetry.io/docs/concepts/signals/traces",
-    "title": null,
-    "creators": [],
-    "publisher": null,
+    "title": "Traces",
+    "creators": ["OpenTelemetry documentation contributors"],
+    "publisher": "OpenTelemetry / CNCF",
     "published_at": null,
     "event_date": null,
     "version": null,
-    "language": null,
+    "language": "en",
     "duration": null,
-    "date_note": null
+    "date_note": "Living OpenTelemetry documentation inspected on 2026-08-27. The page reports a last modification on 2026-01-14; no original publication date is asserted."
   },
   "inspection": {
-    "method": "not inspected",
-    "full_content_used_ephemerally": false,
+    "method": "Direct inspection of the official OpenTelemetry Traces page, including trace hierarchy, spans, span context, context propagation, events, links and span kinds.",
+    "full_content_used_ephemerally": true,
     "full_content_committed": false,
-    "confidence": "metadata_only",
+    "confidence": "direct",
     "gaps": [
-      "Source content has not been mapped yet."
+      "Sampling/export-loss guarantees are outside this conceptual page and matter when asking whether a trace is complete evidence.",
+      "Vendor backend storage/query behavior is intentionally excluded."
     ]
   },
   "prior_knowledge": {
     "captured_at": "2026-08-27",
     "query": "Understand traces as a causal model of distributed work: spans, parent/child relationships, context propagation, links and what observability can reconstruct versus what business execution evidence must record separately.",
     "matches": [
-      {
-        "concept_id": "observability",
-        "label": "Observability",
-        "coverage": "introduced",
-        "evidence_insights": [
-          {
-            "id": "enterprise-agents-production-substrate",
-            "status": "published",
-            "title": "Why enterprise AI agents fail after the POC"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "controlled-execution",
-        "label": "Controlled execution",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "enterprise-agents-production-substrate",
-            "status": "published",
-            "title": "Why enterprise AI agents fail after the POC"
-          },
-          {
-            "id": "open-policy-agent-decision-enforcement-model",
-            "status": "review",
-            "title": "Open Policy Agent: separate policy decisions from enforcement"
-          },
-          {
-            "id": "react-reason-act-observe-loop",
-            "status": "review",
-            "title": "ReAct: reason, act, observe — then update the plan"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "execution-history",
-        "label": "Execution history",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "enterprise-agents-production-substrate",
-            "status": "published",
-            "title": "Why enterprise AI agents fail after the POC"
-          },
-          {
-            "id": "temporal-durable-execution-mental-model",
-            "status": "review",
-            "title": "Temporal: the mental model behind durable execution"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "open-policy-agent",
-        "label": "Open Policy Agent (OPA)",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "open-policy-agent-decision-enforcement-model",
-            "status": "review",
-            "title": "Open Policy Agent: separate policy decisions from enforcement"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      },
-      {
-        "concept_id": "durable-execution",
-        "label": "Durable execution",
-        "coverage": "explained",
-        "evidence_insights": [
-          {
-            "id": "enterprise-agents-production-substrate",
-            "status": "published",
-            "title": "Why enterprise AI agents fail after the POC"
-          },
-          {
-            "id": "temporal-durable-execution-mental-model",
-            "status": "review",
-            "title": "Temporal: the mental model behind durable execution"
-          }
-        ],
-        "relationship_to_source": "unclassified"
-      }
+      {"concept_id": "observability", "label": "Observability", "coverage": "introduced", "evidence_insights": [{"id": "enterprise-agents-production-substrate", "status": "published", "title": "Why enterprise AI agents fail after the POC"}], "relationship_to_source": "refinement"},
+      {"concept_id": "controlled-execution", "label": "Controlled execution", "coverage": "explained", "evidence_insights": [{"id": "enterprise-agents-production-substrate", "status": "published", "title": "Why enterprise AI agents fail after the POC"}, {"id": "open-policy-agent-decision-enforcement-model", "status": "review", "title": "Open Policy Agent: separate policy decisions from enforcement"}, {"id": "react-reason-act-observe-loop", "status": "review", "title": "ReAct: reason, act, observe — then update the plan"}], "relationship_to_source": "not_relevant"},
+      {"concept_id": "execution-history", "label": "Execution history", "coverage": "explained", "evidence_insights": [{"id": "enterprise-agents-production-substrate", "status": "published", "title": "Why enterprise AI agents fail after the POC"}, {"id": "temporal-durable-execution-mental-model", "status": "review", "title": "Temporal: the mental model behind durable execution"}], "relationship_to_source": "not_relevant"},
+      {"concept_id": "open-policy-agent", "label": "Open Policy Agent (OPA)", "coverage": "explained", "evidence_insights": [{"id": "open-policy-agent-decision-enforcement-model", "status": "review", "title": "Open Policy Agent: separate policy decisions from enforcement"}], "relationship_to_source": "not_relevant"},
+      {"concept_id": "durable-execution", "label": "Durable execution", "coverage": "explained", "evidence_insights": [{"id": "enterprise-agents-production-substrate", "status": "published", "title": "Why enterprise AI agents fail after the POC"}, {"id": "temporal-durable-execution-mental-model", "status": "review", "title": "Temporal: the mental model behind durable execution"}], "relationship_to_source": "not_relevant"}
     ],
     "classification_required": true
   },
   "content_map": {
-    "problem": null,
-    "thesis": null,
-    "sections": [],
-    "concepts": [],
-    "mechanisms": [],
-    "tools": [],
-    "examples": [],
-    "claims": [],
-    "evidence": [],
-    "assumptions": [],
-    "limitations": [],
-    "open_questions": []
+    "problem": "A request or job crosses process and service boundaries, so isolated logs from individual components do not preserve enough correlation and hierarchy to reconstruct the observed end-to-end path.",
+    "thesis": "Represent each operation as a span carrying trace/span identity and timing, propagate context across boundaries so child operations join the same trace, and use parent relationships or links to encode synchronous hierarchy and asynchronous causal association.",
+    "sections": ["Trace example and hierarchy", "Spans", "Span Context", "Span Events", "Span Links", "Span Kind", "Context Propagation"],
+    "concepts": ["distributed trace", "span", "trace/span context", "context propagation", "parent-child hierarchy", "span link", "telemetry versus execution evidence"],
+    "mechanisms": [
+      "Give spans in one distributed operation a shared trace ID and distinct span IDs.",
+      "Use parent IDs to build nested synchronous/sub-operation hierarchy.",
+      "Serialize and propagate trace context across process/network boundaries so downstream work joins the same causal trace.",
+      "Use span links when operations are causally related but do not fit a normal parent-child lifetime, such as queued asynchronous work.",
+      "Attach attributes/events/status to make observed operations diagnosable."
+    ],
+    "tools": ["OpenTelemetry Tracer", "OpenTelemetry SDK", "OpenTelemetry Collector", "W3C Trace Context propagator"],
+    "examples": [
+      "Frontend → product-service calls share trace context so the backend request becomes a child span of the frontend operation.",
+      "A producer queues work that executes later; a span link preserves causal association even when a direct parent-child lifetime is inappropriate.",
+      "A business write may have a successful trace yet still need separate authoritative evidence of authorization and durable business outcome."
+    ],
+    "claims": [
+      "A trace is assembled from spans correlated by trace identity and hierarchy, potentially across different processes and services.",
+      "Span context is propagated so downstream spans can join the same distributed trace.",
+      "Span links can express causal relationships between operations that are not represented well by ordinary parent-child nesting.",
+      "Trace telemetry is diagnostic observational evidence and should not automatically be treated as a complete authoritative execution ledger."
+    ],
+    "evidence": [
+      "The official Traces page shows spans sharing a trace_id with parent_id hierarchy.",
+      "The page states that Context Propagation lets spans be correlated regardless of where they are generated.",
+      "The Span Links section describes asynchronous operations linked across traces as causally associated."
+    ],
+    "assumptions": [
+      "Instrumentation creates and exports the relevant spans rather than omitting them through missing coverage or sampling.",
+      "Trace context is propagated across the boundaries whose causal path should be reconstructed.",
+      "Span attributes/events are modeled consistently enough for useful diagnostics."
+    ],
+    "limitations": [
+      "A missing span can mean missing instrumentation, sampling/export loss or genuinely absent work; a trace is not automatically a complete record of everything that happened.",
+      "Trace success/status does not prove business authorization, idempotent side effects or persistence in the system of record.",
+      "Parent-child hierarchy is not sufficient for every asynchronous topology; span links exist for causal relationships that cross normal tree boundaries.",
+      "High-cardinality or sensitive attributes still require deliberate telemetry design and governance."
+    ],
+    "open_questions": [
+      "Which business correlation IDs belong as span attributes versus separate durable execution evidence?",
+      "How should sampling be configured when traces are used for incident reconstruction rather than only performance analysis?",
+      "Which async messaging patterns should use links instead of parent-child relationships?"
+    ]
   },
   "selection": {
     "requested_focus": "Understand traces as a causal model of distributed work: spans, parent/child relationships, context propagation, links and what observability can reconstruct versus what business execution evidence must record separately.",
-    "coherent_core": [],
-    "prerequisites": [],
-    "drop_notes": [],
-    "connections": []
+    "coherent_core": [
+      "Spans are timed units of observed work; trace/span identity correlates them.",
+      "Parent IDs encode nested operation hierarchy while propagated context carries that identity across service boundaries.",
+      "Links preserve causal association for async work that is not naturally a direct child lifetime.",
+      "This refines the existing observability concept but does not replace controlled execution or durable business evidence."
+    ],
+    "prerequisites": ["operation/span", "distributed request boundary", "context propagation"],
+    "drop_notes": [
+      "Do not treat OPA, durable execution or controlled execution as trace mechanisms; retrieval overlap is contextual, not source equivalence.",
+      "Do not call traces an authoritative business ledger: coverage/sampling and telemetry semantics differ from system-of-record evidence."
+    ],
+    "connections": [
+      "observability is refined into a concrete causal telemetry model using trace identity, spans and propagation",
+      "execution history remains a separate responsibility when the system must prove authorization, durable side effects and authoritative outcomes"
+    ]
   },
-  "verification_candidates": [],
-  "source_locators": [],
+  "verification_candidates": [
+    {"question": "What completeness guarantees exist under head/tail sampling and exporter failure?", "reason": "The answer determines how strongly traces may be used for incident reconstruction.", "priority": "high"}
+  ],
+  "source_locators": [
+    {"label": "Trace hierarchy", "locator": "Traces → example trace and shared trace_id / parent_id hierarchy"},
+    {"label": "Span fields", "locator": "Traces → Spans"},
+    {"label": "Span context", "locator": "Traces → Span Context"},
+    {"label": "Context propagation", "locator": "Traces → Context Propagation"},
+    {"label": "Async causal links", "locator": "Traces → Span Links"}
+  ],
   "created_at": "2026-08-27"
 }

--- a/scripts/apply_case_patch.py
+++ b/scripts/apply_case_patch.py
@@ -31,6 +31,59 @@ def upsert(items: list[dict], key: str, value: dict) -> None:
     items.append(value)
 
 
+def freeze_public_concept_before_review(
+    existing: dict,
+    patch: dict,
+    status_by_insight: dict[str, str | None],
+) -> None:
+    """Freeze the published projection before review evidence is added.
+
+    Review case patches are forbidden from writing `public` themselves. When an existing
+    concept has only published evidence and a review case adds the first non-published
+    evidence, preserve the pre-review public state explicitly. If the concept already mixes
+    published and non-published support without a curated public projection, fail closed
+    rather than guessing what was safe to expose.
+    """
+    if existing.get("public") is not None:
+        return
+
+    incoming_ids = list(patch.get("insight_ids", []))
+    incoming_review_ids = [
+        insight_id
+        for insight_id in incoming_ids
+        if status_by_insight.get(insight_id) != "published"
+    ]
+    if not incoming_review_ids:
+        return
+
+    existing_ids = list(existing.get("insight_ids", []))
+    published_ids = [
+        insight_id
+        for insight_id in existing_ids
+        if status_by_insight.get(insight_id) == "published"
+    ]
+    non_published_ids = [
+        insight_id
+        for insight_id in existing_ids
+        if status_by_insight.get(insight_id) != "published"
+    ]
+
+    if published_ids and non_published_ids:
+        raise SystemExit(
+            f"concept '{existing.get('id')}' already mixes published and non-published "
+            "evidence without a public projection; curate that projection before adding "
+            "more review evidence"
+        )
+    if not published_ids:
+        return
+
+    existing["public"] = {
+        "summary": existing["summary"],
+        "coverage": existing["coverage"],
+        "evidence_insights": published_ids,
+    }
+
+
 def merge_concept(existing: dict, patch: dict) -> None:
     """Merge a concept patch without deleting evidence/public projection owned by other cases."""
     patch_ids = list(patch.get("insight_ids", []))
@@ -115,6 +168,11 @@ def main() -> int:
 
     upsert(sources.setdefault("sources", []), "id", source)
     upsert(insights.setdefault("insights", []), "id", insight)
+    status_by_insight = {
+        item["id"]: item.get("status")
+        for item in insights.get("insights", [])
+        if isinstance(item, dict) and item.get("id")
+    }
 
     intake["status"] = "review"
     intake["source_id"] = source["id"]
@@ -128,6 +186,7 @@ def main() -> int:
             graph["concepts"].append(concept_patch)
             concept_map[concept_id] = concept_patch
             continue
+        freeze_public_concept_before_review(existing, concept_patch, status_by_insight)
         merge_concept(existing, concept_patch)
 
     relation_map = {item["id"]: item for item in graph.setdefault("relations", [])}


### PR DESCRIPTION
Dogfood cohort case for #40 and source issue #65, rebased onto current main after Twelve-Factor landed.

Adds the preferred OpenTelemetry review case plus one reusable materializer safety fix.

Key boundaries:
- `observability` is refined into a concrete causal trace model (`distributed-trace`, `telemetry-span`, `trace-context-propagation`, `span-link`);
- tracing reconstructs observed causal telemetry, not an authoritative execution ledger;
- controlled execution, execution history, OPA and durable execution remain separate responsibilities;
- when a previously published-only concept receives its first review evidence, the materializer freezes the pre-review public projection automatically;
- if a concept is already mixed published/review without a public projection, materialization still fails closed instead of guessing.

No publication transition.