### PR TITLE
dogfood: refresh analysis-time prior context and record cohort findings

### DIFF
--- a/docs/DOGFOOD_COHORT.md
+++ b/docs/DOGFOOD_COHORT.md
@@ -1,0 +1,131 @@
+# 20-source dogfood cohort — structural findings
+
+Status: **20 / 20 real sources structurally processed** as of 2026-08-27.
+
+This report records what the repository itself can prove from the cohort. It deliberately does **not** reconstruct or invent private timing, delayed-recall, transfer or Source Decision calibration results. Those observations belong in `.local/` and remain a separate human evidence gate for issue #40.
+
+## What was exercised
+
+The cohort spans at least five source types and multiple domains:
+
+- video;
+- documentation;
+- repository/tool;
+- research paper/framework;
+- article/book chapter.
+
+The final inbox contains one intentionally published reference case and nineteen review cases. Every source has a canonical source record, structured insight, Knowledge Delta, claim evidence, prerequisite map, authored reconstruction/transfer prompt and Source Decision. The review/public boundary remains explicit.
+
+Representative new cases include Kubernetes reconciliation, SQLite WAL, PostgreSQL MVCC, DuckDB, LangGraph, Docker build cache, NIST AI RMF, the original Transformer paper, MapReduce, Idempotent Receiver, Pydantic AI, Terraform state, OpenTelemetry tracing, Google SRE monitoring and Twelve-Factor processes.
+
+## What the cohort actually found
+
+### 1. Prior retrieval is useful but concept identity must stay strict
+
+Several sources produced plausible-looking prior matches that were semantically wrong:
+
+- Kubernetes controller reconciliation was not treated as Temporal durable workflow execution;
+- SQLite WAL was not treated as application execution history simply because both are log-like;
+- PostgreSQL MVCC snapshots were kept separate from SQLite WAL reader snapshots;
+- Transformer research rejected unrelated retrieval-practice, policy and agent-control matches;
+- OpenTelemetry tracing was separated from authoritative execution history and controlled execution.
+
+The `not_relevant` classification is therefore not an edge case. It is a necessary part of cumulative knowledge quality.
+
+### 2. Scaffold-time context can become stale before analysis starts
+
+Queued sources were often scaffolded before earlier cohort cases finished. The knowledge graph changed while the source waited.
+
+The clearest case was DuckDB: its original scaffold predated the PostgreSQL MVCC case, so analysis-time knowledge contained a real overlap the scaffold could not represent. The same pattern appeared while reviewing later queued cases.
+
+Decision: the source-run pipeline should refresh prior context at **analysis start**, but only while the bundle is still untouched. Once inspection/mapping/classification starts, the snapshot becomes evidence and must not drift automatically.
+
+### 3. Atomic review contracts materially reduced partial-state failures
+
+A mature case now moves through one review transaction:
+
+```text
+source + insight + graph
++ Knowledge Delta
++ claim evidence
++ prerequisites
++ learning prompt
++ Source Decision
+```
+
+Before the companion contract layer, adding a new review insight could temporarily make mandatory registries inconsistent. The case-patch + case-contract materializer makes the whole review state testable before it reaches `main`.
+
+### 4. Strict evidence provenance caught real authoring mistakes
+
+CI rejected several apparently harmless shortcuts:
+
+- a DuckDB verification claim used the wrong evidence kind;
+- NIST evidence referenced an official URL that was not registered in source provenance;
+- OpenTelemetry claims derived from specification/context pages had to be labeled as verification rather than canonical-source claims;
+- Source Decision skim locators had to resolve to the same claim-evidence trace.
+
+This friction is useful. The product promise depends on keeping source fact, verification, prior knowledge and project interpretation distinct.
+
+### 5. Public knowledge needs an explicit freeze when review evidence extends a published concept
+
+OpenTelemetry refined the already-public `observability` concept. Without a curated public projection, the graph correctly failed closed because the concept now mixed published and review evidence.
+
+The materializer now freezes the last published-only projection when a previously published-only concept receives its first review evidence. Already-mixed concepts still fail closed rather than guessing what is safe to expose.
+
+### 6. Visual grammar should remain constrained
+
+The PostgreSQL MVCC case initially tried to use a three-way base `comparison`. CI rejected it because the primitive intentionally represents exactly two sides.
+
+The case was redesigned instead of weakening the grammar. This is the right product behavior: visual primitives should have semantic meaning rather than act as arbitrary layout containers.
+
+### 7. Long-running agent work exposed branch-race behavior
+
+Parallel cohort branches exposed a stale-branch materialization bug: a PR created before another case landed could interpret newer main-only files incorrectly during patch discovery.
+
+The workflow now uses the merge-base/triple-dot changed-file view and filters to added/modified/copied/renamed case files, preventing unrelated main changes from being treated as work owned by the stale branch.
+
+## Three product changes justified by the cohort
+
+### A. Refresh prior context at actual research start — implement now
+
+Status: **implemented in the dogfood follow-up**.
+
+`run_source.py` refreshes `prior_knowledge` only while a bundle is still metadata-only, unmapped and unclassified. This closes the gap between queue time and analysis time without rewriting historical research evidence.
+
+### B. Add a one-command pre-PR case preflight
+
+The remaining authoring failures were usually cross-contract mistakes that CI caught only after pushing a PR: evidence origin/kind, source provenance, Source Decision locators or visual grammar.
+
+A useful next tool should materialize a candidate patch + companion contract in an isolated temporary workspace and run the same semantic validators before the branch is pushed. The goal is not weaker CI; it is faster local feedback with the same contracts.
+
+### C. Turn repeated `not_relevant` classifications into measured retrieval feedback
+
+The cohort provides real negative examples for prior retrieval. The next retrieval experiment should test whether domain-aware penalties or curated negative feedback reduce repeated cross-domain false positives **without losing useful graph-neighbor recall**.
+
+Do not jump directly to embeddings/vector infrastructure. Extend the current gold benchmark first and compare precision/recall before and after any ranking change.
+
+## What 20 / 20 does not prove
+
+Structural completion is not product-market or learning validation.
+
+Still required:
+
+- real local per-run time/manual-intervention records;
+- delayed reconstruction and transfer results (#19);
+- Source Decision calibration against consuming the original source (#39);
+- intentional human review/publication of a proof corpus (#38);
+- evidence that the product saves time while preserving or improving retained understanding.
+
+Do not backfill these results retrospectively. Future real use should record them at the time they occur.
+
+## Current conclusion
+
+The cohort supports continuing the product, but it changes the engineering priority.
+
+The core representation is already rich enough. The strongest next work is **validation and friction reduction**:
+
+1. make each new research run use the right current prior context;
+2. catch cross-contract authoring errors before PR round-trips;
+3. measure retrieval noise, Source Decision accuracy and delayed understanding with real use.
+
+More platform breadth should remain secondary until those measurements exist.

--- a/docs/RUN_SOURCE.md
+++ b/docs/RUN_SOURCE.md
@@ -2,7 +2,7 @@
 
 `run_source.py` is the deterministic entry point for starting or resuming one source-to-insight run.
 
-It does not contain an LLM runtime, scraping service or publication agent. Its job is to prepare stable repository context, preserve the run's starting revision, detect what has already been completed and tell the external research agent the exact next blocking action.
+It does not contain an LLM runtime, scraping service or publication agent. Its job is to prepare stable repository context, preserve the run's research evidence, detect what has already been completed and tell the external research agent the exact next blocking action.
 
 ## Start from a URL
 
@@ -19,8 +19,9 @@ The command:
 2. reuses an equivalent intake when one already exists;
 3. otherwise creates a new intake;
 4. creates the graph-aware research bundle only when missing;
-5. writes `data/run-manifests/<intake-id>.json`;
-6. prints the exact next blocking action.
+5. refreshes prior knowledge against the current graph if an existing bundle is still an untouched metadata-only scaffold;
+6. writes `data/run-manifests/<intake-id>.json`;
+7. prints the exact next blocking action.
 
 ## Resume from an intake
 
@@ -28,7 +29,17 @@ The command:
 python scripts/run_source.py intake-2026-08-26-example-source
 ```
 
-The existing bundle is never overwritten just because the command was run again. The manifest preserves its original context snapshot and also records the currently observed profile/graph revision.
+The existing bundle is not generally overwritten just because the command was run again. There is one deliberate exception discovered during the 20-source dogfood cohort: a source may sit in the queue while the knowledge graph evolves, so its scaffold-time prior snapshot can become stale before research actually starts.
+
+`run_source.py` therefore refreshes `prior_knowledge` only while all of these remain true:
+
+- `inspection` is still metadata-only / not inspected;
+- the whole-source problem/thesis has not been mapped;
+- no prior-knowledge relationship has been classified yet.
+
+Once source inspection, mapping or relationship classification starts, the prior snapshot is research evidence and becomes immutable to automatic refresh. Later corrections require an explicit reviewed edit rather than silent context drift.
+
+The manifest records whether this run refreshed the prior snapshot in `bundle_prior_refreshed_this_run`.
 
 ## Manifest
 
@@ -41,6 +52,8 @@ A manifest records:
 - initial knowledge-graph version/date;
 - current profile/graph revision on resume;
 - research-bundle path;
+- whether the bundle was created this run;
+- whether untouched prior context was refreshed this run;
 - expected output paths;
 - current pipeline state;
 - exact next blocker;
@@ -54,7 +67,8 @@ The manifest intentionally contains no full third-party source text and no hidde
 The command checks the pipeline in order:
 
 ```text
-source inspected + whole-source map
+fresh prior context while the scaffold is untouched
+→ source inspected + whole-source map
 → prior knowledge classified
 → source registered
 → insight linked + review-ready
@@ -67,7 +81,7 @@ source inspected + whole-source map
 
 It stops conceptually at the first missing requirement and reports that as `next_blocking_action`.
 
-This lets a capable agent pick up an interrupted source without rereading the repository to rediscover the workflow.
+This lets a capable agent pick up an interrupted source without rereading the repository to rediscover the workflow, while still preserving the actual analysis-time knowledge state.
 
 ## Mature-run checks
 
@@ -109,4 +123,9 @@ The source-run command never auto-publishes.
 python scripts/run_source.py --self-test
 ```
 
-The self-test checks that an existing mature case exposes a deterministic state and that a synthetic fresh bundle correctly reports source research as the first blocker without changing repository data.
+The self-test checks that:
+
+- an existing mature case exposes a deterministic state;
+- a synthetic fresh bundle correctly reports source research as the first blocker;
+- a stale untouched scaffold refreshes against the current graph;
+- an inspected/mapped bundle keeps its prior snapshot immutable.

--- a/scripts/run_source.py
+++ b/scripts/run_source.py
@@ -16,7 +16,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 from new_source import normalize_url, source_key
-from scaffold_bundle import build_bundle
+from scaffold_bundle import build_bundle, prior_snapshot
 
 ROOT = Path(__file__).resolve().parents[1]
 INBOX = ROOT / "data" / "inbox.json"
@@ -115,13 +115,54 @@ def get_intake(intake_id: str) -> dict:
     return item
 
 
-def ensure_bundle(item: dict) -> tuple[dict, Path, bool]:
+def bundle_can_refresh_prior(bundle: dict) -> bool:
+    """Return true only while the bundle is still an untouched research scaffold.
+
+    The prior snapshot may be refreshed while a source waits in the queue, because the graph
+    can evolve between scaffold time and analysis time. Once source inspection, whole-source
+    mapping, or relationship classification starts, the snapshot becomes research evidence and
+    must remain immutable unless a human deliberately edits the case.
+    """
+    inspection = bundle.get("inspection") or {}
+    content_map = bundle.get("content_map") or {}
+    prior = bundle.get("prior_knowledge") or {}
+    matches = prior.get("matches") or []
+
+    inspected = (
+        inspection.get("method") not in {None, "", "not inspected"}
+        and inspection.get("confidence") != "metadata_only"
+    )
+    mapped = bool(content_map.get("problem") or content_map.get("thesis"))
+    classified = any(
+        isinstance(item, dict)
+        and item.get("relationship_to_source") not in {None, "unclassified"}
+        for item in matches
+    )
+    return not inspected and not mapped and not classified
+
+
+def refresh_prior_if_uninspected(item: dict, bundle: dict, captured_at: str | None = None) -> bool:
+    """Refresh graph-aware prior context at actual research start, never after research begins."""
+    if not bundle_can_refresh_prior(bundle):
+        return False
+    refreshed = prior_snapshot(item, captured_at or date.today().isoformat())
+    if bundle.get("prior_knowledge") == refreshed:
+        return False
+    bundle["prior_knowledge"] = refreshed
+    return True
+
+
+def ensure_bundle(item: dict) -> tuple[dict, Path, bool, bool]:
     path = BUNDLES / f"{item['id']}.json"
     if path.exists():
-        return load(path), path, False
+        bundle = load(path)
+        refreshed = refresh_prior_if_uninspected(item, bundle)
+        if refreshed:
+            dump(path, bundle)
+        return bundle, path, False, refreshed
     bundle = build_bundle(item)
     dump(path, bundle)
-    return bundle, path, True
+    return bundle, path, True, False
 
 
 def index_by_id(path: Path, key: str) -> dict[str, dict]:
@@ -237,7 +278,13 @@ def expected_artifacts(item: dict) -> dict:
     }
 
 
-def write_manifest(item: dict, state: dict, bundle_path: Path, created_bundle: bool) -> dict:
+def write_manifest(
+    item: dict,
+    state: dict,
+    bundle_path: Path,
+    created_bundle: bool,
+    refreshed_prior: bool,
+) -> dict:
     target = MANIFESTS / f"{item['id']}.json"
     existing = load(target, default={})
     timestamp = now_iso()
@@ -255,6 +302,7 @@ def write_manifest(item: dict, state: dict, bundle_path: Path, created_bundle: b
         "current_context": snapshot,
         "research_bundle": str(bundle_path.relative_to(ROOT)),
         "bundle_created_this_run": created_bundle,
+        "bundle_prior_refreshed_this_run": refreshed_prior,
         "expected_artifacts": expected_artifacts(item),
         "state": state,
         "agent_handoff": {
@@ -320,8 +368,9 @@ def self_test() -> int:
 
     fixture = {
         "id": "intake-run-source-fixture",
-        "source_url": "https://example.com/new",
+        "source_url": "https://example.com/durable-workflow-retry",
         "source_type": "article",
+        "requested_focus": "durable workflow retry",
         "status": "queued",
         "source_id": None,
         "insight_id": None,
@@ -331,7 +380,42 @@ def self_test() -> int:
     if "Research the source" not in fixture_state["next_blocking_action"]:
         print(f"run_source self-test failed; unexpected first blocker: {fixture_state['next_blocking_action']}")
         return 1
-    print("run_source self-test passed; prepared and mature states expose deterministic next actions.")
+
+    fixture_bundle["prior_knowledge"] = {
+        "captured_at": "2026-01-01",
+        "query": "durable workflow retry",
+        "matches": [],
+        "classification_required": True,
+    }
+    if not refresh_prior_if_uninspected(fixture, fixture_bundle, "2026-08-27"):
+        print("run_source self-test failed; stale untouched scaffold did not refresh prior context")
+        return 1
+    refreshed_ids = {
+        match.get("concept_id")
+        for match in fixture_bundle.get("prior_knowledge", {}).get("matches", [])
+    }
+    if "durable-execution" not in refreshed_ids:
+        print(f"run_source self-test failed; refreshed prior context missed durable-execution: {sorted(refreshed_ids)}")
+        return 1
+
+    fixture_bundle["inspection"] = {
+        "method": "fixture direct inspection",
+        "full_content_used_ephemerally": True,
+        "full_content_committed": False,
+        "confidence": "direct",
+        "gaps": [],
+    }
+    fixture_bundle["content_map"]["problem"] = "Fixture problem already mapped."
+    fixture_bundle["content_map"]["thesis"] = "Fixture thesis already mapped."
+    frozen_prior = json.dumps(fixture_bundle["prior_knowledge"], sort_keys=True)
+    if refresh_prior_if_uninspected(fixture, fixture_bundle, "2026-08-28"):
+        print("run_source self-test failed; inspected bundle prior context must stay immutable")
+        return 1
+    if json.dumps(fixture_bundle["prior_knowledge"], sort_keys=True) != frozen_prior:
+        print("run_source self-test failed; inspected bundle prior context changed")
+        return 1
+
+    print("run_source self-test passed; prepared/mature states and analysis-time prior refresh are deterministic.")
     return 0
 
 
@@ -359,9 +443,9 @@ def main() -> int:
         else:
             item = get_intake(args.source)
 
-        bundle, bundle_path, created_bundle = ensure_bundle(item)
+        bundle, bundle_path, created_bundle, refreshed_prior = ensure_bundle(item)
         state = evaluate_state(item, bundle)
-        manifest = write_manifest(item, state, bundle_path, created_bundle)
+        manifest = write_manifest(item, state, bundle_path, created_bundle, refreshed_prior)
 
         checks = None
         mature = (
@@ -393,6 +477,8 @@ def main() -> int:
             print(f"Run manifest: data/run-manifests/{item['id']}.json")
             print(f"Bundle: {bundle_path.relative_to(ROOT)}")
             print(f"Context: profile {manifest['current_context']['profile_version']} · graph {manifest['current_context']['graph_version']}")
+            if manifest["bundle_prior_refreshed_this_run"]:
+                print("Prior knowledge: refreshed against the current graph before research")
             print(f"Next: {manifest['state']['next_blocking_action']}")
             if checks is not None:
                 print(f"Checks: {'green' if checks['ok'] else 'failed'}")


### PR DESCRIPTION
Follow-up from the completed 20-source structural cohort (#40).

This PR turns the strongest repeated cohort failure into pipeline behavior and records what the cohort actually proved.

Changes:
- `run_source.py` refreshes prior knowledge against the current graph when an existing research bundle is still an untouched metadata-only scaffold;
- refresh is forbidden once source inspection, whole-source mapping or relationship classification has started, so historical research evidence remains immutable;
- manifests record `bundle_prior_refreshed_this_run`;
- self-test covers both stale-scaffold refresh and post-inspection immutability;
- `docs/RUN_SOURCE.md` documents the boundary;
- `docs/DOGFOOD_COHORT.md` records 20/20 structural completion, recurring failure classes and three evidence-justified next changes.

Important: this does not fabricate the private timing/manual-intervention/delayed-recall/Source Decision calibration evidence required to fully close #40. Those remain real-use local gates.