### PR TITLE
research: complete cohort with Google SRE monitoring model

### DIFF
--- a/data/case-contracts/sre-monitoring.json
+++ b/data/case-contracts/sre-monitoring.json
@@ -1,0 +1,195 @@
+{
+  "contract_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-sre-monitoring-distributed-systems",
+  "insight_id": "sre-symptom-cause-actionable-monitoring",
+  "knowledge_delta": {
+    "insight_id": "sre-symptom-cause-actionable-monitoring",
+    "summary": "Google SRE further refines observability from causal telemetry into operator decision semantics: separate symptoms from causes, combine external and internal views, and page only when a condition deserves urgent human action.",
+    "items": [
+      {
+        "relationship": "refines",
+        "concept_id": "observability",
+        "label": "Observability",
+        "source_basis": "The chapter defines monitoring as a system for answering what is broken and why, and distinguishes black-box symptoms, white-box diagnosis and human alerting decisions.",
+        "prior_basis": "The enterprise-agent case introduced observability broadly, and the OpenTelemetry case refined it into causal distributed trace telemetry.",
+        "interpretation": "This source adds the operator-facing layer: useful telemetry must support symptom detection, causal diagnosis and an explicit action/noise decision rather than merely exist.",
+        "evidence_insights": ["enterprise-agents-production-substrate", "opentelemetry-distributed-trace-causality"]
+      },
+      {
+        "relationship": "new",
+        "concept_id": "symptom-cause-monitoring",
+        "label": "Symptom/cause monitoring",
+        "source_basis": "The chapter says monitoring should answer what is broken (symptom) and why (cause) as separate questions.",
+        "prior_basis": "The graph contained telemetry and tracing concepts but no operator model separating detection from diagnosis.",
+        "interpretation": "This becomes the central monitoring review test: which signal proves user impact and which signal explains the likely cause?",
+        "evidence_insights": []
+      },
+      {
+        "relationship": "new",
+        "concept_id": "black-box-monitoring",
+        "label": "Black-box monitoring",
+        "source_basis": "Google SRE defines black-box monitoring as externally visible behavior and emphasizes its symptom-oriented paging value.",
+        "prior_basis": "No prior concept represented a user-perspective external probe as a distinct monitoring responsibility.",
+        "interpretation": "Black-box evidence becomes the strongest default basis for paging active user-visible failure without coupling the alert to one internal implementation cause.",
+        "evidence_insights": []
+      },
+      {
+        "relationship": "new",
+        "concept_id": "actionable-alerting",
+        "label": "Actionable alerting",
+        "source_basis": "The chapter repeatedly ties pages to urgent human response, warns about alert fatigue, and says every page should be actionable.",
+        "prior_basis": "The graph had observability signals but no concept for deciding when telemetry should interrupt a human.",
+        "interpretation": "Alerting becomes a decision interface with a high signal/noise bar rather than a direct consequence of collecting an anomalous metric.",
+        "evidence_insights": []
+      }
+    ],
+    "suppressed_prior_matches": []
+  },
+  "claim_evidence": {
+    "insight_id": "sre-symptom-cause-actionable-monitoring",
+    "claims": [
+      {
+        "id": "sre-monitoring-what-and-why",
+        "text": "Google SRE frames effective monitoring around two distinct questions: what is broken for the service and why that symptom is occurring.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-google-sre-monitoring-distributed-systems-2016", "url": "https://sre.google/sre-book/monitoring-distributed-systems", "locator": "Symptoms Versus Causes"}
+        ],
+        "note": null
+      },
+      {
+        "id": "sre-black-white-complement",
+        "text": "Black-box monitoring focuses on externally visible symptoms while white-box monitoring uses internal instrumentation for diagnosis and for imminent or retry-masked failures.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-google-sre-monitoring-distributed-systems-2016", "url": "https://sre.google/sre-book/monitoring-distributed-systems", "locator": "Black-Box Versus White-Box"}
+        ],
+        "note": null
+      },
+      {
+        "id": "sre-pages-actionable-high-signal",
+        "text": "Human paging should be reserved for clear urgent conditions that require meaningful action because frequent noisy pages degrade attention and can hide real incidents.",
+        "impact": "high",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-google-sre-monitoring-distributed-systems-2016", "url": "https://sre.google/sre-book/monitoring-distributed-systems", "locator": "Why Monitor?; Tying These Principles Together"}
+        ],
+        "note": null
+      },
+      {
+        "id": "sre-four-golden-signals",
+        "text": "The chapter recommends latency, traffic, errors and saturation as four core signals for baseline monitoring of a user-facing service.",
+        "impact": "medium",
+        "origin": "source",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-google-sre-monitoring-distributed-systems-2016", "url": "https://sre.google/sre-book/monitoring-distributed-systems", "locator": "The Four Golden Signals"}
+        ],
+        "note": null
+      },
+      {
+        "id": "sre-observability-needs-decision-semantics",
+        "text": "Telemetry becomes operationally useful only when it is connected to a symptom, diagnostic question or human decision instead of being promoted to alerting merely because it is available.",
+        "impact": "high",
+        "origin": "project_interpretation",
+        "status": "supported",
+        "evidence": [
+          {"kind": "primary_source", "source_id": "src-google-sre-monitoring-distributed-systems-2016", "url": "https://sre.google/sre-book/monitoring-distributed-systems", "locator": "As Simple as Possible, No Simpler; Tying These Principles Together"},
+          {"kind": "prior_insight", "insight_id": "opentelemetry-distributed-trace-causality", "locator": "Distributed traces as causal observability telemetry"}
+        ],
+        "note": "This wording is the project's synthesis connecting the SRE chapter's signal/noise/action guidance to the prior OpenTelemetry observability refinement."
+      }
+    ]
+  },
+  "prerequisite_map": {
+    "insight_id": "sre-symptom-cause-actionable-monitoring",
+    "summary": "The chapter builds on an existing observability idea, then adds a compact operator model: symptom versus cause, external versus internal views, and an explicit actionability threshold for paging.",
+    "items": [
+      {
+        "id": "sre-prereq-observability",
+        "label": "Observability",
+        "concept_id": "observability",
+        "priority": "must_know_now",
+        "prior_coverage": "partial",
+        "state": "known_in_graph",
+        "reason": "The chapter is not about whether telemetry exists, but about how existing telemetry should support detection, diagnosis and operator decisions.",
+        "resolution": {"kind": "existing_concept", "insight_id": null, "target": "observability"}
+      },
+      {
+        "id": "sre-prereq-symptom-cause",
+        "label": "Symptom/cause monitoring",
+        "concept_id": "symptom-cause-monitoring",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "Separating what users experience from why it happens is the central structure for reducing alert noise and improving diagnosis.",
+        "resolution": {"kind": "explained_here", "insight_id": "sre-symptom-cause-actionable-monitoring", "target": null}
+      },
+      {
+        "id": "sre-prereq-black-box",
+        "label": "Black-box monitoring",
+        "concept_id": "black-box-monitoring",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "User-perspective external signals explain why current symptoms are a disciplined default basis for human paging.",
+        "resolution": {"kind": "explained_here", "insight_id": "sre-symptom-cause-actionable-monitoring", "target": null}
+      },
+      {
+        "id": "sre-prereq-white-box",
+        "label": "White-box monitoring",
+        "concept_id": "white-box-monitoring",
+        "priority": "learn_next",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "Internal instrumentation is required to diagnose causes and catch conditions that black-box symptom probes cannot yet see.",
+        "resolution": {"kind": "explained_here", "insight_id": "sre-symptom-cause-actionable-monitoring", "target": null}
+      },
+      {
+        "id": "sre-prereq-actionable-alerting",
+        "label": "Actionable alerting",
+        "concept_id": "actionable-alerting",
+        "priority": "must_know_now",
+        "prior_coverage": "absent",
+        "state": "explained_here",
+        "reason": "The monitoring model is incomplete unless it explains when a signal is important enough to interrupt a human and require urgent judgment.",
+        "resolution": {"kind": "explained_here", "insight_id": "sre-symptom-cause-actionable-monitoring", "target": null}
+      }
+    ]
+  },
+  "learning_prompt": {
+    "insight_id": "sre-symptom-cause-actionable-monitoring",
+    "retention_prompt": "Without looking back, reconstruct the Google SRE monitoring model: distinguish symptom from cause, explain black-box versus white-box roles, name the four golden signals, and state the test that should be satisfied before telemetry is allowed to interrupt a human through a page.",
+    "answer_key": {
+      "problem_from": "whole_source_map.problem",
+      "mechanism_from": "whole_source_map.thesis",
+      "anchor_concept_ids": ["symptom-cause-monitoring", "black-box-monitoring", "white-box-monitoring", "actionable-alerting"],
+      "boundary_limitation_index": 1
+    },
+    "transfer_prompt": {
+      "prompt": "A cross-system customer process has hundreds of internal metrics but operators miss real failures among noisy alerts. Redesign the monitoring boundary: identify one black-box symptom, the white-box signals that help diagnose it, and the exact condition that deserves a human page.",
+      "expected_concept_ids": ["symptom-cause-monitoring", "black-box-monitoring", "white-box-monitoring", "actionable-alerting"]
+    }
+  },
+  "source_decision": {
+    "insight_id": "sre-symptom-cause-actionable-monitoring",
+    "decision": "skim_selected_parts",
+    "rationale": "The explainer preserves the monitoring philosophy, but the original chapter is worth a targeted skim for its concrete symptom/cause examples, black-box/white-box distinction, golden-signal definitions and page-action questions. The long historical case studies are optional for the current mental model.",
+    "novelty": {"level": "high", "reason": "The source adds operator decision semantics on top of existing observability and tracing concepts rather than repeating telemetry mechanics."},
+    "source_quality": {"level": "high", "reason": "This is the original Google SRE chapter authored from production operations practice and hosted on the official SRE site."},
+    "relevance": {"level": "high", "reason": "The model directly applies to cross-system monitoring, incident detection and reducing noisy enterprise support operations."},
+    "practical_leverage": {"level": "high", "reason": "The symptom/cause/action framework can immediately change alert rules, dashboards and escalation design."},
+    "compression_loss": {"level": "medium", "reason": "The causal model compresses well, but concrete examples and alert-review questions add useful judgment when applying it to real monitoring."},
+    "selected_parts": [
+      {"label": "Symptom versus cause", "locator": "Symptoms Versus Causes", "why": "Establishes the what-is-broken versus why distinction that structures the rest of monitoring design.", "claim_refs": ["sre-monitoring-what-and-why"]},
+      {"label": "Black-box versus white-box", "locator": "Black-Box Versus White-Box", "why": "Shows why user-visible symptom detection and internal diagnosis need complementary monitoring views.", "claim_refs": ["sre-black-white-complement"]},
+      {"label": "Actionable paging", "locator": "Why Monitor?; Tying These Principles Together", "why": "Makes the human-cost, urgency and actionability threshold for paging explicit.", "claim_refs": ["sre-pages-actionable-high-signal"]},
+      {"label": "Four golden signals", "locator": "The Four Golden Signals", "why": "Provides a compact service-level coverage baseline without turning every internal metric into a page.", "claim_refs": ["sre-four-golden-signals"]}
+    ]
+  }
+}

--- a/data/case-patches/sre-monitoring.json
+++ b/data/case-patches/sre-monitoring.json
@@ -1,0 +1,132 @@
+{
+  "patch_version": "1.0.0",
+  "intake_id": "intake-2026-08-27-sre-monitoring-distributed-systems",
+  "intake_status": "review",
+  "updated_at": "2026-08-27",
+  "graph_version": "0.4.0",
+  "source": {
+    "id": "src-google-sre-monitoring-distributed-systems-2016",
+    "type": "article",
+    "title": "Monitoring Distributed Systems",
+    "canonical_url": "https://sre.google/sre-book/monitoring-distributed-systems",
+    "creators": ["Rob Ewaschuk"],
+    "publisher": "Google Site Reliability Engineering",
+    "event": null,
+    "published_at": null,
+    "event_date": null,
+    "captured_at": "2026-08-27",
+    "analyzed_at": "2026-08-27",
+    "date_note": "Chapter 6 of Site Reliability Engineering (2016), written by Rob Ewaschuk and edited by Betsy Beyer; exact publication day is not asserted.",
+    "verification": [],
+    "derived_records": ["sre-symptom-cause-actionable-monitoring"]
+  },
+  "insight": {
+    "id": "sre-symptom-cause-actionable-monitoring",
+    "source_id": "src-google-sre-monitoring-distributed-systems-2016",
+    "slug": "sre-symptom-cause-actionable-monitoring",
+    "status": "review",
+    "title": "Google SRE monitoring: page on symptoms, diagnose with causes",
+    "one_liner": "Useful monitoring separates what users experience from why it happens, combines black-box symptoms with white-box diagnosis, and treats every human page as an expensive actionable decision interface.",
+    "why_this_matters": "The source turns observability from a telemetry collection problem into an operator-decision problem: what should interrupt a human, which signal explains the symptom, and which metrics belong in a dashboard rather than a pager.",
+    "whole_source_map": {
+      "problem": "A monitoring stack can collect large volumes of internal telemetry yet still fail operators when it cannot separate user-visible symptoms from causes or when noisy alerts interrupt humans without a clear action.",
+      "thesis": "Design monitoring around symptom/cause questions, combine black-box and white-box perspectives, cover core service behavior with a small signal set, and reserve pages for urgent actionable conditions with high signal and low noise.",
+      "core_topics": [
+        "symptoms versus causes",
+        "black-box monitoring",
+        "white-box monitoring",
+        "actionable paging",
+        "four golden signals",
+        "simple high-signal alerting"
+      ]
+    },
+    "derived_model": {
+      "problem": "Telemetry volume is not operational usefulness: operators need to know whether users are affected, why, and what human action is required now.",
+      "mechanism": "Use black-box signals for active user-visible symptoms, white-box signals for internal diagnosis or imminent problems, keep service coverage centered on latency/traffic/errors/saturation, and promote a condition to paging only when it is urgent and actionable.",
+      "result": "Monitoring becomes a decision-support system with lower alert noise, faster symptom-to-cause reasoning and clearer separation between paging, dashboards and retrospective debugging."
+    },
+    "coherence_review": {
+      "central_chain": [
+        "Monitoring must answer what is broken and why rather than only expose raw metrics.",
+        "Black-box monitoring observes externally visible symptoms and is a strong basis for paging active user impact.",
+        "White-box monitoring exposes internal state needed to diagnose causes and detect imminent or retry-masked problems.",
+        "Latency, traffic, errors and saturation provide a compact service-level coverage baseline.",
+        "A pager rule is justified only when it represents an urgent actionable failure with enough signal to deserve human interruption."
+      ],
+      "prerequisites_complete": true,
+      "source_vs_enrichment_clear": true,
+      "open_gaps": [
+        "Later SRE practice adds more SLO/error-budget based alerting techniques that are outside this 2016 chapter.",
+        "The source does not prescribe one monitoring vendor or telemetry storage architecture."
+      ],
+      "scores": {"coherence": 5, "prerequisite_completeness": 5, "evidence_confidence": 5, "practical_leverage": 5}
+    },
+    "visual_plan": {
+      "dominant": {
+        "type": "comparison",
+        "title": "Symptom detection and diagnosis need different views",
+        "nodes": [
+          {"label": "BLACK BOX", "title": "What users see", "text": "Externally visible behavior tells you that a real symptom is happening now and disciplines paging toward user impact."},
+          {"label": "WHITE BOX", "title": "Why it happens", "text": "Internal metrics, logs and instrumentation expose causes, imminent failures and problems hidden by retries."}
+        ]
+      },
+      "supporting": ["sequence", "concept_grid", "examples", "limitations", "action_map", "source_map"],
+      "image": {"needed": false, "reason": "The main learning is a two-view operational decision boundary; a black-box/white-box comparison is more precise than decorative imagery."}
+    },
+    "concepts": [
+      {"name": "Symptom/cause monitoring", "depth": "learn", "why_needed": "Monitoring should distinguish what is broken from why it is broken so detection and diagnosis do not become one noisy rule set."},
+      {"name": "Black-box monitoring", "depth": "learn", "why_needed": "External behavior is the strongest evidence that users are currently experiencing a symptom."},
+      {"name": "White-box monitoring", "depth": "learn", "why_needed": "Internal telemetry supplies diagnostic causes and early warning that external probes alone cannot provide."},
+      {"name": "Actionable alerting", "depth": "learn", "why_needed": "A page is a human interruption and should correspond to an urgent condition requiring judgment or action."}
+    ],
+    "tool_map": [],
+    "examples": [
+      {"domain": "web service", "scenario": "Users receive HTTP 500 responses while database connection errors rise internally.", "question": "Which signal should page on the symptom, and which white-box evidence helps isolate the cause?"},
+      {"domain": "cross-system business flow", "scenario": "A workflow retries successfully but internal latency and queue depth are rising toward saturation.", "question": "What belongs in white-box early-warning monitoring versus a page that claims current user impact?"},
+      {"domain": "alert review", "scenario": "A pager fires several times per day and the response is always the same script.", "question": "Should this stay a human page, become automation, or be demoted to non-paging monitoring?"}
+    ],
+    "limitations": [
+      "Black-box monitoring is strong for active symptoms but may miss imminent failures before users are affected.",
+      "White-box monitoring can explain causes but becomes noisy when internal anomalies are promoted directly to pages without user-impact or action semantics.",
+      "The four golden signals are a starting point for user-facing services, not a complete domain-specific monitoring specification.",
+      "Monitoring and alerting do not replace durable business evidence, incident response or root-cause remediation."
+    ],
+    "action_map": {
+      "use_now": [
+        "Review every current pager rule by asking what user-visible symptom it represents and what human action is expected.",
+        "Separate dashboards/diagnostic telemetry from page-worthy conditions instead of treating every collected metric as an alert candidate."
+      ],
+      "try": [
+        "Take one service or business process and map its black-box symptom, likely white-box causes, four golden signals and the exact threshold for waking a human."
+      ],
+      "learn": ["four golden signals", "SLO-based alerting", "alert fatigue", "symptom versus cause modeling"],
+      "build": ["A monitoring review checklist that scores each alert for user visibility, urgency, actionability and duplicate/noise risk."],
+      "watch": ["Where modern SLO burn-rate alerting improves on simple threshold-based paging while preserving the same actionability principle."],
+      "ignore_for_now": ["Adding more telemetry dimensions before existing pages have a clear symptom, owner and action."]
+    },
+    "connections": [
+      "observability: refined from collecting/reconstructing telemetry into an operator-facing symptom/cause/action model",
+      "OpenTelemetry distributed tracing: one important white-box diagnostic signal, but the tracing model does not decide when a human should be paged"
+    ],
+    "supporting_sources": [
+      {"title": "Monitoring Distributed Systems", "url": "https://sre.google/sre-book/monitoring-distributed-systems", "publisher": "Google Site Reliability Engineering", "purpose": "primary source for symptom/cause, black-box/white-box, golden signals and actionable paging principles", "accessed_at": "2026-08-27"}
+    ],
+    "tags": ["sre", "monitoring", "observability", "alerting", "reliability", "operations"],
+    "provenance": {"source_linked": true, "source_dates_recorded": true, "full_transcript_stored": false, "analysis_type": "direct official Google SRE chapter analysis focused on operator decision semantics", "reviewed_at": "2026-08-27"}
+  },
+  "graph": {
+    "concepts": [
+      {"id": "observability", "insight_ids": ["sre-symptom-cause-actionable-monitoring"]},
+      {"id": "symptom-cause-monitoring", "label": "Symptom/cause monitoring", "summary": "Structuring monitoring so externally meaningful symptoms answer what is broken while internal evidence helps explain why it is broken.", "domain": "site reliability engineering", "coverage": "explained", "insight_ids": ["sre-symptom-cause-actionable-monitoring"], "aliases": ["what-versus-why monitoring"], "tags": ["monitoring", "diagnosis", "signal"]},
+      {"id": "black-box-monitoring", "label": "Black-box monitoring", "summary": "Testing externally visible service behavior from the user perspective to detect active symptoms without depending on internal implementation details.", "domain": "site reliability engineering", "coverage": "explained", "insight_ids": ["sre-symptom-cause-actionable-monitoring"], "aliases": ["external symptom monitoring"], "tags": ["monitoring", "symptoms", "user-impact"]},
+      {"id": "white-box-monitoring", "label": "White-box monitoring", "summary": "Using internal metrics, logs, instrumentation or interfaces to diagnose causes and detect internal or imminent failure conditions.", "domain": "site reliability engineering", "coverage": "explained", "insight_ids": ["sre-symptom-cause-actionable-monitoring"], "aliases": ["internal instrumentation monitoring"], "tags": ["monitoring", "telemetry", "diagnosis"]},
+      {"id": "actionable-alerting", "label": "Actionable alerting", "summary": "Interrupting a human only for a clear urgent condition that requires meaningful action or judgment, while keeping signal high and noise low.", "domain": "site reliability engineering", "coverage": "explained", "insight_ids": ["sre-symptom-cause-actionable-monitoring"], "aliases": ["high-signal paging"], "tags": ["alerting", "paging", "operations"]}
+    ],
+    "relations": [
+      {"id": "rel-symptom-cause-monitoring-refines-observability", "from": "symptom-cause-monitoring", "to": "observability", "type": "refines", "rationale": "The SRE model makes broad observability operational by separating user-visible symptoms, diagnostic causes and the decisions that monitoring should support.", "evidence_insights": ["sre-symptom-cause-actionable-monitoring"]},
+      {"id": "rel-black-box-monitoring-related-to-symptom-cause-monitoring", "from": "black-box-monitoring", "to": "symptom-cause-monitoring", "type": "related_to", "rationale": "Black-box monitoring supplies symptom-oriented evidence about externally visible service behavior.", "evidence_insights": ["sre-symptom-cause-actionable-monitoring"]},
+      {"id": "rel-white-box-monitoring-related-to-symptom-cause-monitoring", "from": "white-box-monitoring", "to": "symptom-cause-monitoring", "type": "related_to", "rationale": "White-box monitoring supplies internal evidence used to explain causes or detect imminent problems behind service symptoms.", "evidence_insights": ["sre-symptom-cause-actionable-monitoring"]},
+      {"id": "rel-actionable-alerting-depends-on-symptom-cause-monitoring", "from": "actionable-alerting", "to": "symptom-cause-monitoring", "type": "depends_on", "rationale": "A high-signal page needs a clear symptom or imminent failure and enough context to justify a specific urgent human action instead of reacting to arbitrary telemetry anomalies.", "evidence_insights": ["sre-symptom-cause-actionable-monitoring"]}
+    ]
+  }
+}

--- a/data/research-bundles/intake-2026-08-27-sre-monitoring-distributed-systems.json
+++ b/data/research-bundles/intake-2026-08-27-sre-monitoring-distributed-systems.json
@@ -1,57 +1,135 @@
 {
   "bundle_version": "1.1.0",
   "intake_id": "intake-2026-08-27-sre-monitoring-distributed-systems",
-  "source_id": null,
+  "source_id": "src-google-sre-monitoring-distributed-systems-2016",
   "source": {
     "type": "article",
     "canonical_url": "https://sre.google/sre-book/monitoring-distributed-systems",
-    "title": null,
-    "creators": [],
-    "publisher": null,
+    "title": "Monitoring Distributed Systems",
+    "creators": ["Rob Ewaschuk"],
+    "publisher": "Google Site Reliability Engineering",
     "published_at": null,
     "event_date": null,
-    "version": null,
-    "language": null,
+    "version": "Site Reliability Engineering, Chapter 6",
+    "language": "en",
     "duration": null,
-    "date_note": null
+    "date_note": "Chapter 6 of Site Reliability Engineering (2016), written by Rob Ewaschuk and edited by Betsy Beyer; exact chapter publication day is not asserted."
   },
   "inspection": {
-    "method": "not inspected",
-    "full_content_used_ephemerally": false,
+    "method": "Direct inspection of the official Google SRE chapter, including Why Monitor?, Symptoms Versus Causes, Black-Box Versus White-Box, The Four Golden Signals, simplicity guidance and Tying These Principles Together.",
+    "full_content_used_ephemerally": true,
     "full_content_committed": false,
-    "confidence": "metadata_only",
+    "confidence": "direct",
     "gaps": [
-      "Source content has not been mapped yet."
+      "This case preserves monitoring/alerting decision principles, not Google-specific monitoring-system implementation details.",
+      "SLO/error-budget alerting practices evolved further in later SRE material and are outside this source-focused model."
     ]
   },
   "prior_knowledge": {
     "captured_at": "2026-08-27",
     "query": "Understand what monitoring should tell operators, the difference between black-box and white-box signals, alerting boundaries and how to avoid turning telemetry volume into operational noise.",
-    "matches": [],
+    "matches": [
+      {
+        "concept_id": "observability",
+        "label": "Observability",
+        "coverage": "introduced",
+        "evidence_insights": [
+          {"id": "enterprise-agents-production-substrate", "status": "published", "title": "Why enterprise AI agents fail after the POC"},
+          {"id": "opentelemetry-distributed-trace-causality", "status": "review", "title": "OpenTelemetry traces: reconstruct observed causality, not business truth"}
+        ],
+        "relationship_to_source": "refinement"
+      }
+    ],
     "classification_required": true
   },
   "content_map": {
-    "problem": null,
-    "thesis": null,
-    "sections": [],
-    "concepts": [],
-    "mechanisms": [],
-    "tools": [],
-    "examples": [],
-    "claims": [],
-    "evidence": [],
-    "assumptions": [],
-    "limitations": [],
-    "open_questions": []
+    "problem": "Monitoring can collect enormous amounts of telemetry while still failing operators if it cannot distinguish user-visible symptoms from internal causes or if it pages humans on noisy, non-actionable conditions.",
+    "thesis": "Design monitoring around operator questions and human action: detect symptoms and causes separately, combine black-box and white-box views, focus on a small set of service signals, and reserve paging for urgent actionable conditions with high signal and low noise.",
+    "sections": [
+      "Definitions and Why Monitor?",
+      "Setting Reasonable Expectations for Monitoring",
+      "Symptoms Versus Causes",
+      "Black-Box Versus White-Box",
+      "The Four Golden Signals",
+      "As Simple as Possible, No Simpler",
+      "Tying These Principles Together"
+    ],
+    "concepts": [
+      "symptom versus cause monitoring",
+      "black-box monitoring",
+      "white-box monitoring",
+      "actionable alerting",
+      "four golden signals",
+      "signal-to-noise discipline"
+    ],
+    "mechanisms": [
+      "Use symptom-oriented external checks to answer what is broken from the user's perspective.",
+      "Use internal white-box telemetry to diagnose why a symptom exists and to detect imminent or masked failures.",
+      "Keep pager rules simple and tied to clear failures or imminent user impact.",
+      "Use latency, traffic, errors and saturation as a compact default coverage model for user-facing services.",
+      "Remove or demote monitoring signals that create human interruption without a useful decision/action."
+    ],
+    "tools": ["black-box probes", "white-box metrics/logs", "dashboards", "pager/ticket alerting"],
+    "examples": [
+      "HTTP 500s are a symptom while database connection refusal may be an underlying cause.",
+      "A user-visible black-box probe can page on an active outage while white-box metrics help identify database/network causes.",
+      "High page volume can hide a real incident in alert noise and consume engineering time without improving reliability."
+    ],
+    "claims": [
+      "Monitoring should answer both what is broken and why.",
+      "Black-box monitoring is primarily symptom-oriented while white-box monitoring exposes internal signals useful for diagnosis and imminent problems.",
+      "Pages should be urgent and actionable because frequent noisy pages degrade attention and reliability response.",
+      "Latency, traffic, errors and saturation form a compact set of golden signals for user-facing service monitoring."
+    ],
+    "evidence": [
+      "The chapter explicitly names what-is-broken versus why as the symptom/cause distinction.",
+      "The black-box/white-box section describes black-box as symptom-oriented and white-box as internal instrumentation.",
+      "Why Monitor? and the concluding alert questions connect pages to human action and warn about alert fatigue.",
+      "The Four Golden Signals section names latency, traffic, errors and saturation."
+    ],
+    "assumptions": [
+      "The monitoring system can measure at least some user-visible behavior and relevant internal state.",
+      "A human page is expensive and should be reserved for conditions requiring prompt human judgment/action.",
+      "Service-specific signals may supplement or refine the four golden signals."
+    ],
+    "limitations": [
+      "Black-box monitoring detects active user-visible symptoms well but is weak for some imminent failures.",
+      "White-box monitoring can explain causes but can generate huge noisy telemetry volumes if every internal anomaly becomes an alert.",
+      "The four golden signals are a starting coverage model, not a complete domain-specific monitoring specification.",
+      "Monitoring/alerting does not automatically repair root causes or replace incident-response and system-of-record evidence."
+    ],
+    "open_questions": [
+      "Which current alerts have no meaningful human action and should be removed, automated or demoted to dashboards?",
+      "Which business-level black-box symptoms should complement infrastructure white-box signals for cross-system workflows?"
+    ]
   },
   "selection": {
     "requested_focus": "Understand what monitoring should tell operators, the difference between black-box and white-box signals, alerting boundaries and how to avoid turning telemetry volume into operational noise.",
-    "coherent_core": [],
-    "prerequisites": [],
-    "drop_notes": [],
-    "connections": []
+    "coherent_core": [
+      "Monitoring is useful when it answers what is broken and why, not when it merely collects data.",
+      "Black-box and white-box monitoring are complementary: symptom detection versus internal diagnosis/imminent-risk visibility.",
+      "Paging is a human-decision interface and therefore needs high signal, low noise and a clear action.",
+      "The four golden signals give a compact service-level starting point without requiring every internal metric to become an alert."
+    ],
+    "prerequisites": ["observability as system telemetry", "user-visible service behavior", "human paging cost"],
+    "drop_notes": [
+      "Do not turn the source into a monitoring-vendor/tool comparison.",
+      "Do not collapse causal tracing and alerting policy: OpenTelemetry explains distributed causal telemetry, while this source explains operator-facing monitoring decisions."
+    ],
+    "connections": [
+      "observability is refined from causal telemetry into operator-facing symptom/cause and action semantics",
+      "OpenTelemetry traces can be white-box evidence used for diagnosis but do not by themselves define what should page a human"
+    ]
   },
-  "verification_candidates": [],
-  "source_locators": [],
+  "verification_candidates": [
+    {"question": "How should this symptom/action model be updated with modern SLO burn-rate alerting?", "reason": "Useful follow-up beyond the 2016 chapter; not required to preserve the source's core monitoring philosophy.", "priority": "medium"}
+  ],
+  "source_locators": [
+    {"label": "Alerting cost and signal/noise", "locator": "Why Monitor?; Setting Reasonable Expectations for Monitoring"},
+    {"label": "Symptom versus cause", "locator": "Symptoms Versus Causes"},
+    {"label": "Black-box versus white-box", "locator": "Black-Box Versus White-Box"},
+    {"label": "Golden signals", "locator": "The Four Golden Signals"},
+    {"label": "Actionable paging", "locator": "Tying These Principles Together"}
+  ],
   "created_at": "2026-08-27"
 }


### PR DESCRIPTION
Final structural dogfood case for #40 and source issue #66.

Adds a review-only Google SRE `Monitoring Distributed Systems` case on top of the newly refined OpenTelemetry observability model.

Key boundaries:
- refines `observability` from causal telemetry into operator decision semantics;
- separates symptom (`what is broken`) from cause (`why`);
- models black-box user-visible signals and white-box internal diagnosis as complementary views;
- treats paging as an expensive human decision interface: urgent, actionable, high signal / low noise;
- keeps the four golden signals as a compact monitoring baseline without turning every internal metric into an alert;
- tracing remains one diagnostic/white-box evidence source, not the alerting policy itself.

If this passes and materializes, the repository has 20 structurally processed real sources. Private timing/learning/calibration observations for #40 remain a separate local evidence gate; this PR does not fabricate them.

No publication transition.