### PR TITLE
Make Signal to Insight public surface proof-first and deploy-ready

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,8 @@
 name: Deploy Signal to Insight Pages
 
-# Pages is currently a repository-level setting. Keep this workflow manual until Pages is
-# enabled for GitHub Actions; then it can be switched to push-on-main deployment.
+# Pages is a repository-level setting. Keep this workflow manual until Pages is enabled
+# with GitHub Actions as the source. Once that setting exists, this workflow can deploy
+# the already-validated static root without changing the knowledge/publication model.
 on:
   workflow_dispatch:
 
@@ -43,6 +44,9 @@ jobs:
           python scripts/build_graph.py
           python scripts/build_syntheses.py
           python scripts/build_sitemap.py
+
+      - name: Verify deployable static routes and review privacy
+        run: python scripts/validate_public_surface.py
 
       - name: Configure Pages metadata
         uses: actions/configure-pages@v5

--- a/.github/workflows/public-surface.yml
+++ b/.github/workflows/public-surface.yml
@@ -1,0 +1,57 @@
+name: Validate public surface
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "index.html"
+      - "walkthrough/**"
+      - "library/**"
+      - "knowledge/**"
+      - "explainers/**"
+      - "previews/**"
+      - "sitemap.xml"
+      - "scripts/build_sitemap.py"
+      - "scripts/validate_public_surface.py"
+      - ".github/workflows/pages.yml"
+      - ".github/workflows/public-surface.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "index.html"
+      - "walkthrough/**"
+      - "library/**"
+      - "knowledge/**"
+      - "explainers/**"
+      - "previews/**"
+      - "sitemap.xml"
+      - "scripts/build_sitemap.py"
+      - "scripts/validate_public_surface.py"
+      - ".github/workflows/pages.yml"
+      - ".github/workflows/public-surface.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify sitemap is current
+        run: python scripts/build_sitemap.py --check
+
+      - name: Verify public and review routes
+        run: python scripts/validate_public_surface.py
+
+      - name: Compile public-surface validator
+        run: python -m py_compile scripts/validate_public_surface.py

--- a/README.md
+++ b/README.md
@@ -1,107 +1,146 @@
 # Signal to Insight
 
-A personalized source-to-understanding engine with cumulative concept memory.
+**An evidence-backed source-to-understanding engine with cumulative concept memory.**
 
-Give the agent a useful source — video, article, paper, podcast, documentation, repository, tool or system — and turn it into a coherent, visual, actionable explanation of what is worth understanding, learning, trying, using, building or simply tracking.
+Give it a useful source — video, article, paper, documentation, repository, tool or system — and turn it into a coherent mental model of what is worth understanding, what changed relative to prior knowledge, whether the original is still worth your time, and what to learn or try next.
 
-This is **not a summarizer** and it is **not domain-locked**. The system preserves the minimum complete mental model behind a source rather than extracting disconnected highlights. New sources are also compared with prior knowledge so repeated ideas reinforce or refine the existing model instead of becoming isolated pages.
+Signal to Insight is **not a generic summarizer**. The durable output is a versioned knowledge model with provenance, evidence boundaries and review state — not a pile of disconnected summaries.
 
-The product now treats that comparison as a first-class artifact: every review-ready insight has a curated **Knowledge Delta** explaining what is genuinely new, what reinforces or refines earlier knowledge, and which retrieved connections were rejected as noise.
+**Start here:** [Golden walkthrough](walkthrough/index.html) — one complete published proof path from source → whole-source model → Knowledge Delta → Source Decision → explainer → delayed-reconstruction checkpoint.
 
-## Product loop
+**Validation evidence:** [20-source cohort report](docs/COHORT_20_REPORT.md) — 20 real sources across five source types, with structural coverage and dogfood failures recorded rather than hidden.
+
+> Map the whole source first. Then compress it without breaking the model.
+>
+> Check what is already known before creating something new.
+>
+> Show what the source actually changes — and reject attractive false connections.
+
+## The product loop
 
 ```text
-source
-  ↓
-intake + provenance
-  ↓
-prior-knowledge lookup
-  ↓
+source + provenance
+        ↓
+prior-knowledge retrieval
+        ↓
 whole-source map
-  ↓
-normalized research bundle
-  ↓
-personal research profile
-  ↓
-coherent-core selection
-  ↓
-verification + enrichment
-  ↓
-mental model
-  ↓
-curated Knowledge Delta
-  ↓
-merge concepts + relations into knowledge graph
-  ↓
-structured insight
-  ↓
+        ↓
+verification / enrichment
+        ↓
+coherent mental model
+        ↓
+Knowledge Delta
+        ↓
+claim evidence + prerequisites
+        ↓
+Source Decision
+        ↓
 review preview
-  ↓
-review
-  ↓
-published visual explainer + library + public knowledge graph
+        ↓
+explicit human publication
+        ↓
+published explainer + library + concept graph
+        ↓
+delayed reconstruction / transfer check
 ```
 
-The strongest rules in the project are:
+The five product questions are:
 
-> **Map the whole source first. Then compress it without breaking the model.**
->
-> **Check what is already known before creating something new.**
->
-> **Show what the new source actually changes — and reject attractive false connections.**
+1. **What did this source actually change in the existing model?**
+2. **Why should that change be trusted?**
+3. **Do I still need the original source?**
+4. **Can I reconstruct and apply the model later?**
+5. **What should I learn, test or investigate next?**
 
-## What is implemented
+## What works today
 
-The repository now has a working deterministic foundation for the complete source-to-page lifecycle:
+The repository has a deterministic, validated foundation for the full source-to-review lifecycle:
 
-- source intake queue and URL normalization;
-- owner-only GitHub Issue intake that can queue a source and scaffold its research bundle in one workflow;
-- stable intake/source/insight identifiers;
-- provenance and source-date rules;
-- personalized research profile;
-- source adapter contracts for video, article/docs, paper/PDF, GitHub repository and tools/systems;
-- normalized research bundles that never commit full third-party source text;
-- automatic prior-knowledge snapshot in newly scaffolded bundles;
-- cumulative concept graph with stable concept IDs and typed evidence-backed relations;
-- prior-knowledge retrieval with neighboring concepts and supporting insights;
-- curated Knowledge Delta records with source/prior/interpretation separation and explicit noise suppression;
-- machine-readable insight records;
-- schema/semantic validation and cross-reference checks;
-- generated visual explainer pages with Knowledge Delta sections;
-- `review` previews with `noindex,nofollow` and no public canonical/JSON-LD;
-- reusable explainer visual grammar;
-- generated searchable library with tag filters;
-- generated public knowledge graph and relation-derived learning path;
-- explicit owner-confirmed `review → published` transition;
-- explicit owner-confirmed `published → review/archived` retraction with provenance history;
-- stale public explainer removal when publication is retracted;
-- end-to-end fixture-driven acceptance tests;
-- GitHub Actions checks for structured data and generated-output drift;
-- auto-sync workflows for review previews, published explainers, the public knowledge graph and the generated library.
+- URL/source intake with stable IDs and provenance;
+- normalized research bundles without committed third-party full text;
+- whole-source mapping before selection/compression;
+- cumulative concept graph with typed evidence-backed relations;
+- prior-knowledge retrieval with cohort-derived regression tests;
+- curated **Knowledge Delta** records separating source evidence, prior evidence and project interpretation;
+- claim-level evidence traces;
+- prerequisite maps;
+- evidence-backed **Source Decision**: `consume / skim selected parts / explainer is enough / skip for now`;
+- authored delayed-reconstruction and transfer prompts;
+- visual explainer generation from structured knowledge;
+- review previews with `noindex,nofollow`;
+- explicit owner-confirmed `review → published` lifecycle;
+- public concept projections that cannot leak review-only evidence;
+- private/local personal baseline and sensitive-source overlay;
+- living-source freshness and knowledge-evolution support;
+- local action/outcome and learning-utility stores;
+- generated library, knowledge graph, concept pages, sitemap and discovery bundle;
+- reusable local-first starter and repo-local CLI;
+- CI contracts for source, evidence, knowledge, publication, privacy and generated-output drift.
 
-## Cumulative knowledge model
+## What still requires an external research agent
 
-`data/knowledge-graph.json` is the durable memory layer between source-specific research runs.
+The repository is the stable knowledge and product layer. It does **not** embed a universal browser, YouTube transcription service, PDF extractor or LLM runtime.
 
-A concept has a stable ID, short definition, domain, aliases, tags, coverage and supporting insight IDs. Relations are explicit and typed:
+A capable research agent currently performs source inspection and additional verification, then writes the normalized repository contracts. This is intentional: source-specific extraction is kept behind stable inputs so the core model does not depend on one provider.
+
+Provider adapters are a later expansion only when repeated dogfood proves they remove meaningful friction.
+
+## What is still experimental or human-gated
+
+These are deliberately not represented as solved:
+
+- **Delayed reconstruction + transfer benchmark (#19):** prompts and local measurement format exist; real delayed human results are still required.
+- **Curated public proof corpus (#38):** review cases stay private-to-review until a person explicitly approves publication.
+- **Source Decision calibration (#39):** deterministic decision contracts exist; trustworthiness must still be tested against real full-source consumption.
+- **Dogfood utility metrics (#40):** structural 20-source cohort is complete; subjective utility, elapsed work and human learning measurements remain private/human evidence.
+- **GitHub Pages (#45):** the static site and deployment workflow are ready, but the repository-level Pages setting is not currently enabled.
+
+## 20-source validation cohort
+
+The frozen validation cohort is now **20/20 processed**:
+
+| Source type | Count |
+| --- | ---: |
+| Documentation | 7 |
+| Repository | 4 |
+| Paper | 4 |
+| Article | 4 |
+| Video | 1 |
+
+Current publication state: **1 published + 19 review**. This is intentional; output volume is not treated as publication quality.
+
+The cohort exposed real product failures, including:
+
+- semantic retrieval precision/recall errors;
+- evidence-boundary mismatches in transfer prompts, prerequisites and skim locators;
+- mixed published/review concept projection risk;
+- stale-branch materialization races under parallel agent loops;
+- visual-primitive overreach;
+- publication self-test assumptions that broke as the cumulative graph grew.
+
+Those failures produced concrete validators, CI fixes and retrieval regressions. See [`docs/COHORT_20_REPORT.md`](docs/COHORT_20_REPORT.md).
+
+## Knowledge model
+
+`data/knowledge-graph.json` is the cumulative memory between source runs.
+
+A concept has a stable ID, definition, domain, aliases, tags, coverage and supporting insight IDs. Relations are explicit and typed:
 
 ```text
 depends_on
- enables
- realized_by
- refines
- related_to
+enables
+realized_by
+refines
+related_to
 ```
 
-Every relation needs a rationale and shared evidence. The graph validator rejects dangling concepts, dangling insights, duplicate semantic edges, self-relations, unsupported relations and isolated nodes.
-
-Before researching a new source, query prior knowledge:
+Before research, prior concepts are retrieved:
 
 ```bash
 python scripts/graph_context.py "durable workflow retry"
 ```
 
-The agent then classifies overlap as:
+The new source is then classified against prior knowledge as:
 
 ```text
 reinforcement
@@ -111,100 +150,62 @@ new knowledge
 not relevant
 ```
 
-The research-bundle classification is only the input to the public-facing comparison. `data/knowledge-deltas.json` is the curated layer that explains meaningful changes using three separate statements: what the current source establishes, what prior project evidence said, and how the project interprets the difference. `not_relevant` matches remain suppressed rather than becoming decorative graph edges.
+`not relevant` matches are kept out of the graph. Review-only knowledge can help future research internally, while public concept pages remain backed only by published evidence.
 
-Review-only concepts may exist in machine-readable memory so later research can use them. The public `/knowledge/` page exposes only concepts backed by at least one published insight, so cumulative memory cannot bypass human publication review.
+## Knowledge Delta
 
-## Current operating model
+`data/knowledge-deltas.json` is the curated comparison layer.
 
-A capable research agent is currently the intelligence/extraction layer. It reads [`AGENTS.md`](AGENTS.md), the research profile, prior concept graph and pipeline, inspects the supplied source using the tools available to it, performs additional research when needed, and writes the normalized repository artifacts.
+Each meaningful delta separates:
 
-The repository itself does **not** yet contain a universal YouTube/web/PDF transcription service or an embedded LLM runtime. That is intentional: source-specific extraction is separated from the stable research/output contracts so different agents/providers can be used without changing the knowledge model.
+- what the current source establishes;
+- what prior project evidence established;
+- how the project interprets the change.
+
+The first published reference case establishes `controlled-execution` and `execution-history`. Later sources can refine those stable concepts instead of creating new pages just because terminology differs.
+
+## Source Decision
+
+Every review-ready insight gets a decision only after whole-source mapping and evidence exist:
+
+```text
+consume
+skim_selected_parts
+explainer_is_enough
+skip_for_now
+```
+
+For `skim_selected_parts`, every recommended locator is tied back to claim evidence. The decision is a product hypothesis until the human calibration loop in #39 confirms that it reliably saves time.
+
+## Delayed reconstruction
+
+Every review/published insight has an authored prompt designed to test whether the mental model survives after reading.
+
+Example from the published reference case:
+
+> Without looking back, reconstruct why a capable AI agent still needs a controlled execution substrate: state the production failure mode, the surrounding mechanism, the operational result, and one boundary where that model is still insufficient.
+
+The prompt is implemented. A real delayed score is **not** claimed until the human benchmark in #19 is performed.
 
 ## Start a source
 
-A URL can be queued locally with:
+Using the repo-local CLI:
 
 ```bash
-python scripts/new_source.py "https://example.com/source" --type article --focus "What should I learn or try from this?"
+python sti.py intake "https://example.com/source" --type article --focus "What should I learn or try?"
+python sti.py scaffold <intake-id>
+python sti.py validate
 ```
 
-Then create the normalized working artifact:
+Or use the owner-only GitHub source Issue Form. New source issues are normalized, deduplicated and scaffolded with a snapshot of relevant prior knowledge.
 
-```bash
-python scripts/scaffold_bundle.py <intake-id>
-```
-
-New bundles include a snapshot of relevant graph concepts. Those matches begin as `unclassified`; the research step must decide whether the new source reinforces, refines, contradicts or adds knowledge.
-
-The owner-only GitHub Issue Form removes the second manual command: a new `[source]` issue is normalized, deduplicated and, when newly queued, committed together with its graph-aware research bundle.
-
-For agent-driven work, simply provide the source to an agent that can edit this repository and tell it to follow `AGENTS.md`.
-
-## Required processing behavior
-
-Before selecting insights, the agent maps:
-
-- prior concepts and neighboring relations;
-- problem and thesis;
-- source structure;
-- concepts and prerequisites;
-- mechanisms and relationships;
-- named tools/systems;
-- examples;
-- claims/evidence;
-- assumptions;
-- limitations;
-- unresolved questions.
-
-Then `config/research-profile.json` determines what deserves attention. Topic match alone is not enough: an unfamiliar tool or concept stays when it has high learning or practical leverage.
-
-After the coherent model exists, reusable concepts and relations are merged into `data/knowledge-graph.json`. Different wording is not enough to create a new concept; prefer a stable concept ID plus aliases when the meaning is already represented.
-
-Before the insight reaches review, curate its Knowledge Delta. Only meaningful `new / reinforces / refines / contradicts` changes should appear. Keep source evidence, prior evidence and project interpretation visibly separate.
-
-The final action vocabulary is deliberately small:
-
-`use now / try / learn / build / watch / ignore for now`
-
-## Source and date policy
-
-Every published item must preserve:
-
-- canonical source URL or stable identifier;
-- creator/publisher when known;
-- publication date when verifiable;
-- event date separately when relevant;
-- capture and analysis dates;
-- supporting/verification sources and access dates.
-
-A missing source date remains `null` with a note. It is never guessed.
-
-Full third-party transcripts, copied articles, PDF text dumps or mirrored repository contents are not committed. They may be transient research input; public data stores derived maps, paraphrased analysis, safe locators and provenance.
-
-## Visual output
-
-The explainer is generated from structured knowledge, not directly from raw source text.
-
-The visual grammar supports different idea structures:
-
-```text
-causal chain     problem → mechanism → result
-sequence         A → B → C → D
-layered system   experience / orchestration / data
-comparison       A | B
-decision         condition → choices
-```
-
-See [`docs/VISUAL_GRAMMAR.md`](docs/VISUAL_GRAMMAR.md). Images are optional and should be used only when they explain more than a diagram can.
-
-The knowledge graph is a different visualization: its layout is generated from reusable concepts and typed relations, while its learning path is derived from relation semantics rather than manually curated ordering.
+For agent-driven work, give the agent access to this repository and tell it to follow [`AGENTS.md`](AGENTS.md).
 
 ## Publication lifecycle
 
-Publication remains deliberately human-controlled.
+Research output stops at `review` by default.
 
-To publish an existing review insight, use the owner workflow or:
+Publishing requires an explicit confirmation and review note:
 
 ```bash
 python scripts/publish_reviewed.py \
@@ -214,96 +215,91 @@ python scripts/publish_reviewed.py \
   --review-note "What was checked"
 ```
 
-A published insight can be returned to review or archived without losing provenance:
+Published content can be returned to review or archived without losing provenance. Review patches cannot silently downgrade or overwrite a published insight.
 
-```bash
-python scripts/retract_published.py \
-  --insight <insight-id> \
-  --target review \
-  --confirm REVIEW:<insight-id> \
-  --changed-by <reviewer> \
-  --note "Why public state changed"
-```
+## Privacy boundary
 
-The equivalent archive confirmation is `ARCHIVE:<insight-id>`. Public surfaces are regenerated in the same workflow so a retracted item cannot remain discoverable merely because an old generated file survived.
+Private personalization and sensitive-source context live under `.local/` and are excluded from public builders.
 
-## Repository structure
-
-```text
-AGENTS.md                         agent operating contract
-config/research-profile.json      personalization rules
-content/                          human-readable source/explainer notes
-data/
-  inbox.json                      source queue
-  sources.json                    canonical source registry
-  research-bundles/               normalized source maps + prior-knowledge snapshots
-  insights.json                   publishable knowledge model
-  knowledge-deltas.json           curated source-vs-prior changes
-  knowledge-graph.json            cumulative concepts + typed relations
-schemas/                          machine-readable contracts
-scripts/
-  new_source.py                   queue a URL
-  scaffold_bundle.py              create graph-aware research bundle
-  graph_context.py                retrieve relevant prior concepts
-  validate.py                     knowledge validation
-  validate_knowledge_deltas.py    curated-delta consistency checks
-  validate_bundles.py             research-bundle safety + prior-knowledge checks
-  validate_graph.py               concept/relation/evidence validation
-  build.py                        public explainer generator
-  build_previews.py               review-preview generator
-  build_library.py                library generator
-  build_graph.py                  public graph + learning-path generator
-  publish_reviewed.py             explicit review → published transition
-  retract_published.py            explicit published → review/archived transition
-explainers/                       generated published pages
-previews/                         generated review pages
-library/                          generated browsable collection
-knowledge/                        generated public concept graph
-tests/                            end-to-end acceptance fixtures
-```
-
-## Checks
-
-```bash
-python scripts/validate.py
-python scripts/validate_knowledge_deltas.py
-python scripts/validate_graph.py
-python scripts/validate_bundles.py
-python scripts/graph_context.py --self-test
-python scripts/scaffold_bundle.py --self-test
-python scripts/publish_reviewed.py --self-test
-python scripts/retract_published.py --self-test
-python -m unittest discover -s tests -p "test_*.py" -v
-python scripts/build.py
-python scripts/build_previews.py
-python scripts/build_library.py
-python scripts/build_graph.py
-```
-
-Core CI runs graph validation, Knowledge Delta validation, publication-lifecycle tests and prior-knowledge self-tests. Generated pages are also checked or synchronized by dedicated workflows so adding or retracting content cannot silently leave stale public output.
-
-## Reference cases
-
-The first published case uses the AI Engineer World's Fair 2026 talk **“Why Your Enterprise Tech Stack Isn't Ready for AI Agents — And What to Build Instead”** by Christopher Lovejoy and Saul Howard.
-
-Four additional real sources — Temporal documentation, Open Policy Agent, the ReAct paper and retrieval-practice research — are held in `review` and exercise different source adapters and visual structures. Their concepts may participate in machine-readable cumulative memory but remain withheld from the public graph until publication.
-
-These are reference cases only. The same contracts are designed for new tools, repositories, papers, custom architectures, productivity systems and other high-value sources.
+The committed graph may store stable public/review knowledge, but local personal beliefs, active goals, learning results and private source contents are protected by explicit boundary validators.
 
 ## Public surfaces
 
-When GitHub Pages is enabled from `main` / repository root:
+The repository already contains the static public surface:
 
 - `/` — product/method page;
+- `/walkthrough/` — golden proof path;
 - `/library/` — generated searchable explainer library;
-- `/knowledge/` — generated public concept graph + learning path;
+- `/knowledge/` — public concept graph and learning path;
+- `/knowledge/concepts/<id>/` — published-evidence concept pages;
 - `/explainers/<slug>/` — published explainers;
-- `/previews/<slug>/` — review-only noindex pages;
-- `/data/insights.json` and `/data/sources.json` — machine-readable knowledge/provenance;
-- `/data/knowledge-graph.json` — complete cumulative concept memory, including review-supported concepts.
+- `/previews/<slug>/` — review-only `noindex,nofollow` previews;
+- `/data/*.json` — machine-readable source/insight/graph contracts.
 
-See [`ROADMAP.md`](ROADMAP.md) for the next development loops.
+The intended Pages URL is:
+
+```text
+https://dkharlanau.github.io/signal-to-insight/
+```
+
+The deployment workflow is `.github/workflows/pages.yml`. The repository-level GitHub Pages setting must still be enabled for **GitHub Actions** before the workflow can deploy. Until that setting is enabled, the files and route contracts are ready but the Pages URL should not be treated as live.
+
+## Public proof path
+
+The first published case is based on the AI Engineer World's Fair 2026 talk **“Why Your Enterprise Tech Stack Isn't Ready for AI Agents — And What to Build Instead”** by Christopher Lovejoy and Saul Howard.
+
+Use the [Golden walkthrough](walkthrough/index.html) to see how the project turns that source into:
+
+```text
+provenance
+→ whole-source mental model
+→ Knowledge Delta
+→ Source Decision
+→ published visual explainer
+→ delayed reconstruction checkpoint
+```
+
+The walkthrough explicitly marks the delayed outcome as pending rather than inventing a result.
+
+## Repository map
+
+```text
+AGENTS.md                         agent operating contract
+config/                           research profiles and starter configuration
+data/
+  inbox.json                      source queue
+  sources.json                    canonical source registry
+  research-bundles/               whole-source maps + prior-knowledge snapshot
+  insights.json                   structured insights and publication status
+  knowledge-deltas.json           curated source-vs-prior changes
+  claim-evidence.json             important claims + provenance
+  prerequisite-maps.json          prerequisite resolution
+  learning-prompts.json           reconstruction + transfer prompts
+  source-decisions.json           evidence-backed source consumption decision
+  knowledge-graph.json            cumulative concepts + typed relations
+  cohorts/validation-20.json      frozen dogfood cohort evidence
+scripts/                          validators, builders, lifecycle and local loops
+explainers/                       generated published pages
+previews/                         generated review-only pages
+library/                          generated collection
+knowledge/                        generated public concept surfaces
+walkthrough/                      golden product proof path
+docs/                             architecture, visual grammar, cohort report
+```
+
+## Core checks
+
+```bash
+python sti.py validate
+python scripts/benchmark_retrieval.py
+python scripts/cohort_audit.py --check --check-report docs/COHORT_20_REPORT.md
+python scripts/build_sitemap.py --check
+python scripts/publish_reviewed.py --self-test
+python -m unittest discover -s tests -p "test_*.py" -v
+```
+
+See [`ROADMAP.md`](ROADMAP.md) and the GitHub backlog for the remaining validation-first loops.
 
 ---
 
-Maintained by [Dzmitryi Kharlanau](https://github.com/dkharlanau).
+MIT licensed. Maintained by [Dzmitryi Kharlanau](https://github.com/dkharlanau).

--- a/docs/PUBLIC_SURFACE.md
+++ b/docs/PUBLIC_SURFACE.md
@@ -1,0 +1,81 @@
+# Public surface and repository settings
+
+The static product surface is committed and validated in-repository. GitHub repository metadata and Pages enablement are repository-level settings and are intentionally listed separately from code so their state cannot be confused with a successful build.
+
+## Intended repository metadata
+
+Use these values for the GitHub repository settings:
+
+**Description**
+
+> Evidence-backed source-to-understanding engine: whole-source models, cumulative concept memory, Knowledge Delta, Source Decision and reconstruction checks.
+
+**Homepage**
+
+```text
+https://dkharlanau.github.io/signal-to-insight/
+```
+
+**Topics**
+
+```text
+knowledge-management
+research
+learning
+knowledge-graph
+ai-agents
+information-synthesis
+provenance
+local-first
+static-site
+```
+
+The homepage value should be set only together with Pages enablement so GitHub does not advertise a dead route.
+
+## Pages setting
+
+The intended Pages configuration is:
+
+```text
+Settings → Pages → Build and deployment → Source: GitHub Actions
+```
+
+`.github/workflows/pages.yml` then performs:
+
+1. knowledge/evidence validation;
+2. deterministic regeneration of public and review surfaces;
+3. static route + review-privacy validation;
+4. Pages artifact upload;
+5. deployment to the `github-pages` environment.
+
+The workflow remains `workflow_dispatch` while the repository-level Pages setting is disabled. After Pages is enabled and the first manual deployment is verified, switching deployment to `push` on `main` can be considered separately.
+
+## Expected public routes
+
+```text
+/
+/walkthrough/
+/library/
+/knowledge/
+/knowledge/concepts/<published-concept-id>/
+/explainers/<published-slug>/
+```
+
+Review previews exist under `/previews/<slug>/` for repository review workflows, but they must remain `noindex,nofollow`, absent from the sitemap and free of public canonical/JSON-LD discovery metadata.
+
+## Pre-deployment validation
+
+Run:
+
+```bash
+python scripts/build_sitemap.py --check
+python scripts/validate_public_surface.py
+```
+
+The same checks run in `.github/workflows/public-surface.yml` and again before any Pages deployment.
+
+## Evidence boundary
+
+The Golden walkthrough is based only on the already-published reference insight. It can show the authored delayed-reconstruction prompt, but it explicitly marks the delayed outcome as pending because issue #19 still requires a real human delayed-recall attempt.
+
+The 20-source cohort report proves structural/reliability coverage. It does not substitute for human publication review (#38) or Source Decision calibration against full-source consumption (#39).

--- a/index.html
+++ b/index.html
@@ -3,288 +3,103 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Signal to Insight — Personalized Source-to-Understanding Engine</title>
-  <meta name="description" content="Turn videos, papers, tools, repositories and other useful sources into coherent, personalized visual explanations with concepts, tools, actions, sources and dates.">
-  <meta name="theme-color" content="#f1f0e9">
+  <title>Signal to Insight — Evidence-backed source-to-understanding</title>
+  <meta name="description" content="Turn a source into a verified change in understanding: whole-source model, Knowledge Delta, Source Decision, visual explainer and reconstruction checkpoint.">
+  <meta name="theme-color" content="#f2efe7">
   <meta property="og:title" content="Signal to Insight">
-  <meta property="og:description" content="Give it a source. Get back a coherent mental model, useful tools and next actions.">
+  <meta property="og:description" content="Not another summarizer. A cumulative, evidence-backed source-to-understanding engine.">
   <meta property="og:type" content="website">
-  <link rel="stylesheet" href="styles.css">
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "name": "Signal to Insight",
-    "description": "A personalized source-to-understanding engine for concepts, tools and systems.",
-    "author": {
-      "@type": "Person",
-      "name": "Dzmitryi Kharlanau",
-      "url": "https://github.com/dkharlanau"
-    }
-  }
-  </script>
+  <style>
+    :root{--paper:#f2efe7;--ink:#171717;--muted:#66635d;--line:#c8c2b5;--soft:#e7e1d5;--dark:#202326;--max:1180px}
+    *{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.55 Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}a{color:inherit}.wrap{width:min(var(--max),calc(100% - 38px));margin:auto}
+    header{display:flex;justify-content:space-between;align-items:center;gap:24px;padding:26px 0;border-bottom:1px solid var(--line)}.brand{text-decoration:none;font-weight:850;letter-spacing:-.025em}.mark{display:inline-grid;place-items:center;width:36px;height:36px;border:1px solid var(--ink);font-size:12px;margin-right:10px}nav{display:flex;gap:20px;flex-wrap:wrap}nav a{text-decoration:none;font-size:12px;text-transform:uppercase;letter-spacing:.09em;font-weight:750}
+    .hero{padding:82px 0 58px}.eyebrow{font-size:12px;letter-spacing:.12em;text-transform:uppercase;font-weight:800;color:var(--muted)}h1{font-size:clamp(54px,9vw,106px);line-height:.91;letter-spacing:-.07em;margin:16px 0 28px;max-width:1030px}h1 em,h2 em{font-family:Georgia,serif;font-weight:400}.lede{font-size:clamp(21px,3vw,31px);line-height:1.24;max-width:880px;color:#353431;margin:0}.actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:30px}.button{display:inline-block;padding:13px 17px;border:1px solid var(--ink);text-decoration:none;font-weight:800}.button.primary{background:var(--ink);color:var(--paper)}
+    .metrics{display:grid;grid-template-columns:repeat(4,1fr);border-top:1px solid var(--ink);border-bottom:1px solid var(--ink);margin-top:58px}.metric{padding:22px;border-right:1px solid var(--line)}.metric:last-child{border-right:0}.metric strong{display:block;font-size:36px;letter-spacing:-.05em}.metric span{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+    section{padding:70px 0;border-bottom:1px solid var(--line)}h2{font-size:clamp(38px,6vw,70px);line-height:1;letter-spacing:-.052em;margin:10px 0 22px;max-width:970px}.section-lede{font-size:20px;max-width:790px;color:#3f3d38}
+    .loop{display:grid;grid-template-columns:repeat(6,1fr);margin-top:34px;border:1px solid var(--ink)}.loop div{padding:20px;border-right:1px solid var(--line);min-height:160px}.loop div:last-child{border-right:0}.loop small{display:block;color:var(--muted);font-weight:800;letter-spacing:.08em}.loop strong{display:block;font-size:18px;margin:10px 0}
+    .difference{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin-top:34px}.card{border:1px solid var(--line);padding:28px;min-height:210px;background:rgba(255,255,255,.16)}.card small{font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);font-weight:800}.card h3{font-size:28px;letter-spacing:-.035em;margin:9px 0}.card p{margin-bottom:0}
+    .proof{display:grid;grid-template-columns:1.05fr .95fr;gap:14px;margin-top:34px}.proof-main{background:var(--dark);color:#f4f1e9;padding:34px}.proof-main h3{font-size:36px;line-height:1.05;letter-spacing:-.04em;margin:12px 0}.proof-side{border:1px solid var(--line);padding:30px}.proof-side ul{padding-left:20px}.proof-side li{margin:8px 0}
+    .status-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin-top:34px}.status{border:1px solid var(--line);padding:26px}.status strong{font-size:21px;display:block;margin-bottom:12px}.status ul{padding-left:19px;margin:0}.status li{margin:7px 0}.status.pending{background:var(--soft)}
+    .boundary{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-top:30px}.boundary div{padding:30px;border:1px solid var(--line)}.boundary .dark{background:var(--dark);color:#f3f0e8}.boundary h3{font-size:27px;margin-top:0}.boundary ul{padding-left:20px}
+    footer{padding:34px 0 52px;color:var(--muted);display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;font-size:13px}
+    @media(max-width:850px){header{align-items:flex-start;flex-direction:column}.metrics{grid-template-columns:repeat(2,1fr)}.metric:nth-child(2){border-right:0}.loop{grid-template-columns:repeat(2,1fr)}.loop div{border-bottom:1px solid var(--line)}.difference,.proof,.status-grid,.boundary{grid-template-columns:1fr}}@media(max-width:520px){.metrics{grid-template-columns:1fr}.metric{border-right:0;border-bottom:1px solid var(--line)}.loop{grid-template-columns:1fr}}
+  </style>
 </head>
 <body>
-  <div class="progress" aria-hidden="true"><span id="progressBar"></span></div>
-
-  <header class="site-header wrap">
-    <a class="brand" href="#top" aria-label="Signal to Insight home">
-      <span class="brand-mark">S→I</span>
-      <span>Signal to Insight</span>
-    </a>
-    <nav aria-label="Primary navigation">
-      <a href="#method">Engine</a>
-      <a href="#explainer">Case 001</a>
-      <a href="#actions">Action map</a>
-      <a href="data/sources.json">Sources</a>
-      <a href="data/insights.json">Data</a>
-    </nav>
+  <header class="wrap">
+    <a class="brand" href="./"><span class="mark">S→I</span>Signal to Insight</a>
+    <nav aria-label="Primary navigation"><a href="walkthrough/">Walkthrough</a><a href="library/">Library</a><a href="knowledge/">Knowledge</a><a href="docs/COHORT_20_REPORT.md">Evidence</a><a href="https://github.com/dkharlanau/signal-to-insight">GitHub</a></nav>
   </header>
 
-  <main id="top">
+  <main>
     <section class="hero wrap">
-      <p class="eyebrow">PERSONAL RESEARCH ENGINE / 0.2</p>
-      <h1>Give it a source.<br><em>Get back understanding.</em></h1>
-      <div class="hero-grid">
-        <p class="lede">Video, paper, article, tool, repository or unfamiliar system → a coherent visual model of what matters, what to learn, what to try and what to remember.</p>
-        <div class="signal-chain" aria-label="Source to understanding process">
-          <span>source</span><b>→</b><span>model</span><b>→</b><span>action</span>
-        </div>
-      </div>
-      <div class="source-types" aria-label="Supported source types">
-        <span>VIDEO</span><span>PAPER</span><span>ARTICLE</span><span>REPOSITORY</span><span>TOOL</span><span>DOCS</span><span>SYSTEM</span><span>PODCAST</span>
-      </div>
-    </section>
-
-    <section class="profile-band wrap" aria-labelledby="profileTitle">
-      <div>
-        <p class="kicker">THE PERSONALIZATION LAYER</p>
-        <h2 id="profileTitle">Not “summarize this.”<br><em>Figure out what I need from this.</em></h2>
-      </div>
-      <div class="profile-rules">
-        <p><strong>Keep</strong><span>Concepts, prerequisites, tools and examples required for a complete mental model.</span></p>
-        <p><strong>Research</strong><span>Missing context, official docs, counterpoints and useful adjacent systems.</span></p>
-        <p><strong>Drop</strong><span>Repetition, promotional framing and detail that changes neither understanding nor action.</span></p>
-        <p><strong>Never force</strong><span>A SAP or enterprise angle when another application explains the concept better.</span></p>
+      <p class="eyebrow">Evidence-backed source-to-understanding</p>
+      <h1>Turn a source into <em>a change in understanding.</em></h1>
+      <p class="lede">Signal to Insight maps the whole source, compares it with accumulated knowledge, shows what actually changed, tells you whether the original is still worth your time, and leaves a model you can later reconstruct.</p>
+      <div class="actions"><a class="button primary" href="walkthrough/">See the golden walkthrough →</a><a class="button" href="explainers/why-enterprise-ai-agents-fail-after-the-poc/">Open published explainer</a></div>
+      <div class="metrics" aria-label="Validation evidence">
+        <div class="metric"><strong>20</strong><span>real sources processed</span></div>
+        <div class="metric"><strong>5</strong><span>source types</span></div>
+        <div class="metric"><strong>20</strong><span>Source Decisions</span></div>
+        <div class="metric"><strong>1 / 19</strong><span>published / review</span></div>
       </div>
     </section>
 
-    <section id="method" class="method section wrap">
-      <div class="section-number">00</div>
-      <div>
-        <p class="kicker">THE ENGINE</p>
-        <h2>Compress the material.<br><em>Preserve the model.</em></h2>
-      </div>
-      <ol class="method-grid">
-        <li><span>01</span><strong>Capture</strong><p>Record canonical source, creator, publication/event date, capture date and analysis date.</p></li>
-        <li><span>02</span><strong>Map</strong><p>Understand the whole source before selecting highlights: problem, thesis, concepts, tools, examples and assumptions.</p></li>
-        <li><span>03</span><strong>Select</strong><p>Apply the personal research profile and keep the coherent core — including prerequisites needed to understand it.</p></li>
-        <li><span>04</span><strong>Enrich</strong><p>Verify important claims, open official documentation and add missing context or useful tool connections.</p></li>
-        <li><span>05</span><strong>Explain</strong><p>Build a visual landing page ending in use / try / learn / build / watch decisions.</p></li>
-      </ol>
-    </section>
-
-    <section class="quality section wrap">
-      <p class="eyebrow">QUALITY GATE</p>
-      <div class="quality-grid">
-        <h2>A page is finished when <em>the source is optional.</em></h2>
-        <div>
-          <p>Can I explain the topic end-to-end after reading the page?</p>
-          <p>Do I know which concepts and tools deserve deeper attention?</p>
-          <p>Do I understand what the source misses or oversimplifies?</p>
-          <p>Do I know what to use, try, learn, build, watch — or ignore?</p>
-        </div>
+    <section class="wrap" id="loop">
+      <p class="eyebrow">The product loop</p>
+      <h2>Not “save and summarize.” <em>Compile trusted knowledge.</em></h2>
+      <p class="section-lede">The durable asset is not a page. It is a cumulative model with provenance, stable concepts, explicit evidence boundaries and review state.</p>
+      <div class="loop">
+        <div><small>01</small><strong>Source</strong><p>Canonical URL, creator, dates and provenance.</p></div>
+        <div><small>02</small><strong>Whole-source map</strong><p>Problem, thesis, mechanisms, evidence and limitations before compression.</p></div>
+        <div><small>03</small><strong>Knowledge Delta</strong><p>New, reinforced, refined or contradicted knowledge — with noise suppressed.</p></div>
+        <div><small>04</small><strong>Source Decision</strong><p>Consume, skim, explainer-is-enough or skip-for-now.</p></div>
+        <div><small>05</small><strong>Explainer</strong><p>Visual, coherent and generated from structured reviewed knowledge.</p></div>
+        <div><small>06</small><strong>Reconstruct</strong><p>Test whether the mental model survives after reading.</p></div>
       </div>
     </section>
 
-    <article id="explainer" class="explainer section wrap">
-      <header class="explainer-head">
-        <div>
-          <p class="eyebrow">CASE / 001 · VIDEO → MENTAL MODEL</p>
-          <h2>Why enterprise AI agents fail <em>after</em> the POC</h2>
-        </div>
-        <a class="source-link" href="https://www.youtube.com/watch?v=mav15aW9lLM" target="_blank" rel="noreferrer">Original source ↗</a>
-      </header>
-
-      <div class="thesis-grid">
-        <p class="thesis">The useful idea is broader than “enterprise AI.” A model may be capable of doing the work while the <strong>execution system around it</strong> is incapable of controlling, explaining or replaying that work.</p>
-        <div class="meta-card">
-          <span>Source</span><strong>AI Engineer World's Fair 2026</strong>
-          <span>Speakers</span><strong>Christopher Lovejoy<br>Saul Howard</strong>
-          <span>Event date</span><strong>02 Jul 2026</strong>
-          <span>Analyzed</span><strong>26 Aug 2026</strong>
-          <span>Scope</span><strong>Architecture pattern, not SAP-specific</strong>
-        </div>
+    <section class="wrap" id="difference">
+      <p class="eyebrow">Why this is different</p>
+      <h2>Four outputs a normal summary <em>does not give you.</em></h2>
+      <div class="difference">
+        <article class="card"><small>Delta</small><h3>What changed?</h3><p>Every review-ready source is compared against existing concept memory. Attractive but irrelevant matches are recorded as noise instead of becoming fake graph edges.</p></article>
+        <article class="card"><small>Evidence</small><h3>Why believe it?</h3><p>Important claims carry source, verification or prior-insight evidence. Project interpretation is labeled separately from source-authored claims.</p></article>
+        <article class="card"><small>Decision</small><h3>Do I need the original?</h3><p>Source Decision is made only after whole-source mapping. `skim_selected_parts` locators must be backed by the same claim-evidence trace.</p></article>
+        <article class="card"><small>Retention</small><h3>Can I reconstruct it later?</h3><p>Each insight has authored reconstruction and transfer prompts. Real delayed scores remain a human benchmark rather than a generated confidence number.</p></article>
       </div>
+    </section>
 
-      <section class="contrast" aria-labelledby="contrastTitle">
-        <p class="kicker" id="contrastTitle">THE FALSE FINISH LINE</p>
-        <div class="contrast-grid">
-          <div class="contrast-card pale">
-            <span>CAPABILITY</span>
-            <h3>Model → Tool → Result</h3>
-            <p>The demo proves that the model can perform the task.</p>
-          </div>
-          <div class="arrow-block" aria-hidden="true">≠</div>
-          <div class="contrast-card dark">
-            <span>CONTROLLED EXECUTION</span>
-            <h3>Authority + State + Human + History + Replay</h3>
-            <p>The system proves that consequential work can be governed and reconstructed.</p>
-          </div>
-        </div>
-      </section>
-
-      <section id="principles" class="primitives" aria-labelledby="primitivesTitle">
-        <p class="kicker" id="primitivesTitle">THE COHERENT CORE · FOUR IDEAS THAT BELONG TOGETHER</p>
-
-        <div class="primitive">
-          <div class="primitive-id">01</div>
-          <div class="primitive-copy">
-            <h3>Execution history, not only logs</h3>
-            <p>Record enough state and evidence to reconstruct the request, authority, context, decision, action and verification later.</p>
-          </div>
-          <div class="mini-diagram ledger" aria-label="Execution history diagram">
-            <span>request</span><span>identity</span><span>context</span><span>decision</span><span>action</span><span>verify</span>
-          </div>
-        </div>
-
-        <div class="primitive">
-          <div class="primitive-id">02</div>
-          <div class="primitive-copy">
-            <h3>Separate execution from protected data</h3>
-            <p>Observability should not automatically grant broad access to the data used by the workflow. Keep references and protected objects separable.</p>
-          </div>
-          <div class="plane-diagram" aria-label="Separated execution and data planes diagram">
-            <div><small>EXECUTION</small><strong>event → object:v4</strong></div>
-            <i>↕ authorized reference</i>
-            <div><small>PROTECTED DATA</small><strong>object:v4</strong></div>
-          </div>
-        </div>
-
-        <div class="primitive">
-          <div class="primitive-id">03</div>
-          <div class="primitive-copy">
-            <h3>Task first. Executor second.</h3>
-            <p>Define the task independently from whether an AI or person performs it. Human handoff becomes a normal execution mode, not a parallel exception process.</p>
-          </div>
-          <div class="task-diagram" aria-label="Human and AI task equivalence">
-            <strong>approve_change(context)</strong>
-            <div><span>AI executor</span><span>Human executor</span></div>
-          </div>
-        </div>
-
-        <div class="primitive">
-          <div class="primitive-id">04</div>
-          <div class="primitive-copy">
-            <h3>Replay turns history into eval material</h3>
-            <p>When context can be reconstructed, the same case can be rerun with a changed model, prompt, policy or tool and compared against the prior result.</p>
-          </div>
-          <div class="replay-diagram" aria-label="Replay evaluation diagram">
-            <span>same case</span><b>→</b><span>old stack / A</span>
-            <span>same case</span><b>→</b><span>new stack / B</span>
-          </div>
-        </div>
-      </section>
-
-      <section class="application" aria-labelledby="applicationTitle">
-        <div>
-          <p class="kicker">MENTAL MODEL</p>
-          <h3 id="applicationTitle">Any consequential tool call</h3>
-          <p>Customer update, refund, infrastructure change, account action, healthcare workflow or SAP master-data update: the domain changes, but the production question is the same.</p>
-        </div>
-        <div class="flow" aria-label="Controlled agent execution flow">
-          <span>Request</span><b>↓</b>
-          <span>Identity + authority</span><b>↓</b>
-          <span>Context access</span><b>↓</b>
-          <span class="split">Task → AI / Human</span><b>↓</b>
-          <span>Tool / API action</span><b>↓</b>
-          <span>Verification + history</span><b>↓</b>
-          <span>Replay / evaluation</span>
-        </div>
-      </section>
-
-      <section class="tool-section" aria-labelledby="toolsTitle">
-        <p class="kicker">ADJACENT TOOLS TO LEARN</p>
-        <h3 id="toolsTitle">Turn the concept into a learning path.</h3>
-        <p class="section-note">These are project-added connections for learning; they are not presented as tools recommended by the speakers.</p>
-        <div class="tool-grid">
-          <a class="tool-card" href="https://docs.temporal.io/" target="_blank" rel="noreferrer">
-            <span>LEARN</span><strong>Temporal</strong><p>Durable workflows and recovery for long-running execution.</p><small>durable execution ↗</small>
-          </a>
-          <a class="tool-card" href="https://opentelemetry.io/docs/" target="_blank" rel="noreferrer">
-            <span>LEARN</span><strong>OpenTelemetry</strong><p>A standard model for traces, metrics and logs across distributed systems.</p><small>observability ↗</small>
-          </a>
-          <a class="tool-card" href="https://www.openpolicyagent.org/docs" target="_blank" rel="noreferrer">
-            <span>TRY</span><strong>Open Policy Agent</strong><p>A concrete way to separate policy decisions from application logic.</p><small>policy as code ↗</small>
-          </a>
-        </div>
-      </section>
-
-      <section class="critique" aria-labelledby="critiqueTitle">
-        <p class="kicker">WHAT THE HIGH-LEVEL MODEL DOESN'T SOLVE</p>
-        <h3 id="critiqueTitle">Useful primitives still leave real engineering.</h3>
-        <div class="critique-grid">
-          <p><strong>History</strong><br>Still needs identity evidence, component/policy versions, retention, event semantics and tamper resistance.</p>
-          <p><strong>Security</strong><br>Separating data and orchestration reduces exposure; it does not eliminate injection or exfiltration risk.</p>
-          <p><strong>Handoff</strong><br>Still needs ownership, locking, idempotency, approval authority, timeout and recovery rules.</p>
-        </div>
-      </section>
-
-      <section id="actions" class="action-section" aria-labelledby="actionTitle">
-        <p class="kicker">WHAT TO DO WITH THIS</p>
-        <h3 id="actionTitle">Understanding should end in a decision.</h3>
-        <div class="action-map">
-          <div><span>USE NOW</span><p>Judge agent readiness by whether consequential actions can be reconstructed and explained later.</p></div>
-          <div><span>TRY</span><p>Model one task as AI/human-executor independent; write one explicit policy rule outside app logic.</p></div>
-          <div><span>LEARN</span><p>Durable execution, event sourcing, OpenTelemetry concepts and policy-as-code.</p></div>
-          <div><span>BUILD</span><p>A minimal execution ledger: request → authority → context → executor → action → verification.</p></div>
-          <div><span>WATCH</span><p>Whether agent platforms converge on standard identity, state, handoff and replay layers.</p></div>
-        </div>
-      </section>
-
-      <footer class="takeaway">
-        <p class="kicker">THE DURABLE INSIGHT</p>
-        <blockquote>Don't judge an AI system only by whether the model can do the work. Judge whether the surrounding execution system lets the work be controlled, transferred, reconstructed and evaluated.</blockquote>
-      </footer>
-
-      <section class="source-ledger" aria-labelledby="sourcesTitle">
-        <p class="kicker">SOURCES + DATES</p>
-        <h3 id="sourcesTitle">Keep provenance visible.</h3>
-        <div class="source-row">
-          <span>PRIMARY</span>
-          <p><a href="https://www.youtube.com/watch?v=mav15aW9lLM" target="_blank" rel="noreferrer">Lovejoy & Howard — Why Your Enterprise Tech Stack Isn't Ready for AI Agents</a><br>AI Engineer World's Fair 2026 · event 02 Jul 2026 · analyzed 26 Aug 2026</p>
-        </div>
-        <div class="source-row">
-          <span>VERIFY</span>
-          <p><a href="https://ai.engineer/worldsfair/schedule" target="_blank" rel="noreferrer">AI Engineer World's Fair 2026 schedule</a><br>Used to verify session/event date · accessed 26 Aug 2026</p>
-        </div>
-        <div class="source-row">
-          <span>ENRICH</span>
-          <p><a href="https://docs.temporal.io/" target="_blank" rel="noreferrer">Temporal docs</a> · <a href="https://opentelemetry.io/docs/" target="_blank" rel="noreferrer">OpenTelemetry docs</a> · <a href="https://www.openpolicyagent.org/docs" target="_blank" rel="noreferrer">OPA docs</a><br>Adjacent learning/tool context · accessed 26 Aug 2026</p>
-        </div>
-      </section>
-    </article>
-
-    <section class="knowledge section wrap">
-      <div>
-        <p class="eyebrow">KNOWLEDGE LAYER</p>
-        <h2>Landing page outside.<br><em>Structured memory underneath.</em></h2>
+    <section class="wrap" id="proof">
+      <p class="eyebrow">Public proof</p>
+      <h2>One intentionally published case. <em>Nineteen remain review-only.</em></h2>
+      <p class="section-lede">Publication is a trust boundary, not a content-volume target. The 20-source cohort was used to expose failures in retrieval, evidence linking, public projection and parallel agent execution before expanding the platform.</p>
+      <div class="proof">
+        <div class="proof-main"><p class="eyebrow" style="color:#bfc1bf">Case 001 · published</p><h3>Why enterprise AI agents fail after the POC</h3><p>The case establishes the baseline controlled-execution and execution-history model. Later sources refine these concepts without rewriting the public evidence boundary.</p><a class="button" style="border-color:#f4f1e9;color:#f4f1e9" href="walkthrough/">Follow the complete proof path →</a></div>
+        <div class="proof-side"><strong>20-source cohort</strong><ul><li>7 documentation sources</li><li>4 repositories</li><li>4 papers</li><li>4 articles</li><li>1 video</li><li>20 Knowledge Deltas</li><li>20 Source Decisions</li><li>85 important claims at cohort freeze</li></ul><a class="button" href="docs/COHORT_20_REPORT.md">Read structural evidence</a></div>
       </div>
-      <p>Source metadata, dates, concepts, tools, limitations and action decisions are stored as data so future agents can connect new material to what has already been learned.</p>
-      <div class="button-stack">
-        <a class="button" href="data/insights.json">Open insights.json →</a>
-        <a class="button" href="data/sources.json">Open sources.json →</a>
-        <a class="button" href="config/research-profile.json">Research profile →</a>
+    </section>
+
+    <section class="wrap" id="status">
+      <p class="eyebrow">Current product boundary</p>
+      <h2>Know what works now — <em>and what is not yet proven.</em></h2>
+      <div class="status-grid">
+        <div class="status"><strong>Usable today</strong><ul><li>Intake + provenance</li><li>Whole-source bundles</li><li>Cumulative concept graph</li><li>Knowledge Delta + evidence</li><li>Prerequisite maps</li><li>Source Decision</li><li>Review/publish isolation</li><li>Private/local context</li></ul></div>
+        <div class="status"><strong>Requires a research agent</strong><ul><li>Inspect arbitrary external sources</li><li>Use browser/PDF/repository tools</li><li>Perform source-specific verification</li><li>Write normalized research artifacts</li></ul></div>
+        <div class="status pending"><strong>Human evidence pending</strong><ul><li>Delayed reconstruction benchmark #19</li><li>Curated publication review #38</li><li>Source Decision calibration #39</li><li>Repository-level Pages enablement #45</li></ul></div>
+      </div>
+    </section>
+
+    <section class="wrap" id="boundary">
+      <p class="eyebrow">Trust boundary</p>
+      <h2>Review knowledge may improve the model <em>without becoming public.</em></h2>
+      <div class="boundary">
+        <div><h3>Internal cumulative memory</h3><ul><li>Published + review-supported concepts</li><li>Prior retrieval for later research</li><li>Knowledge evolution and refinements</li><li>Explicit false-match suppression</li></ul></div>
+        <div class="dark"><h3>Public projection</h3><ul><li>Published evidence only</li><li>Human-confirmed publication</li><li>No review previews in sitemap</li><li>No silent leakage when a published concept receives a review refinement</li></ul></div>
       </div>
     </section>
   </main>
 
-  <footer class="site-footer wrap">
-    <span>Signal to Insight</span>
-    <span>Built by <a href="https://github.com/dkharlanau">Dzmitryi Kharlanau</a></span>
-    <span>Source → model → action</span>
-  </footer>
-
-  <script src="app.js"></script>
+  <footer class="wrap"><span>Signal to Insight · MIT licensed</span><span><a href="walkthrough/">Walkthrough</a> · <a href="library/">Library</a> · <a href="knowledge/">Knowledge</a> · <a href="https://github.com/dkharlanau/signal-to-insight">GitHub</a></span></footer>
 </body>
 </html>

--- a/scripts/build_sitemap.py
+++ b/scripts/build_sitemap.py
@@ -46,6 +46,7 @@ def render() -> str:
 
     blocks = [
         url_block(f"{BASE}/", today, "weekly", "1.0"),
+        url_block(f"{BASE}/walkthrough/", today, "monthly", "0.95"),
         url_block(f"{BASE}/library/", today, "weekly", "0.9"),
         url_block(f"{BASE}/knowledge/", today, "weekly", "0.9"),
     ]

--- a/scripts/validate_public_surface.py
+++ b/scripts/validate_public_surface.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Validate the static public/review surface before a GitHub Pages deployment."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSIGHTS = ROOT / "data" / "insights.json"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    required_routes = {
+        "root": ROOT / "index.html",
+        "walkthrough": ROOT / "walkthrough" / "index.html",
+        "library": ROOT / "library" / "index.html",
+        "knowledge": ROOT / "knowledge" / "index.html",
+    }
+    for label, path in required_routes.items():
+        if not path.exists():
+            errors.append(f"missing public route {label}: {path.relative_to(ROOT)}")
+
+    readme = read(ROOT / "README.md")
+    for required in (
+        "Golden walkthrough",
+        "20-source cohort report",
+        "GitHub Pages setting",
+        "delayed reconstruction",
+        "Source Decision",
+    ):
+        if required.lower() not in readme.lower():
+            errors.append(f"README is missing public-surface proof text: {required!r}")
+
+    root_html = read(required_routes["root"]) if required_routes["root"].exists() else ""
+    if "Signal to Insight" not in root_html:
+        errors.append("root product page does not identify Signal to Insight")
+    if 'name="robots" content="noindex' in root_html.lower():
+        errors.append("root public page must not be noindex")
+
+    walkthrough = read(required_routes["walkthrough"]) if required_routes["walkthrough"].exists() else ""
+    walkthrough_requirements = (
+        "Knowledge Delta",
+        "Source Decision",
+        "published explainer",
+        "Outcome pending human benchmark",
+        "What is already proven",
+    )
+    for required in walkthrough_requirements:
+        if required.lower() not in walkthrough.lower():
+            errors.append(f"walkthrough is missing proof stage/boundary: {required!r}")
+    if "no delayed-recall score is invented" not in walkthrough.lower():
+        errors.append("walkthrough must explicitly refuse to invent delayed-recall evidence")
+
+    data = json.loads(read(INSIGHTS))
+    published = [item for item in data.get("insights", []) if item.get("status") == "published"]
+    if not published:
+        errors.append("public surface requires at least one explicitly published insight")
+    for insight in published:
+        slug = insight.get("slug")
+        if not isinstance(slug, str) or not slug:
+            errors.append(f"published insight missing slug: {insight.get('id')}")
+            continue
+        page = ROOT / "explainers" / slug / "index.html"
+        if not page.exists():
+            errors.append(f"published explainer route missing: {page.relative_to(ROOT)}")
+            continue
+        html = read(page).lower()
+        if 'name="robots" content="noindex' in html:
+            errors.append(f"published explainer must not be noindex: {page.relative_to(ROOT)}")
+
+    previews = sorted((ROOT / "previews").glob("*/index.html")) if (ROOT / "previews").exists() else []
+    for preview in previews:
+        html = read(preview).lower().replace(" ", "")
+        if 'name="robots"content="noindex,nofollow"' not in html:
+            errors.append(f"review preview is not noindex,nofollow: {preview.relative_to(ROOT)}")
+        if 'rel="canonical"' in html or 'application/ld+json' in html:
+            errors.append(f"review preview exposes public discovery metadata: {preview.relative_to(ROOT)}")
+
+    sitemap = read(ROOT / "sitemap.xml") if (ROOT / "sitemap.xml").exists() else ""
+    for route in (
+        "https://dkharlanau.github.io/signal-to-insight/",
+        "https://dkharlanau.github.io/signal-to-insight/walkthrough/",
+        "https://dkharlanau.github.io/signal-to-insight/library/",
+        "https://dkharlanau.github.io/signal-to-insight/knowledge/",
+    ):
+        if f"<loc>{route}</loc>" not in sitemap:
+            errors.append(f"sitemap missing intended public route: {route}")
+    if "/previews/" in sitemap:
+        errors.append("sitemap must never expose review preview routes")
+
+    pages_workflow = ROOT / ".github" / "workflows" / "pages.yml"
+    if not pages_workflow.exists():
+        errors.append("GitHub Pages deployment workflow is missing")
+    else:
+        workflow = read(pages_workflow)
+        for action in ("actions/configure-pages@", "actions/upload-pages-artifact@", "actions/deploy-pages@"):
+            if action not in workflow:
+                errors.append(f"Pages workflow missing deployment action: {action}")
+
+    if errors:
+        print(f"Public surface validation failed with {len(errors)} error(s):")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print(
+        "Public surface validation passed: "
+        f"{len(required_routes)} primary routes, {len(published)} published explainer(s), "
+        f"{len(previews)} protected review preview(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,6 +7,12 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://dkharlanau.github.io/signal-to-insight/walkthrough/</loc>
+    <lastmod>2026-08-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://dkharlanau.github.io/signal-to-insight/library/</loc>
     <lastmod>2026-08-27</lastmod>
     <changefreq>weekly</changefreq>

--- a/walkthrough/index.html
+++ b/walkthrough/index.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Golden walkthrough — Signal to Insight</title>
+  <meta name="description" content="One complete Signal to Insight proof path: source, whole-source model, Knowledge Delta, Source Decision, published explainer and delayed reconstruction checkpoint.">
+  <meta name="theme-color" content="#f3f1e9">
+  <meta property="og:title" content="Signal to Insight — Golden walkthrough">
+  <meta property="og:description" content="See one source move through the complete evidence-backed understanding loop.">
+  <meta property="og:type" content="article">
+  <style>
+    :root{--paper:#f3f1e9;--ink:#171717;--muted:#66645e;--line:#c9c5ba;--panel:#e9e5da;--dark:#1f2326;--max:1120px}
+    *{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;background:var(--paper);color:var(--ink);font:16px/1.55 Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+    a{color:inherit} .wrap{width:min(var(--max),calc(100% - 36px));margin:auto}
+    header{display:flex;justify-content:space-between;gap:24px;align-items:center;padding:26px 0;border-bottom:1px solid var(--line)}
+    .brand{font-weight:800;text-decoration:none;letter-spacing:-.02em}.brand span{display:inline-grid;place-items:center;width:34px;height:34px;border:1px solid var(--ink);margin-right:10px;font-size:12px}
+    nav{display:flex;gap:18px;flex-wrap:wrap}nav a{font-size:13px;text-transform:uppercase;letter-spacing:.08em;text-decoration:none}
+    .hero{padding:72px 0 54px}.eyebrow,.step-no,.status{font-size:12px;letter-spacing:.12em;text-transform:uppercase;font-weight:800}.eyebrow{color:var(--muted)}
+    h1{font-size:clamp(46px,8vw,94px);line-height:.95;letter-spacing:-.065em;margin:16px 0 24px;max-width:950px}h1 em,h2 em{font-family:Georgia,serif;font-weight:400}
+    .lede{font-size:clamp(20px,3vw,30px);line-height:1.25;max-width:820px;margin:0;color:#343330}
+    .proof-strip{display:grid;grid-template-columns:repeat(6,1fr);border-top:1px solid var(--ink);border-bottom:1px solid var(--ink);margin-top:48px}.proof-strip span{padding:15px 10px;font-size:12px;text-transform:uppercase;letter-spacing:.07em;text-align:center;border-right:1px solid var(--line)}.proof-strip span:last-child{border-right:0}
+    main{padding-bottom:90px}.step{display:grid;grid-template-columns:90px 1fr;gap:34px;padding:58px 0;border-bottom:1px solid var(--line)}.step-no{padding-top:8px;color:var(--muted)}
+    h2{font-size:clamp(34px,5vw,62px);line-height:1;letter-spacing:-.045em;margin:0 0 20px;max-width:880px}.intro{font-size:20px;max-width:780px;color:#383733}
+    .grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:28px}.card{border:1px solid var(--line);padding:24px;min-height:150px;background:rgba(255,255,255,.18)}.card strong{display:block;font-size:20px;margin:6px 0}.card small{color:var(--muted);text-transform:uppercase;letter-spacing:.08em}
+    .model{display:grid;grid-template-columns:1fr auto 1fr auto 1fr;gap:12px;align-items:stretch;margin-top:30px}.model div{border:1px solid var(--ink);padding:22px}.model b{display:grid;place-items:center;font-size:26px}.model small{display:block;color:var(--muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:7px}
+    .delta{background:var(--dark);color:#f5f3ed;padding:30px;margin-top:28px}.delta-row{display:grid;grid-template-columns:110px 1fr;gap:20px;padding:18px 0;border-top:1px solid #51565a}.delta-row:first-of-type{margin-top:18px}.delta-row span{font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:#bfc4c7}.delta-row strong{font-size:21px;display:block;margin-bottom:5px}
+    .decision{display:grid;grid-template-columns:220px 1fr;gap:28px;border:2px solid var(--ink);padding:30px;margin-top:28px}.decision .badge{display:grid;place-items:center;text-align:center;background:var(--ink);color:var(--paper);font-weight:850;text-transform:uppercase;letter-spacing:.08em;padding:22px}.selected{margin:16px 0 0;padding-left:20px}.selected li{margin:8px 0}
+    .cta{display:inline-block;margin-top:18px;border:1px solid var(--ink);padding:12px 16px;text-decoration:none;font-weight:750}.cta:hover{background:var(--ink);color:var(--paper)}
+    blockquote{font:28px/1.35 Georgia,serif;margin:28px 0;padding:28px;border-left:5px solid var(--ink);background:var(--panel)}
+    .pending{border:1px dashed var(--ink);padding:24px;margin-top:22px}.pending .status{display:inline-block;background:#e1d9c6;padding:5px 8px;margin-bottom:12px}.pending p{margin:7px 0}
+    .truth{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-top:28px}.truth>div{padding:28px;border:1px solid var(--line)}.truth .no{background:#e5e0d5}.truth ul{padding-left:20px;margin-bottom:0}
+    footer{padding:30px 0 50px;color:var(--muted);font-size:13px;display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
+    @media(max-width:760px){header{align-items:flex-start;flex-direction:column}.proof-strip{grid-template-columns:repeat(2,1fr)}.step{grid-template-columns:1fr;gap:10px}.model{grid-template-columns:1fr}.model b{transform:rotate(90deg);height:28px}.grid,.truth,.decision{grid-template-columns:1fr}.decision .badge{min-height:110px}}
+  </style>
+</head>
+<body>
+  <header class="wrap">
+    <a class="brand" href="../"><span>S→I</span>Signal to Insight</a>
+    <nav aria-label="Walkthrough navigation">
+      <a href="#delta">Delta</a><a href="#decision">Decision</a><a href="#reconstruct">Reconstruct</a><a href="../library/">Library</a><a href="../knowledge/">Knowledge</a>
+    </nav>
+  </header>
+
+  <section class="hero wrap">
+    <p class="eyebrow">Golden walkthrough · one complete proof path</p>
+    <h1>Not a summary.<br><em>A change in understanding.</em></h1>
+    <p class="lede">This page follows one already-published source through the complete Signal to Insight contract: source provenance → whole-source model → Knowledge Delta → Source Decision → published explainer → delayed reconstruction checkpoint.</p>
+    <div class="proof-strip" aria-label="Product proof path">
+      <span>01 Source</span><span>02 Model</span><span>03 Delta</span><span>04 Decision</span><span>05 Explainer</span><span>06 Reconstruct</span>
+    </div>
+  </section>
+
+  <main class="wrap">
+    <section class="step" id="source">
+      <div class="step-no">01 / SOURCE</div>
+      <div>
+        <p class="eyebrow">Start with evidence, not generated prose</p>
+        <h2>One source, <em>with provenance.</em></h2>
+        <p class="intro">The reference case is the 2026 AI Engineer World's Fair talk “Why Your Enterprise Tech Stack Isn't Ready for AI Agents — And What to Build Instead.” The system records the canonical source, speakers, event date, capture/analysis date and verification sources before deriving an insight.</p>
+        <div class="grid">
+          <div class="card"><small>Primary source</small><strong>Conference talk</strong><p>Christopher Lovejoy & Saul Howard · AI Engineer World's Fair 2026.</p></div>
+          <div class="card"><small>Product question</small><strong>What survives compression?</strong><p>Keep the production architecture model, not a sequence of memorable quotes.</p></div>
+        </div>
+        <a class="cta" href="https://www.youtube.com/watch?v=mav15aW9lLM" target="_blank" rel="noreferrer">Open original source ↗</a>
+      </div>
+    </section>
+
+    <section class="step" id="model">
+      <div class="step-no">02 / MODEL</div>
+      <div>
+        <p class="eyebrow">Map the whole source before selecting highlights</p>
+        <h2>Compress without <em>breaking the causal chain.</em></h2>
+        <p class="intro">The whole-source model separates the problem, mechanism and result before the page is written. For this case, the key distinction is capability versus controlled production execution.</p>
+        <div class="model" aria-label="Mental model">
+          <div><small>Problem</small><strong>A capable model is not a production system</strong><p>Tool success does not prove authority, recoverability, auditability or safe intervention.</p></div><b>→</b>
+          <div><small>Mechanism</small><strong>Controlled execution substrate</strong><p>Identity + policy + protected data boundaries + executor-independent tasks + durable history.</p></div><b>→</b>
+          <div><small>Result</small><strong>Work can be reconstructed and evaluated</strong><p>Consequential actions become governable, transferable and replayable rather than opaque tool calls.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="step" id="delta">
+      <div class="step-no">03 / DELTA</div>
+      <div>
+        <p class="eyebrow">Compare with accumulated knowledge</p>
+        <h2>Show what the source <em>actually changes.</em></h2>
+        <p class="intro">Because this was the first reference case, its Knowledge Delta establishes the baseline rather than pretending there was earlier evidence to refine.</p>
+        <div class="delta">
+          <p class="eyebrow" style="color:#bfc4c7">Knowledge Delta · curated, evidence-aware</p>
+          <div class="delta-row"><span>NEW</span><div><strong>Controlled execution</strong><p>The source establishes that production agent work needs authority, durable history, protected-data boundaries, intervention and replay around model execution.</p></div></div>
+          <div class="delta-row"><span>NEW</span><div><strong>Execution history</strong><p>Reconstructable work evidence becomes a reusable concept for governance and later evaluation.</p></div></div>
+        </div>
+        <p><small>Later sources can reinforce or refine these stable concepts instead of creating disconnected pages. False retrieval matches remain suppressed rather than becoming decorative graph edges.</small></p>
+      </div>
+    </section>
+
+    <section class="step" id="decision">
+      <div class="step-no">04 / DECISION</div>
+      <div>
+        <p class="eyebrow">Do I still need the original?</p>
+        <h2>Turn understanding into a <em>time decision.</em></h2>
+        <div class="decision">
+          <div class="badge">Skim selected parts</div>
+          <div>
+            <p>The explainer preserves the production mental model, but the original talk still adds value in three evidence-dense areas:</p>
+            <ol class="selected">
+              <li>POC success versus production readiness.</li>
+              <li>Execution history and replay.</li>
+              <li>The controlled-substrate framing across protected data and human handoff.</li>
+            </ol>
+            <p><small>This recommendation is generated only after whole-source mapping and claim evidence exist. Issue #39 separately tests whether these recommendations are actually calibrated against full-source consumption.</small></p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="step" id="explainer">
+      <div class="step-no">05 / EXPLAINER</div>
+      <div>
+        <p class="eyebrow">Published only after review</p>
+        <h2>A visual explainer backed by <em>structured knowledge.</em></h2>
+        <p class="intro">The public page is generated from the reviewed insight, claim evidence, prerequisites, Knowledge Delta and source metadata — not directly from a raw transcript.</p>
+        <div class="grid">
+          <div class="card"><small>Public state</small><strong>Published</strong><p>One intentionally public reference case. The rest of the 20-source cohort remains review-only until explicit human publication review.</p></div>
+          <div class="card"><small>Cumulative memory</small><strong>Stable concepts</strong><p>Later research can use review knowledge internally while public concept projections remain limited to published evidence.</p></div>
+        </div>
+        <a class="cta" href="../explainers/why-enterprise-ai-agents-fail-after-the-poc/">Open the published explainer →</a>
+      </div>
+    </section>
+
+    <section class="step" id="reconstruct">
+      <div class="step-no">06 / RECONSTRUCT</div>
+      <div>
+        <p class="eyebrow">Immediate clarity is not enough</p>
+        <h2>Can the model be <em>reconstructed later?</em></h2>
+        <p class="intro">Every review-ready insight has an authored reconstruction prompt. This is where the product moves from “I understood the page” to a falsifiable learning check.</p>
+        <blockquote>Without looking back, reconstruct why a capable AI agent still needs a controlled execution substrate: state the production failure mode, the surrounding mechanism, the operational result, and one boundary where that model is still insufficient.</blockquote>
+        <div class="pending">
+          <span class="status">Outcome pending human benchmark</span>
+          <p><strong>What exists now:</strong> the prompt, answer-key anchors and transfer question are implemented and validated.</p>
+          <p><strong>What is not claimed:</strong> no delayed-recall score is invented here. Issue #19 requires a real human delay, reconstruction attempt and missed-model analysis.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="step" id="truth">
+      <div class="step-no">PROOF / BOUNDARY</div>
+      <div>
+        <p class="eyebrow">What is already proven versus still experimental</p>
+        <h2>Keep the evidence boundary <em>visible.</em></h2>
+        <div class="truth">
+          <div><h3>Usable today</h3><ul><li>URL intake and provenance contracts.</li><li>Whole-source research bundles.</li><li>Cumulative concept graph and prior retrieval.</li><li>Knowledge Delta, claim evidence and prerequisites.</li><li>Source Decision and visual explainers.</li><li>Review/publish isolation and private/local context.</li><li>20-source structural dogfood cohort with regression fixes.</li></ul></div>
+          <div class="no"><h3>Still requires external or human evidence</h3><ul><li>A capable research agent/provider to inspect arbitrary external sources.</li><li>Human approval before review content becomes public.</li><li>Delayed reconstruction/transfer benchmark (#19).</li><li>Source Decision calibration against full-source consumption (#39).</li><li>GitHub Pages repository setting before this static surface is live.</li></ul></div>
+        </div>
+        <a class="cta" href="../docs/COHORT_20_REPORT.md">Read the 20-source cohort report →</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="wrap"><span>Signal to Insight · evidence-backed source-to-understanding</span><span><a href="../">Home</a> · <a href="../library/">Library</a> · <a href="../knowledge/">Knowledge</a> · <a href="https://github.com/dkharlanau/signal-to-insight">GitHub</a></span></footer>
+</body>
+</html>


### PR DESCRIPTION
Implements the autonomous repository side of #45.

Adds/changes:
- replaces the early 0.2 root demo with a concise proof-first product landing page;
- adds `/walkthrough/` showing the full published proof path: source → whole-source model → Knowledge Delta → Source Decision → published explainer → delayed reconstruction checkpoint;
- explicitly marks delayed outcome as pending human benchmark rather than fabricating evidence;
- rewrites README around the current 20-source cohort and clear `usable today / external agent / human evidence pending` boundaries;
- adds the walkthrough to generated sitemap;
- adds `scripts/validate_public_surface.py` and PR/push CI to verify root/walkthrough/library/knowledge/published explainers plus `noindex,nofollow` review previews;
- runs the same route/privacy audit inside the Pages deployment before artifact upload;
- documents intended GitHub description, homepage, topics and the exact Pages `Source: GitHub Actions` repository setting in `docs/PUBLIC_SURFACE.md`.

Repository-level metadata and Pages enablement are not claimed as changed because the connected GitHub actions do not expose those settings mutations. The static site and deployment path are now independently testable before that admin switch is enabled.