### PR TITLE
retrieval: learn from cohort not-relevant matches

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -86,7 +86,7 @@ jobs:
           python scripts/scaffold_bundle.py --self-test
 
       - name: Benchmark prior-knowledge retrieval quality
-        run: python scripts/benchmark_retrieval.py
+        run: python scripts/benchmark_retrieval.py --compare-feedback
 
       - name: Test one-command source orchestration
         run: python scripts/run_source.py --self-test

--- a/data/retrieval-negative-feedback.json
+++ b/data/retrieval-negative-feedback.json
@@ -1,0 +1,59 @@
+{
+  "version": "1.0.0",
+  "records": [
+    {
+      "id": "kubernetes-controller-rejections",
+      "intake_id": "intake-2026-08-27-kubernetes-controller",
+      "query": "Understand reconciliation/control loops: desired state vs current state, why many small controllers are preferable to one monolith, and what this teaches about resilient automation.",
+      "rejected_concepts": [
+        "durable-execution",
+        "workflow-execution",
+        "controlled-execution",
+        "event-history",
+        "worker-process"
+      ]
+    },
+    {
+      "id": "sqlite-wal-rejections",
+      "intake_id": "intake-2026-08-27-sqlite-wal-html",
+      "query": "Understand the WAL mental model, read/write concurrency, checkpointing, failure boundaries, and when append-first persistence changes system behavior.",
+      "rejected_concepts": [
+        "execution-history",
+        "event-history",
+        "controlled-execution",
+        "replayable-evaluation"
+      ]
+    },
+    {
+      "id": "postgresql-mvcc-rejections",
+      "intake_id": "intake-2026-08-27-postgresql-mvcc-intro-html",
+      "query": "Understand MVCC as a concurrency model: snapshots, read/write non-blocking behavior, isolation boundaries, and what the model does not eliminate.",
+      "rejected_concepts": [
+        "wal-reader-snapshot"
+      ]
+    },
+    {
+      "id": "transformer-rejections",
+      "intake_id": "intake-2026-08-27-arxiv-1706-03762",
+      "query": "Understand why self-attention replaced recurrence for the Transformer architecture, what parallelism and dependency modeling changed, and which claims belong to the original machine-translation context rather than later LLM folklore.",
+      "rejected_concepts": [
+        "retrieval-practice",
+        "observation-grounding",
+        "policy-as-code",
+        "performance-retention-gap",
+        "controlled-execution"
+      ]
+    },
+    {
+      "id": "opentelemetry-trace-rejections",
+      "intake_id": "intake-2026-08-27-opentelemetry-traces",
+      "query": "Understand traces as a causal model of distributed work: spans, parent/child relationships, context propagation, links and what observability can reconstruct versus what business execution evidence must record separately.",
+      "rejected_concepts": [
+        "controlled-execution",
+        "execution-history",
+        "open-policy-agent",
+        "durable-execution"
+      ]
+    }
+  ]
+}

--- a/docs/RETRIEVAL_FEEDBACK_EXPERIMENT.md
+++ b/docs/RETRIEVAL_FEEDBACK_EXPERIMENT.md
@@ -1,0 +1,119 @@
+# Retrieval feedback experiment — cohort negative matches
+
+Status: **measured, not adopted**.
+
+The 20-source dogfood cohort produced several real `not_relevant` prior-knowledge matches. Instead of treating them as anecdotes, this experiment asked whether remembered negative matches should suppress concepts during future retrieval.
+
+## Evidence set
+
+`data/retrieval-negative-feedback.json` contains five source-time rejection sets from real research bundles:
+
+- Kubernetes controllers rejected Temporal/workflow/control concepts;
+- SQLite WAL rejected execution-history/control concepts;
+- PostgreSQL MVCC rejected the SQLite WAL reader snapshot as concept identity;
+- the original Transformer paper rejected unrelated learning/policy/control concepts;
+- OpenTelemetry tracing rejected execution-history/control/durable-execution/OPA concepts.
+
+Every feedback record is checked against the original research bundle. A stored negative is valid only when the captured prior snapshot actually contained that concept and the source analysis classified it `relationship_to_source = not_relevant`.
+
+This is evidence-backed retrieval feedback, not a free-form blacklist.
+
+## Gold set
+
+The retrieval benchmark now contains **12 cases**. Four cohort-derived cases were added for:
+
+- Kubernetes reconciliation versus workflow execution;
+- PostgreSQL MVCC versus SQLite WAL snapshot semantics;
+- Transformer architecture versus cross-domain vocabulary noise;
+- OpenTelemetry tracing versus execution-history/control concepts.
+
+The earlier SQLite and SRE regression probes remain as additional cohort-derived coverage.
+
+Each case preserves:
+
+- required concepts;
+- acceptable context;
+- forbidden concepts;
+- minimum precision proxy;
+- traceability through matched terms or an explicit graph path.
+
+## Candidate tested
+
+The baseline remained the normal deterministic `graph_context.rank()` behavior.
+
+The experimental candidate added an **opt-in** suppression set. Historical negative feedback was activated only when the current query shared at least three searchable terms and at least 40% term coverage with a captured source-time query.
+
+The candidate was intentionally conservative:
+
+- no embeddings;
+- no vector store;
+- no hidden reranker;
+- no global permanent blacklist;
+- every suppressed concept came from validated historical evidence.
+
+Production retrieval was not changed during the experiment.
+
+## Measured result
+
+CI comparison on the 12-case gold set:
+
+| Metric | Baseline | Feedback-aware candidate |
+| --- | ---: | ---: |
+| Cases passed | 12 / 12 | 12 / 12 |
+| Forbidden hits | 0 | 0 |
+| Macro precision proxy | 0.950 | 0.950 |
+| Macro required recall | 1.000 | 1.000 |
+| Required-recall regressions | 0 | 0 |
+
+The candidate was safe, but it produced **no measurable improvement**.
+
+The benchmark decision was therefore:
+
+```text
+DO NOT ADOPT
+candidate_safe = true
+forbidden_improvement = false
+precision_not_worse = true
+recall_regressions = none
+```
+
+## Why the experiment did not improve retrieval
+
+The current deterministic retrieval had already improved during the cohort:
+
+- weak one-token lexical matches are rejected as seeds;
+- graph expansion stays one hop by default;
+- a second hop is allowed only through a query-relevant bridge;
+- real cohort regressions are already part of the gold benchmark.
+
+As a result, the historical false positives that motivated the experiment no longer appear in the measured baseline.
+
+Examples from the final baseline:
+
+- Kubernetes returns only reconciliation / desired-state / observed-state concepts;
+- PostgreSQL returns the MVCC/isolation cluster and not `wal-reader-snapshot`;
+- Transformer returns the self-attention/sequence cluster and no learning/policy/control noise;
+- OpenTelemetry returns trace/context/span concepts and not execution-history/control concepts.
+
+## Product decision
+
+Do **not** make negative-feedback suppression part of production retrieval now.
+
+Keep:
+
+- the 12-case regression benchmark;
+- the evidence-backed negative-feedback corpus;
+- the manual `--compare-feedback` experiment for future regression analysis;
+- the existing transparent lexical + graph-path retrieval contract.
+
+Production CI should continue enforcing the ordinary baseline benchmark.
+
+Re-run the comparison only when new real source work produces a false prior match that the baseline benchmark can reproduce. Adopt a feedback mechanism only if it reduces measured forbidden results without lowering required recall or precision.
+
+## What this means for embeddings
+
+This experiment is evidence against adding retrieval infrastructure for completeness alone.
+
+The current deterministic approach reaches 1.000 required recall with zero forbidden hits on the measured 12-case set. That does not prove it will remain sufficient forever, but it means embeddings/vector infrastructure currently lacks a measured problem to solve.
+
+A future retrieval architecture change should begin with a failing regression case, not with a new retrieval technology.

--- a/scripts/benchmark_retrieval.py
+++ b/scripts/benchmark_retrieval.py
@@ -8,18 +8,127 @@ import json
 import sys
 from pathlib import Path
 
-from graph_context import rank
+from graph_context import rank, words
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_FIXTURE = ROOT / "tests" / "fixtures" / "retrieval-benchmark.json"
+DEFAULT_FEEDBACK = ROOT / "data" / "retrieval-negative-feedback.json"
+BUNDLES = ROOT / "data" / "research-bundles"
+
+
+class BenchmarkError(ValueError):
+    pass
 
 
 def load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def evaluate_case(case: dict) -> dict:
-    result = rank(case["query"], int(case.get("limit", 5)))
+def load_feedback(path: Path = DEFAULT_FEEDBACK) -> list[dict]:
+    data = load(path)
+    records = data.get("records")
+    if not isinstance(records, list):
+        raise BenchmarkError("retrieval feedback records must be a list")
+
+    seen: set[str] = set()
+    validated: list[dict] = []
+    for index, record in enumerate(records):
+        where = f"feedback[{index}]"
+        record_id = record.get("id")
+        intake_id = record.get("intake_id")
+        query = record.get("query")
+        rejected = record.get("rejected_concepts")
+        if not isinstance(record_id, str) or not record_id:
+            raise BenchmarkError(f"{where}.id must be non-empty")
+        if record_id in seen:
+            raise BenchmarkError(f"duplicate feedback id: {record_id}")
+        seen.add(record_id)
+        if not isinstance(intake_id, str) or not intake_id:
+            raise BenchmarkError(f"{where}.intake_id must be non-empty")
+        if not isinstance(query, str) or not query.strip():
+            raise BenchmarkError(f"{where}.query must be non-empty")
+        if not isinstance(rejected, list) or not rejected or not all(isinstance(item, str) and item for item in rejected):
+            raise BenchmarkError(f"{where}.rejected_concepts must be a non-empty string list")
+        if len(set(rejected)) != len(rejected):
+            raise BenchmarkError(f"{where}.rejected_concepts contains duplicates")
+
+        bundle_path = BUNDLES / f"{intake_id}.json"
+        if not bundle_path.exists():
+            raise BenchmarkError(f"{where}: research bundle not found: {bundle_path.relative_to(ROOT)}")
+        bundle = load(bundle_path)
+        prior = bundle.get("prior_knowledge") or {}
+        if prior.get("query") != query:
+            raise BenchmarkError(f"{where}: feedback query differs from captured research-bundle query")
+        match_by_id = {
+            item.get("concept_id"): item
+            for item in prior.get("matches", [])
+            if isinstance(item, dict) and item.get("concept_id")
+        }
+        for concept_id in rejected:
+            match = match_by_id.get(concept_id)
+            if match is None:
+                raise BenchmarkError(
+                    f"{where}: rejected concept '{concept_id}' is absent from captured prior snapshot"
+                )
+            if match.get("relationship_to_source") != "not_relevant":
+                raise BenchmarkError(
+                    f"{where}: rejected concept '{concept_id}' is not classified not_relevant"
+                )
+        validated.append({
+            **record,
+            "query_terms": sorted(words(query)),
+        })
+    return validated
+
+
+def feedback_suppression(query: str, records: list[dict]) -> tuple[set[str], list[dict]]:
+    """Return rejected concepts from sufficiently similar historical source-time queries.
+
+    This is intentionally conservative and experimental. It requires at least three shared
+    searchable terms and 40% overlap relative to the smaller query. Exact historical queries
+    therefore activate their evidence-backed negatives, while unrelated domains do not inherit
+    a global blacklist.
+    """
+    query_terms = words(query)
+    suppressed: set[str] = set()
+    activations: list[dict] = []
+    if not query_terms:
+        return suppressed, activations
+
+    for record in records:
+        historical_terms = set(record.get("query_terms", []))
+        if not historical_terms:
+            continue
+        overlap = query_terms & historical_terms
+        denominator = max(1, min(len(query_terms), len(historical_terms)))
+        coverage = len(overlap) / denominator
+        if len(overlap) < 3 or coverage < 0.4:
+            continue
+        rejected = set(record.get("rejected_concepts", []))
+        suppressed.update(rejected)
+        activations.append({
+            "feedback_id": record["id"],
+            "overlap_terms": sorted(overlap),
+            "coverage": round(coverage, 3),
+            "rejected_concepts": sorted(rejected),
+        })
+    return suppressed, activations
+
+
+def evaluate_case(
+    case: dict,
+    feedback_records: list[dict] | None = None,
+) -> dict:
+    suppressed: set[str] = set()
+    activations: list[dict] = []
+    if feedback_records is not None:
+        suppressed, activations = feedback_suppression(case["query"], feedback_records)
+
+    result = rank(
+        case["query"],
+        int(case.get("limit", 5)),
+        suppressed_concepts=suppressed,
+    )
     returned = [item["concept_id"] for item in result.get("matches", [])]
     required = set(case.get("required", []))
     acceptable = set(case.get("acceptable", []))
@@ -64,16 +173,21 @@ def evaluate_case(case: dict) -> dict:
         "required_recall": round(recall, 3),
         "precision_proxy": round(precision, 3),
         "forbidden_found": sorted(forbidden_found),
+        "suppressed_concepts": sorted(suppressed),
+        "feedback_activations": activations,
         "traces": traces,
         "passed": not failures,
         "failures": failures,
     }
 
 
-def run_benchmark(fixture: Path = DEFAULT_FIXTURE) -> dict:
+def run_benchmark(
+    fixture: Path = DEFAULT_FIXTURE,
+    feedback_records: list[dict] | None = None,
+) -> dict:
     data = load(fixture)
     cases = data.get("cases", [])
-    results = [evaluate_case(case) for case in cases]
+    results = [evaluate_case(case, feedback_records=feedback_records) for case in cases]
     if results:
         macro_precision = sum(item["precision_proxy"] for item in results) / len(results)
         macro_recall = sum(item["required_recall"] for item in results) / len(results)
@@ -87,19 +201,77 @@ def run_benchmark(fixture: Path = DEFAULT_FIXTURE) -> dict:
             "case_count": len(results),
             "passed": sum(item["passed"] for item in results),
             "failed": sum(not item["passed"] for item in results),
+            "forbidden_hits": sum(len(item["forbidden_found"]) for item in results),
+            "feedback_activations": sum(bool(item["feedback_activations"]) for item in results),
             "macro_precision_proxy": round(macro_precision, 3),
             "macro_required_recall": round(macro_recall, 3),
         },
     }
 
 
-def print_report(report: dict) -> None:
+def compare_benchmarks(fixture: Path, feedback_path: Path) -> dict:
+    feedback = load_feedback(feedback_path)
+    baseline = run_benchmark(fixture, feedback_records=None)
+    candidate = run_benchmark(fixture, feedback_records=feedback)
+    baseline_by_id = {item["id"]: item for item in baseline["cases"]}
+    candidate_by_id = {item["id"]: item for item in candidate["cases"]}
+
+    recall_regressions = [
+        case_id
+        for case_id, item in candidate_by_id.items()
+        if item["required_recall"] < baseline_by_id[case_id]["required_recall"]
+    ]
+    forbidden_improvement = (
+        candidate["summary"]["forbidden_hits"] < baseline["summary"]["forbidden_hits"]
+    )
+    precision_not_worse = (
+        candidate["summary"]["macro_precision_proxy"] >= baseline["summary"]["macro_precision_proxy"]
+    )
+    candidate_safe = candidate["summary"]["failed"] == 0 and not recall_regressions
+    adopt = candidate_safe and forbidden_improvement and precision_not_worse
+
+    changed_cases = []
+    for case_id, candidate_item in candidate_by_id.items():
+        baseline_item = baseline_by_id[case_id]
+        if candidate_item["returned"] != baseline_item["returned"]:
+            changed_cases.append({
+                "id": case_id,
+                "baseline": baseline_item["returned"],
+                "candidate": candidate_item["returned"],
+                "suppressed": candidate_item["suppressed_concepts"],
+                "baseline_forbidden": baseline_item["forbidden_found"],
+                "candidate_forbidden": candidate_item["forbidden_found"],
+                "baseline_recall": baseline_item["required_recall"],
+                "candidate_recall": candidate_item["required_recall"],
+            })
+
+    return {
+        "baseline": baseline,
+        "candidate": candidate,
+        "decision": {
+            "adopt": adopt,
+            "candidate_safe": candidate_safe,
+            "forbidden_improvement": forbidden_improvement,
+            "precision_not_worse": precision_not_worse,
+            "recall_regressions": recall_regressions,
+            "changed_cases": changed_cases,
+            "rule": "Adopt only if candidate has no failed cases or required-recall regressions, reduces forbidden hits, and does not reduce macro precision proxy.",
+        },
+    }
+
+
+def print_report(report: dict, title: str | None = None) -> None:
+    if title:
+        print(title)
     for item in report["cases"]:
         status = "PASS" if item["passed"] else "FAIL"
         print(
             f"{status} {item['id']}: precision={item['precision_proxy']:.3f} "
             f"required_recall={item['required_recall']:.3f} returned={','.join(item['returned'])}"
         )
+        if item.get("feedback_activations"):
+            ids = ",".join(entry["feedback_id"] for entry in item["feedback_activations"])
+            print(f"  feedback: {ids}; suppressed={','.join(item['suppressed_concepts'])}")
         for failure in item["failures"]:
             print(f"  - {failure}")
         for trace in item["traces"]:
@@ -111,20 +283,54 @@ def print_report(report: dict) -> None:
     summary = report["summary"]
     print(
         f"Summary: {summary['passed']}/{summary['case_count']} passed; "
+        f"forbidden hits={summary['forbidden_hits']}; "
         f"macro precision={summary['macro_precision_proxy']:.3f}; "
         f"macro required recall={summary['macro_required_recall']:.3f}"
     )
 
 
+def print_comparison(comparison: dict) -> None:
+    print_report(comparison["baseline"], "=== Baseline ===")
+    print()
+    print_report(comparison["candidate"], "=== Feedback-aware candidate ===")
+    decision = comparison["decision"]
+    print()
+    print(
+        "Decision: "
+        + ("ADOPT" if decision["adopt"] else "DO NOT ADOPT")
+        + f"; candidate_safe={decision['candidate_safe']}"
+        + f"; forbidden_improvement={decision['forbidden_improvement']}"
+        + f"; precision_not_worse={decision['precision_not_worse']}"
+        + f"; recall_regressions={','.join(decision['recall_regressions']) or 'none'}"
+    )
+    for item in decision["changed_cases"]:
+        print(
+            f"  changed {item['id']}: baseline={','.join(item['baseline'])} "
+            f"candidate={','.join(item['candidate'])} suppressed={','.join(item['suppressed'])}"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE)
+    parser.add_argument("--feedback", type=Path, default=DEFAULT_FEEDBACK)
+    parser.add_argument("--compare-feedback", action="store_true")
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
 
     try:
+        if args.compare_feedback:
+            comparison = compare_benchmarks(args.fixture, args.feedback)
+            if args.json:
+                print(json.dumps(comparison, ensure_ascii=False, indent=2))
+            else:
+                print_comparison(comparison)
+            # Baseline is allowed to expose the measured problem. The experiment is CI-safe only
+            # when the feedback candidate itself has no failed cases or recall regressions.
+            return 0 if comparison["decision"]["candidate_safe"] else 1
+
         report = run_benchmark(args.fixture)
-    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError, BenchmarkError) as exc:
         print(f"Retrieval benchmark error: {exc}")
         return 1
 

--- a/scripts/graph_context.py
+++ b/scripts/graph_context.py
@@ -83,11 +83,23 @@ def is_strong_seed(features: dict) -> bool:
     return False
 
 
-def rank(query: str, limit: int = 5) -> dict:
+def rank(
+    query: str,
+    limit: int = 5,
+    suppressed_concepts: set[str] | None = None,
+) -> dict:
+    """Rank graph concepts, optionally excluding an experiment-provided concept set.
+
+    `suppressed_concepts` is deliberately opt-in. Production retrieval does not learn from
+    rejected cohort matches unless a caller explicitly supplies evidence-backed feedback.
+    This makes baseline-versus-candidate experiments possible without silently changing the
+    live ranking contract.
+    """
     graph = json.loads(GRAPH.read_text(encoding="utf-8"))
     insight_data = json.loads(INSIGHTS.read_text(encoding="utf-8"))
     insights = {item["id"]: item for item in insight_data.get("insights", [])}
     concepts = {item["id"]: item for item in graph.get("concepts", [])}
+    suppressed = set(suppressed_concepts or ())
     query_words = words(query)
     if not query_words:
         return {"query": query, "matches": [], "message": "No searchable terms."}
@@ -97,6 +109,8 @@ def rank(query: str, limit: int = 5) -> dict:
     for concept in concepts.values():
         features = lexical_features(query, query_words, concept)
         feature_map[concept["id"]] = features
+        if concept["id"] in suppressed:
+            continue
         if is_strong_seed(features):
             scored.append((features["score"], concept["id"]))
     scored.sort(key=lambda item: (-item[0], concepts[item[1]]["label"].lower()))
@@ -119,7 +133,7 @@ def rank(query: str, limit: int = 5) -> dict:
                 "rationale": relation["rationale"],
             }
             neighbors[left].append(entry)
-            if right not in seeds:
+            if right not in seeds and right not in suppressed:
                 neighbor_candidates.setdefault(right, {"via": [], "strength": 0})
                 neighbor_candidates[right]["via"].append({"seed": left, "type": relation["type"], "direction": "out"})
                 neighbor_candidates[right]["strength"] += score_map.get(left, 0)
@@ -132,7 +146,7 @@ def rank(query: str, limit: int = 5) -> dict:
                 "rationale": relation["rationale"],
             }
             neighbors[right].append(entry)
-            if left not in seeds:
+            if left not in seeds and left not in suppressed:
                 neighbor_candidates.setdefault(left, {"via": [], "strength": 0})
                 neighbor_candidates[left]["via"].append({"seed": right, "type": relation["type"], "direction": "in"})
                 neighbor_candidates[left]["strength"] += score_map.get(right, 0)
@@ -160,7 +174,12 @@ def rank(query: str, limit: int = 5) -> dict:
             bridge_id, target_id, direction = right, left, "in"
         if bridge_id is None or target_id is None or direction is None:
             continue
-        if target_id in seeds or target_id in direct_candidates or target_id == bridge_id:
+        if (
+            target_id in seeds
+            or target_id in direct_candidates
+            or target_id == bridge_id
+            or target_id in suppressed
+        ):
             continue
         bridge_strength = neighbor_candidates[bridge_id]["strength"]
         neighbor_candidates[target_id] = {
@@ -235,6 +254,7 @@ def rank(query: str, limit: int = 5) -> dict:
         "query": query,
         "query_terms": sorted(query_words),
         "matches": matches,
+        "suppressed_concepts": sorted(suppressed),
         "instruction": "Use lexical matches as likely prior concepts and graph-neighbor matches as context. Distinguish reinforcement, refinement, contradiction and genuinely new concepts before drafting a new insight."
     }
 
@@ -249,6 +269,15 @@ def self_test() -> int:
         return 1
     if not any(item.get("neighbors") for item in durable["matches"]):
         print("graph context self-test failed; expected expanded neighbors")
+        return 1
+
+    suppressed = rank(
+        "durable workflow retry",
+        limit=5,
+        suppressed_concepts={"durable-execution"},
+    )
+    if "durable-execution" in {item["concept_id"] for item in suppressed.get("matches", [])}:
+        print("graph context self-test failed; opt-in suppression did not exclude durable-execution")
         return 1
 
     opa = rank(

--- a/tests/fixtures/retrieval-benchmark.json
+++ b/tests/fixtures/retrieval-benchmark.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.2.0",
   "cases": [
     {
       "id": "durable-workflow-retry",
@@ -80,6 +80,46 @@
       "forbidden": ["execution-history", "event-history", "replayable-evaluation", "controlled-execution"],
       "min_precision": 0.6,
       "classification_probe": "cohort-precision-regression"
+    },
+    {
+      "id": "kubernetes-reconciliation-not-workflow",
+      "query": "Understand reconciliation/control loops: desired state vs current state, why many small controllers are preferable to one monolith, and what this teaches about resilient automation.",
+      "limit": 5,
+      "required": ["reconciliation-loop", "desired-state", "observed-state"],
+      "acceptable": [],
+      "forbidden": ["durable-execution", "workflow-execution", "controlled-execution", "event-history", "worker-process"],
+      "min_precision": 0.6,
+      "classification_probe": "cohort-negative-feedback"
+    },
+    {
+      "id": "postgresql-mvcc-not-wal-snapshot",
+      "query": "Understand MVCC as a concurrency model: snapshots, read/write non-blocking behavior, isolation boundaries, and what the model does not eliminate.",
+      "limit": 5,
+      "required": ["multiversion-concurrency-control", "mvcc-snapshot", "transaction-isolation-scope"],
+      "acceptable": ["serialization-failure-retry"],
+      "forbidden": ["wal-reader-snapshot", "write-ahead-log", "checkpointing"],
+      "min_precision": 0.6,
+      "classification_probe": "cohort-negative-feedback"
+    },
+    {
+      "id": "transformer-no-cross-domain-noise",
+      "query": "Understand why self-attention replaced recurrence for the Transformer architecture, what parallelism and dependency modeling changed, and which claims belong to the original machine-translation context rather than later LLM folklore.",
+      "limit": 5,
+      "required": ["self-attention", "sequence-computation-parallelism", "positional-encoding"],
+      "acceptable": ["transformer-sequence-transduction", "attention-dependency-path"],
+      "forbidden": ["retrieval-practice", "observation-grounding", "policy-as-code", "performance-retention-gap", "controlled-execution"],
+      "min_precision": 0.6,
+      "classification_probe": "cohort-negative-feedback"
+    },
+    {
+      "id": "opentelemetry-trace-not-execution-history",
+      "query": "Understand traces as a causal model of distributed work: spans, parent/child relationships, context propagation, links and what observability can reconstruct versus what business execution evidence must record separately.",
+      "limit": 5,
+      "required": ["distributed-trace", "trace-context-propagation", "span-link"],
+      "acceptable": ["telemetry-span", "observability"],
+      "forbidden": ["execution-history", "controlled-execution", "durable-execution", "open-policy-agent"],
+      "min_precision": 0.6,
+      "classification_probe": "cohort-negative-feedback"
     }
   ]
 }


### PR DESCRIPTION
Implements the measured experiment from #98 without changing production retrieval by default.

Adds:
- evidence-backed `data/retrieval-negative-feedback.json` from five real cohort source-time snapshots (Kubernetes, SQLite WAL, PostgreSQL MVCC, Transformer, OpenTelemetry);
- validation that every stored rejection actually appears in that intake's captured prior snapshot with `relationship_to_source=not_relevant`;
- four additional cohort regression cases in the retrieval gold set (12 total);
- an opt-in `suppressed_concepts` path in `graph_context.rank()` used only by the experiment;
- baseline-vs-feedback-aware comparison with a conservative query-similarity activation rule;
- an explicit adoption rule: no failed candidate cases or required-recall regression, fewer forbidden hits, and no macro-precision regression.

CI temporarily runs the comparison mode. Baseline is allowed to expose the measured problem; the feedback candidate must be safe. Production ranking remains unchanged until the comparison result justifies adoption.