### PR TITLE
Freeze and audit the completed 20-source validation cohort

### DIFF
--- a/.github/workflows/cohort-audit.yml
+++ b/.github/workflows/cohort-audit.yml
@@ -1,0 +1,62 @@
+name: Validate 20-source cohort
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "data/cohorts/**.json"
+      - "data/inbox.json"
+      - "data/sources.json"
+      - "data/insights.json"
+      - "data/knowledge-graph.json"
+      - "data/knowledge-deltas.json"
+      - "data/claim-evidence.json"
+      - "data/prerequisite-maps.json"
+      - "data/learning-prompts.json"
+      - "data/source-decisions.json"
+      - "data/research-bundles/**.json"
+      - "data/case-patches/**.json"
+      - "data/case-contracts/**.json"
+      - "scripts/cohort_audit.py"
+      - "docs/COHORT_20_REPORT.md"
+      - ".github/workflows/cohort-audit.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "data/cohorts/**.json"
+      - "data/inbox.json"
+      - "data/sources.json"
+      - "data/insights.json"
+      - "data/knowledge-graph.json"
+      - "data/knowledge-deltas.json"
+      - "data/claim-evidence.json"
+      - "data/prerequisite-maps.json"
+      - "data/learning-prompts.json"
+      - "data/source-decisions.json"
+      - "data/research-bundles/**.json"
+      - "data/case-patches/**.json"
+      - "data/case-contracts/**.json"
+      - "scripts/cohort_audit.py"
+      - "docs/COHORT_20_REPORT.md"
+      - ".github/workflows/cohort-audit.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Audit frozen validation cohort
+        run: python scripts/cohort_audit.py --check --check-report docs/COHORT_20_REPORT.md
+
+      - name: Compile cohort audit
+        run: python -m py_compile scripts/cohort_audit.py

--- a/data/cohorts/validation-20.json
+++ b/data/cohorts/validation-20.json
@@ -1,0 +1,77 @@
+{
+  "cohort_version": "1.0.0",
+  "cohort_id": "validation-20",
+  "purpose": "Validation-first dogfood cohort used to expose source-processing, cumulative-knowledge and reliability failure modes before further platform expansion.",
+  "members": [
+    "intake-2026-08-26-ai-engineer-enterprise-stack-agents",
+    "intake-2026-08-26-temporal-docs",
+    "intake-2026-08-26-github-opa",
+    "intake-2026-08-26-arxiv-2210-03629",
+    "intake-2026-08-26-psychologicalscience-j-1467-9280-2006-01693-x",
+    "intake-2026-08-27-kubernetes-controller",
+    "intake-2026-08-27-sqlite-wal-html",
+    "intake-2026-08-27-postgresql-mvcc-intro-html",
+    "intake-2026-08-27-github-duckdb",
+    "intake-2026-08-27-github-langgraph",
+    "intake-2026-08-27-docs-optimize",
+    "intake-2026-08-27-nist-artificial-intelligence-risk-management-framewor",
+    "intake-2026-08-27-arxiv-1706-03762",
+    "intake-2026-08-27-research-mapreduce-simplified-data-processing-on-large-cl",
+    "intake-2026-08-27-martinfowler-idempotent-receiver-html",
+    "intake-2026-08-27-github-pydantic-ai",
+    "intake-2026-08-27-developer-purpose",
+    "intake-2026-08-27-opentelemetry-traces",
+    "intake-2026-08-27-sre-monitoring-distributed-systems",
+    "intake-2026-08-27-12factor-processes"
+  ],
+  "observed_failure_modes": [
+    {
+      "id": "retrieval-semantic-precision-recall",
+      "observation": "Prior retrieval produced attractive but irrelevant cross-layer matches for Kubernetes and SQLite, while the SRE monitoring query missed the broader existing observability model.",
+      "evidence": ["Kubernetes prior-match classification", "SQLite WAL suppressed history matches", "SRE observability recall miss"],
+      "resolution": "Cohort-derived retrieval benchmark probes plus query-relevant bridge expansion; PR #94.",
+      "status": "resolved_with_regression"
+    },
+    {
+      "id": "evidence-boundary-mismatch",
+      "observation": "Draft review records occasionally referenced concepts, prerequisite explainers or skim locators that were not evidenced by the current source boundary.",
+      "evidence": ["Kubernetes transfer concept mismatch", "Idempotent Receiver review-only prerequisite", "SQLite Source Decision locator mismatch"],
+      "resolution": "Existing semantic validators blocked materialization; authored records were corrected rather than weakening the gates.",
+      "status": "resolved_by_contract"
+    },
+    {
+      "id": "mixed-public-review-evidence",
+      "observation": "A concept that began with published evidence later accumulated review-only refinements, requiring the public projection to remain frozen on reviewed public evidence.",
+      "evidence": ["observability refined by OpenTelemetry and Google SRE"],
+      "resolution": "Materializer freezes the pre-review published concept projection before adding the first review evidence; main commit 48b6ab4.",
+      "status": "resolved_by_contract"
+    },
+    {
+      "id": "stale-pr-materialization-diff",
+      "observation": "Parallel agent loops advanced main after a case branch was created, causing two-point diff logic to misclassify main-only patches as changes owned by a stale PR.",
+      "evidence": ["Terraform cohort PR attempted to materialize a main-only MapReduce patch"],
+      "resolution": "Pull-request materialization now uses merge-base/triple-dot diff with added/modified filters; PR #86.",
+      "status": "resolved_with_ci_fix"
+    },
+    {
+      "id": "visual-primitive-overreach",
+      "observation": "A PostgreSQL isolation model tried to use a two-sided comparison primitive for three isolation levels.",
+      "evidence": ["PostgreSQL MVCC comparison validator failure"],
+      "resolution": "Kept the visual grammar small and changed the case to a sequence instead of expanding the DSL for one source.",
+      "status": "resolved_by_content_change"
+    },
+    {
+      "id": "publication-self-test-order-dependence",
+      "observation": "Publication self-test assumed the first review insight was publishable and failed once cumulative review evidence made that assumption invalid.",
+      "evidence": ["mixed evidence publication self-test failure after Idempotent Receiver"],
+      "resolution": "Self-test now searches for a valid positive dry-run candidate while retaining fail-closed publication rules; PR #74.",
+      "status": "resolved_with_test_fix"
+    }
+  ],
+  "human_evidence_gaps": [
+    "Per-run elapsed work, manual interventions and subjective utility remain private in .local dogfood records and were not fabricated for this structural audit.",
+    "Delayed reconstruction and transfer outcomes require a real human delay and remain tracked by issue #19.",
+    "Source Decision calibration against full-source consumption requires actual consumption checks and remains tracked by issue #39.",
+    "Publication of the curated proof corpus requires explicit human review and remains tracked by issue #38."
+  ]
+}

--- a/docs/COHORT_20_REPORT.md
+++ b/docs/COHORT_20_REPORT.md
@@ -1,0 +1,94 @@
+# Validation cohort — 20 sources
+
+Structural readiness: **YES**
+
+This report audits committed source/knowledge contracts only. It deliberately does not claim human learning utility, delayed recall, elapsed work time or Source Decision calibration unless those measurements actually exist.
+
+## Coverage
+
+- Cohort members: 20 / 20
+- Sources linked: 20
+- Insights linked: 20
+- Research bundles: 20
+- Statuses: published=1, review=19
+
+| Source type | Count |
+| --- | ---: |
+| article | 4 |
+| documentation | 7 |
+| paper | 4 |
+| repository | 4 |
+| video | 1 |
+
+## Structured knowledge evidence
+
+| Contract | Count |
+| --- | ---: |
+| Knowledge Delta records | 20 |
+| Claim-evidence records | 20 |
+| Important claims | 85 |
+| Prerequisite maps | 20 |
+| Prerequisites | 73 |
+| Learning prompts | 20 |
+| Source Decisions | 20 |
+| Graph concepts (total graph) | 76 |
+| Graph relations (total graph) | 68 |
+| Review case patches | 17 |
+| Companion case contracts | 15 |
+
+## Failure modes exposed by dogfood
+
+### retrieval-semantic-precision-recall
+
+Prior retrieval produced attractive but irrelevant cross-layer matches for Kubernetes and SQLite, while the SRE monitoring query missed the broader existing observability model.
+
+Resolution: Cohort-derived retrieval benchmark probes plus query-relevant bridge expansion; PR #94.
+
+Status: `resolved_with_regression`
+
+### evidence-boundary-mismatch
+
+Draft review records occasionally referenced concepts, prerequisite explainers or skim locators that were not evidenced by the current source boundary.
+
+Resolution: Existing semantic validators blocked materialization; authored records were corrected rather than weakening the gates.
+
+Status: `resolved_by_contract`
+
+### mixed-public-review-evidence
+
+A concept that began with published evidence later accumulated review-only refinements, requiring the public projection to remain frozen on reviewed public evidence.
+
+Resolution: Materializer freezes the pre-review published concept projection before adding the first review evidence; main commit 48b6ab4.
+
+Status: `resolved_by_contract`
+
+### stale-pr-materialization-diff
+
+Parallel agent loops advanced main after a case branch was created, causing two-point diff logic to misclassify main-only patches as changes owned by a stale PR.
+
+Resolution: Pull-request materialization now uses merge-base/triple-dot diff with added/modified filters; PR #86.
+
+Status: `resolved_with_ci_fix`
+
+### visual-primitive-overreach
+
+A PostgreSQL isolation model tried to use a two-sided comparison primitive for three isolation levels.
+
+Resolution: Kept the visual grammar small and changed the case to a sequence instead of expanding the DSL for one source.
+
+Status: `resolved_by_content_change`
+
+### publication-self-test-order-dependence
+
+Publication self-test assumed the first review insight was publishable and failed once cumulative review evidence made that assumption invalid.
+
+Resolution: Self-test now searches for a valid positive dry-run candidate while retaining fail-closed publication rules; PR #74.
+
+Status: `resolved_with_test_fix`
+
+## What this cohort still does not prove
+
+- Per-run elapsed work, manual interventions and subjective utility remain private in .local dogfood records and were not fabricated for this structural audit.
+- Delayed reconstruction and transfer outcomes require a real human delay and remain tracked by issue #19.
+- Source Decision calibration against full-source consumption requires actual consumption checks and remains tracked by issue #39.
+- Publication of the curated proof corpus requires explicit human review and remains tracked by issue #38.

--- a/scripts/cohort_audit.py
+++ b/scripts/cohort_audit.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Audit the frozen 20-source validation cohort using committed knowledge contracts only.
+
+This is intentionally separate from .local/dogfood-cohort.json. The committed audit can prove
+structural coverage and recorded failure modes, but it must not invent elapsed-time, subjective
+utility, delayed-recall or Source Decision calibration evidence that requires a real user run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = ROOT / "data" / "cohorts" / "validation-20.json"
+DEFAULT_REPORT = ROOT / "docs" / "COHORT_20_REPORT.md"
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def records(path: Path) -> list[dict]:
+    return load(path).get("records", [])
+
+
+def registry_ids(path: Path) -> set[str]:
+    return {
+        item.get("insight_id")
+        for item in records(path)
+        if isinstance(item, dict) and isinstance(item.get("insight_id"), str)
+    }
+
+
+def audit(manifest_path: Path = DEFAULT_MANIFEST) -> dict:
+    manifest = load(manifest_path)
+    member_ids = manifest.get("members", [])
+    errors: list[str] = []
+    if len(member_ids) != 20:
+        errors.append(f"manifest must contain exactly 20 intake ids, found {len(member_ids)}")
+    if len(set(member_ids)) != len(member_ids):
+        errors.append("manifest contains duplicate intake ids")
+
+    inbox_data = load(ROOT / "data" / "inbox.json")
+    source_data = load(ROOT / "data" / "sources.json")
+    insight_data = load(ROOT / "data" / "insights.json")
+    graph = load(ROOT / "data" / "knowledge-graph.json")
+
+    inbox = {item.get("id"): item for item in inbox_data.get("items", []) if isinstance(item, dict)}
+    sources = {item.get("id"): item for item in source_data.get("sources", []) if isinstance(item, dict)}
+    insights = {item.get("id"): item for item in insight_data.get("insights", []) if isinstance(item, dict)}
+
+    members: list[dict] = []
+    source_types: Counter[str] = Counter()
+    statuses: Counter[str] = Counter()
+    member_insight_ids: set[str] = set()
+    member_source_ids: set[str] = set()
+
+    for intake_id in member_ids:
+        item = inbox.get(intake_id)
+        if item is None:
+            errors.append(f"missing cohort intake: {intake_id}")
+            continue
+        source_type = item.get("source_type")
+        status = item.get("status")
+        source_id = item.get("source_id")
+        insight_id = item.get("insight_id")
+        if not isinstance(source_type, str) or not source_type:
+            errors.append(f"{intake_id}: source_type missing")
+        else:
+            source_types[source_type] += 1
+        if status not in {"review", "published"}:
+            errors.append(f"{intake_id}: cohort item is not review/published: {status!r}")
+        else:
+            statuses[status] += 1
+        if not isinstance(source_id, str) or source_id not in sources:
+            errors.append(f"{intake_id}: linked source missing: {source_id!r}")
+        else:
+            member_source_ids.add(source_id)
+        if not isinstance(insight_id, str) or insight_id not in insights:
+            errors.append(f"{intake_id}: linked insight missing: {insight_id!r}")
+        else:
+            member_insight_ids.add(insight_id)
+            if insights[insight_id].get("status") != status:
+                errors.append(
+                    f"{intake_id}: inbox/insight status mismatch "
+                    f"({status!r} vs {insights[insight_id].get('status')!r})"
+                )
+        bundle = ROOT / "data" / "research-bundles" / f"{intake_id}.json"
+        if not bundle.exists():
+            errors.append(f"{intake_id}: research bundle missing")
+        members.append(
+            {
+                "intake_id": intake_id,
+                "source_type": source_type,
+                "status": status,
+                "source_id": source_id,
+                "insight_id": insight_id,
+            }
+        )
+
+    if len(source_types) < 5:
+        errors.append(f"cohort must cover at least five source types, found {len(source_types)}")
+
+    registry_paths = {
+        "knowledge_deltas": ROOT / "data" / "knowledge-deltas.json",
+        "claim_evidence": ROOT / "data" / "claim-evidence.json",
+        "prerequisite_maps": ROOT / "data" / "prerequisite-maps.json",
+        "learning_prompts": ROOT / "data" / "learning-prompts.json",
+        "source_decisions": ROOT / "data" / "source-decisions.json",
+    }
+    registry_coverage: dict[str, int] = {}
+    for label, path in registry_paths.items():
+        ids = registry_ids(path)
+        missing = sorted(member_insight_ids - ids)
+        registry_coverage[label] = len(member_insight_ids & ids)
+        if missing:
+            errors.append(f"{label}: missing cohort insight records: {missing}")
+
+    graph_linked = {
+        insight_id
+        for concept in graph.get("concepts", [])
+        if isinstance(concept, dict)
+        for insight_id in concept.get("insight_ids", [])
+        if isinstance(insight_id, str)
+    }
+    missing_graph = sorted(member_insight_ids - graph_linked)
+    if missing_graph:
+        errors.append(f"knowledge graph: cohort insights without concept linkage: {missing_graph}")
+
+    claim_records = records(ROOT / "data" / "claim-evidence.json")
+    prereq_records = records(ROOT / "data" / "prerequisite-maps.json")
+    claim_count = sum(
+        len(item.get("claims", []))
+        for item in claim_records
+        if item.get("insight_id") in member_insight_ids
+    )
+    prerequisite_count = sum(
+        len(item.get("items", []))
+        for item in prereq_records
+        if item.get("insight_id") in member_insight_ids
+    )
+
+    report = {
+        "cohort_id": manifest.get("cohort_id"),
+        "member_count": len(member_ids),
+        "processed_members": len(members),
+        "source_types": dict(sorted(source_types.items())),
+        "statuses": dict(sorted(statuses.items())),
+        "registry_coverage": registry_coverage,
+        "metrics": {
+            "sources": len(member_source_ids),
+            "insights": len(member_insight_ids),
+            "research_bundles": sum(
+                (ROOT / "data" / "research-bundles" / f"{intake_id}.json").exists()
+                for intake_id in member_ids
+            ),
+            "knowledge_deltas": registry_coverage["knowledge_deltas"],
+            "claim_evidence_records": registry_coverage["claim_evidence"],
+            "claims": claim_count,
+            "prerequisite_maps": registry_coverage["prerequisite_maps"],
+            "prerequisites": prerequisite_count,
+            "learning_prompts": registry_coverage["learning_prompts"],
+            "source_decisions": registry_coverage["source_decisions"],
+            "graph_concepts_total": len(graph.get("concepts", [])),
+            "graph_relations_total": len(graph.get("relations", [])),
+            "case_patches_total": len(list((ROOT / "data" / "case-patches").glob("*.json"))),
+            "case_contracts_total": len(list((ROOT / "data" / "case-contracts").glob("*.json"))),
+        },
+        "observed_failure_modes": manifest.get("observed_failure_modes", []),
+        "human_evidence_gaps": manifest.get("human_evidence_gaps", []),
+        "structural_ready": not errors,
+        "errors": errors,
+    }
+    return report
+
+
+def render_markdown(report: dict) -> str:
+    ready = "YES" if report["structural_ready"] else "NO"
+    lines = [
+        "# Validation cohort — 20 sources",
+        "",
+        f"Structural readiness: **{ready}**",
+        "",
+        "This report audits committed source/knowledge contracts only. It deliberately does not claim human learning utility, delayed recall, elapsed work time or Source Decision calibration unless those measurements actually exist.",
+        "",
+        "## Coverage",
+        "",
+        f"- Cohort members: {report['processed_members']} / {report['member_count']}",
+        f"- Sources linked: {report['metrics']['sources']}",
+        f"- Insights linked: {report['metrics']['insights']}",
+        f"- Research bundles: {report['metrics']['research_bundles']}",
+        f"- Statuses: {', '.join(f'{key}={value}' for key, value in report['statuses'].items())}",
+        "",
+        "| Source type | Count |",
+        "| --- | ---: |",
+    ]
+    for source_type, count in report["source_types"].items():
+        lines.append(f"| {source_type} | {count} |")
+
+    metrics = report["metrics"]
+    lines.extend(
+        [
+            "",
+            "## Structured knowledge evidence",
+            "",
+            "| Contract | Count |",
+            "| --- | ---: |",
+            f"| Knowledge Delta records | {metrics['knowledge_deltas']} |",
+            f"| Claim-evidence records | {metrics['claim_evidence_records']} |",
+            f"| Important claims | {metrics['claims']} |",
+            f"| Prerequisite maps | {metrics['prerequisite_maps']} |",
+            f"| Prerequisites | {metrics['prerequisites']} |",
+            f"| Learning prompts | {metrics['learning_prompts']} |",
+            f"| Source Decisions | {metrics['source_decisions']} |",
+            f"| Graph concepts (total graph) | {metrics['graph_concepts_total']} |",
+            f"| Graph relations (total graph) | {metrics['graph_relations_total']} |",
+            f"| Review case patches | {metrics['case_patches_total']} |",
+            f"| Companion case contracts | {metrics['case_contracts_total']} |",
+            "",
+            "## Failure modes exposed by dogfood",
+            "",
+        ]
+    )
+    for item in report["observed_failure_modes"]:
+        lines.extend(
+            [
+                f"### {item['id']}",
+                "",
+                item["observation"],
+                "",
+                f"Resolution: {item['resolution']}",
+                "",
+                f"Status: `{item['status']}`",
+                "",
+            ]
+        )
+
+    lines.extend(["## What this cohort still does not prove", ""])
+    for gap in report["human_evidence_gaps"]:
+        lines.append(f"- {gap}")
+    if report["errors"]:
+        lines.extend(["", "## Audit errors", ""])
+        for error in report["errors"]:
+            lines.append(f"- {error}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--write-report", type=Path)
+    parser.add_argument("--check-report", type=Path)
+    args = parser.parse_args()
+
+    try:
+        report = audit(args.manifest)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"cohort audit error: {exc}")
+        return 2
+
+    markdown = render_markdown(report)
+    if args.write_report:
+        path = args.write_report
+        if not path.is_absolute():
+            path = ROOT / path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(markdown, encoding="utf-8")
+        print(f"wrote cohort report: {path.relative_to(ROOT)}")
+    if args.check_report:
+        path = args.check_report
+        if not path.is_absolute():
+            path = ROOT / path
+        if not path.exists() or path.read_text(encoding="utf-8") != markdown:
+            print(f"cohort audit error: report is stale: {path.relative_to(ROOT)}")
+            return 1
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(
+            f"Cohort {report['cohort_id']}: {report['processed_members']}/{report['member_count']} members; "
+            f"types={len(report['source_types'])}; structural_ready={report['structural_ready']}"
+        )
+        if report["errors"]:
+            for error in report["errors"]:
+                print(f"- {error}")
+
+    if args.check and not report["structural_ready"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Turns the completed source cohort into a stable, machine-verifiable product evidence artifact.

Adds:
- `data/cohorts/validation-20.json` with the exact 20 intake members, six observed failure classes/resolutions and explicit human-evidence gaps;
- `scripts/cohort_audit.py` validating every member has source + insight + bundle + Knowledge Delta + claim evidence + prerequisite map + learning prompt + Source Decision + graph linkage;
- deterministic `docs/COHORT_20_REPORT.md` with source-type/status coverage and structured evidence counts;
- CI that fails if the frozen cohort regresses or the committed report becomes stale.

Important boundary: this audit proves structural/reliability coverage only. It explicitly does not invent elapsed work, delayed recall, transfer or Source Decision calibration evidence; those remain human benchmarks (#19/#39) and review work (#38).