### PR TITLE
Superseded: explicit public-freeze contract proposal

### DIFF
--- a/scripts/apply_case_patch.py
+++ b/scripts/apply_case_patch.py
@@ -12,6 +12,7 @@ INBOX = ROOT / "data" / "inbox.json"
 SOURCES = ROOT / "data" / "sources.json"
 INSIGHTS = ROOT / "data" / "insights.json"
 GRAPH = ROOT / "data" / "knowledge-graph.json"
+FROZEN_PUBLIC_REFERENCE_KEYS = {"id", "insight_ids", "public"}
 
 
 def load(path: Path) -> dict:
@@ -31,6 +32,30 @@ def upsert(items: list[dict], key: str, value: dict) -> None:
     items.append(value)
 
 
+def validate_public_freeze(existing: dict | None, patch: dict, published_ids: set[str], current_insight_id: str) -> None:
+    if existing is None:
+        raise SystemExit("frozen public projection requires an existing concept")
+    if set(patch) != FROZEN_PUBLIC_REFERENCE_KEYS:
+        raise SystemExit("public projection is only allowed on a reference-only existing concept patch")
+    public = patch.get("public")
+    if not isinstance(public, dict):
+        raise SystemExit("frozen public projection must be an object")
+    existing_public = existing.get("public")
+    if existing_public is not None and existing_public != public:
+        raise SystemExit("review case cannot change an existing public concept projection")
+    if public.get("summary") != existing.get("summary") or public.get("coverage") != existing.get("coverage"):
+        raise SystemExit("review case public projection must freeze existing summary and coverage")
+    evidence = public.get("evidence_insights")
+    if not isinstance(evidence, list) or not evidence:
+        raise SystemExit("review case public projection requires published evidence")
+    if current_insight_id in evidence:
+        raise SystemExit("current review insight cannot enter frozen public projection")
+    if any(item_id not in set(existing.get("insight_ids", [])) for item_id in evidence):
+        raise SystemExit("frozen public evidence must already support the existing concept")
+    if any(item_id not in published_ids for item_id in evidence):
+        raise SystemExit("frozen public evidence must already be published")
+
+
 def merge_concept(existing: dict, patch: dict) -> None:
     """Merge a concept patch without deleting evidence/public projection owned by other cases."""
     patch_ids = list(patch.get("insight_ids", []))
@@ -39,11 +64,18 @@ def merge_concept(existing: dict, patch: dict) -> None:
         if insight_id not in existing_ids:
             existing_ids.append(insight_id)
 
-    if set(patch) <= {"id", "insight_ids"}:
+    public = patch.get("public")
+    if public is not None:
+        existing_public = existing.get("public")
+        if existing_public is not None and existing_public != public:
+            raise SystemExit("review case cannot replace an existing public concept projection")
+        existing["public"] = public
+
+    if set(patch) <= FROZEN_PUBLIC_REFERENCE_KEYS:
         return
 
     for key, value in patch.items():
-        if key in {"id", "insight_ids"}:
+        if key in {"id", "insight_ids", "public"}:
             continue
         existing[key] = value
 
@@ -86,14 +118,11 @@ def main() -> int:
         None,
     )
 
-    # A case patch is a review snapshot. Explicit publication is terminal for this snapshot:
-    # materialization must never silently downgrade it back to review.
     if current_insight is not None and current_insight.get("status") == "published":
         raise SystemExit(
             f"refusing to overwrite published insight '{insight.get('id')}' with a review case patch"
         )
 
-    # Defense in depth: researched case patches can prepare review artifacts, never publish them.
     if patch.get("intake_status") != "review" or insight.get("status") != "review":
         raise SystemExit("case patches are review-only; publication requires a separate reviewed transition")
     if source.get("canonical_url") != intake.get("source_url"):
@@ -106,12 +135,24 @@ def main() -> int:
         raise SystemExit("source.derived_records must contain the current insight id")
 
     graph_patch = patch.get("graph") or {}
-    for concept in graph_patch.get("concepts", []):
-        if "public" in concept:
-            raise SystemExit("review case patches may not mutate public concept projection")
     for relation in graph_patch.get("relations", []):
         if "public" in relation:
             raise SystemExit("review case patches may not mutate public relation projection")
+
+    published_ids = {
+        item.get("id")
+        for item in insights.get("insights", [])
+        if isinstance(item, dict) and item.get("status") == "published"
+    }
+    concept_map = {item["id"]: item for item in graph.setdefault("concepts", [])}
+    for concept_patch in graph_patch.get("concepts", []):
+        if "public" in concept_patch:
+            validate_public_freeze(
+                concept_map.get(concept_patch.get("id")),
+                concept_patch,
+                published_ids,
+                insight["id"],
+            )
 
     upsert(sources.setdefault("sources", []), "id", source)
     upsert(insights.setdefault("insights", []), "id", insight)
@@ -120,7 +161,6 @@ def main() -> int:
     intake["source_id"] = source["id"]
     intake["insight_id"] = insight["id"]
 
-    concept_map = {item["id"]: item for item in graph.setdefault("concepts", [])}
     for concept_patch in graph_patch.get("concepts", []):
         concept_id = concept_patch["id"]
         existing = concept_map.get(concept_id)

--- a/scripts/validate_case_patches.py
+++ b/scripts/validate_case_patches.py
@@ -14,6 +14,8 @@ ROOT = Path(__file__).resolve().parents[1]
 PATCHES = ROOT / "data" / "case-patches"
 INBOX = ROOT / "data" / "inbox.json"
 BUNDLES = ROOT / "data" / "research-bundles"
+GRAPH = ROOT / "data" / "knowledge-graph.json"
+INSIGHTS = ROOT / "data" / "insights.json"
 
 SLUG = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
@@ -21,6 +23,8 @@ COVERAGE = {"introduced", "explained", "applied"}
 RELATION_TYPES = {"depends_on", "enables", "realized_by", "refines", "related_to"}
 FULL_CONCEPT_KEYS = {"id", "label", "summary", "domain", "coverage", "insight_ids", "aliases", "tags"}
 REFERENCE_CONCEPT_KEYS = {"id", "insight_ids"}
+FROZEN_PUBLIC_REFERENCE_KEYS = {"id", "insight_ids", "public"}
+PUBLIC_CONCEPT_KEYS = {"summary", "coverage", "evidence_insights"}
 RELATION_KEYS = {"id", "from", "to", "type", "rationale", "evidence_insights"}
 TOP_KEYS = {"patch_version", "intake_id", "intake_status", "updated_at", "graph_version", "source", "insight", "graph"}
 
@@ -46,10 +50,69 @@ def valid_date(value: object) -> bool:
         return False
 
 
+def validate_frozen_public_reference(
+    concept: dict,
+    existing: dict | None,
+    published_ids: set[str],
+    current_insight_id: object,
+    where: str,
+) -> list[str]:
+    """Validate an explicit public snapshot without letting review content rewrite it.
+
+    A review case may be the first item that turns a previously published-only concept into a
+    mixed published/review concept. At that moment the case is allowed to freeze the existing
+    published summary/coverage and published evidence as an explicit public projection. It may
+    not invent a new public summary, include the review insight, or change an existing override.
+    """
+    errors: list[str] = []
+    if existing is None:
+        return [f"{where}.public: frozen public projection is only allowed for an existing concept"]
+    if set(concept) != FROZEN_PUBLIC_REFERENCE_KEYS:
+        errors.append(f"{where}: public projection is only allowed on a reference-only concept patch")
+        return errors
+
+    override = concept.get("public")
+    if not isinstance(override, dict) or set(override) != PUBLIC_CONCEPT_KEYS:
+        errors.append(f"{where}.public: expected exactly {sorted(PUBLIC_CONCEPT_KEYS)}")
+        return errors
+
+    existing_public = existing.get("public")
+    if existing_public is not None and existing_public != override:
+        errors.append(f"{where}.public: review patch may not change an existing public projection")
+
+    if override.get("summary") != existing.get("summary"):
+        errors.append(f"{where}.public.summary: must freeze the existing pre-review concept summary")
+    if override.get("coverage") != existing.get("coverage"):
+        errors.append(f"{where}.public.coverage: must freeze the existing pre-review concept coverage")
+
+    evidence = override.get("evidence_insights")
+    if not isinstance(evidence, list) or not evidence:
+        errors.append(f"{where}.public.evidence_insights: expected non-empty list")
+        return errors
+    if len(set(evidence)) != len(evidence):
+        errors.append(f"{where}.public.evidence_insights: duplicates are not allowed")
+    existing_links = set(existing.get("insight_ids", []))
+    if any(item_id not in existing_links for item_id in evidence):
+        errors.append(f"{where}.public.evidence_insights: must reference only pre-existing concept evidence")
+    if any(item_id not in published_ids for item_id in evidence):
+        errors.append(f"{where}.public.evidence_insights: all frozen public evidence must already be published")
+    if current_insight_id in evidence:
+        errors.append(f"{where}.public.evidence_insights: current review insight may not enter public projection")
+    return errors
+
+
 def main() -> int:
     errors: list[str] = []
     inbox_data = load(INBOX)
     inbox = {item.get("id"): item for item in inbox_data.get("items", []) if isinstance(item, dict)}
+    current_graph = load(GRAPH)
+    current_concepts = {item.get("id"): item for item in current_graph.get("concepts", []) if isinstance(item, dict)}
+    current_insights = load(INSIGHTS)
+    published_ids = {
+        item.get("id")
+        for item in current_insights.get("insights", [])
+        if isinstance(item, dict) and item.get("status") == "published"
+    }
     files = sorted(PATCHES.glob("*.json")) if PATCHES.exists() else []
 
     for path in files:
@@ -77,7 +140,6 @@ def main() -> int:
         if not valid_date(patch.get("updated_at")):
             errors.append(f"{rel}.updated_at: expected ISO date")
 
-        # Publication is deliberately outside the case-patch contract.
         if patch.get("intake_status") != "review":
             errors.append(f"{rel}.intake_status: must be 'review'; case patches cannot publish")
 
@@ -143,12 +205,12 @@ def main() -> int:
             if not isinstance(concept, dict):
                 errors.append(f"{where}: expected object")
                 continue
-            if "public" in concept:
-                errors.append(f"{where}: review case patches may not mutate public projection")
             keys = set(concept)
-            if keys != REFERENCE_CONCEPT_KEYS and keys != FULL_CONCEPT_KEYS:
+            allowed_keys = {frozenset(REFERENCE_CONCEPT_KEYS), frozenset(FULL_CONCEPT_KEYS), frozenset(FROZEN_PUBLIC_REFERENCE_KEYS)}
+            if frozenset(keys) not in allowed_keys:
                 errors.append(
-                    f"{where}: expected reference-only keys {sorted(REFERENCE_CONCEPT_KEYS)} "
+                    f"{where}: expected reference-only keys {sorted(REFERENCE_CONCEPT_KEYS)}, "
+                    f"frozen-public reference keys {sorted(FROZEN_PUBLIC_REFERENCE_KEYS)}, "
                     f"or full concept keys {sorted(FULL_CONCEPT_KEYS)}"
                 )
             concept_id = concept.get("id")
@@ -163,7 +225,18 @@ def main() -> int:
                 errors.append(f"{where}.insight_ids: must contain current insight id")
             elif len(set(linked)) != len(linked):
                 errors.append(f"{where}.insight_ids: duplicates are not allowed")
-            if keys == FULL_CONCEPT_KEYS:
+
+            if "public" in concept:
+                errors.extend(
+                    validate_frozen_public_reference(
+                        concept,
+                        current_concepts.get(concept_id),
+                        published_ids,
+                        insight_id,
+                        where,
+                    )
+                )
+            elif keys == FULL_CONCEPT_KEYS:
                 if concept.get("coverage") not in COVERAGE:
                     errors.append(f"{where}.coverage: invalid value")
                 if not isinstance(concept.get("summary"), str) or len(concept.get("summary", "").strip()) < 10:
@@ -180,7 +253,7 @@ def main() -> int:
                 errors.append(f"{where}: expected object")
                 continue
             if "public" in relation:
-                errors.append(f"{where}: review case patches may not mutate public projection")
+                errors.append(f"{where}: review case patches may not mutate public relation projection")
             if set(relation) != RELATION_KEYS:
                 errors.append(f"{where}: relation keys must equal {sorted(RELATION_KEYS)}")
             relation_id = relation.get("id")
@@ -200,7 +273,6 @@ def main() -> int:
             if not isinstance(relation.get("rationale"), str) or len(relation.get("rationale", "").strip()) < 10:
                 errors.append(f"{where}.rationale: expected meaningful explanation")
 
-        # A review patch cannot bypass the prior-knowledge classification gate.
         bundle_path = BUNDLES / f"{intake_id}.json"
         if bundle_path.exists():
             try:


### PR DESCRIPTION
Superseded by main commit `48b6ab4`, which implemented the same safety invariant directly in `apply_case_patch.py`: when the first review evidence is added to a published-only concept, the pre-review summary/coverage and published evidence IDs are frozen; already-mixed concepts without a curated projection fail closed. OpenTelemetry then materialized successfully. Keeping this alternative validator/API contract out avoids duplicate mechanisms.