### PR TITLE
Superseded: retrieval baseline comparison duplicate

### DIFF
--- a/scripts/benchmark_retrieval.py
+++ b/scripts/benchmark_retrieval.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run deterministic precision-oriented prior-knowledge retrieval benchmarks."""
+"""Run deterministic baseline-vs-candidate prior-knowledge retrieval benchmarks."""
 
 from __future__ import annotations
 
@@ -18,8 +18,16 @@ def load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def evaluate_case(case: dict) -> dict:
-    result = rank(case["query"], int(case.get("limit", 5)))
+def evaluate_case(case: dict, mode: str) -> dict:
+    if mode not in {"baseline", "candidate"}:
+        raise ValueError(f"unknown retrieval mode: {mode}")
+    candidate = mode == "candidate"
+    result = rank(
+        case["query"],
+        int(case.get("limit", 5)),
+        strict_seed_gating=candidate,
+        query_relevant_bridge=candidate,
+    )
     returned = [item["concept_id"] for item in result.get("matches", [])]
     required = set(case.get("required", []))
     acceptable = set(case.get("acceptable", []))
@@ -64,16 +72,14 @@ def evaluate_case(case: dict) -> dict:
         "required_recall": round(recall, 3),
         "precision_proxy": round(precision, 3),
         "forbidden_found": sorted(forbidden_found),
+        "forbidden_count": len(forbidden_found),
         "traces": traces,
         "passed": not failures,
         "failures": failures,
     }
 
 
-def run_benchmark(fixture: Path = DEFAULT_FIXTURE) -> dict:
-    data = load(fixture)
-    cases = data.get("cases", [])
-    results = [evaluate_case(case) for case in cases]
+def summarize(results: list[dict]) -> dict:
     if results:
         macro_precision = sum(item["precision_proxy"] for item in results) / len(results)
         macro_recall = sum(item["required_recall"] for item in results) / len(results)
@@ -81,39 +87,131 @@ def run_benchmark(fixture: Path = DEFAULT_FIXTURE) -> dict:
         macro_precision = 0.0
         macro_recall = 0.0
     return {
+        "case_count": len(results),
+        "passed": sum(item["passed"] for item in results),
+        "failed": sum(not item["passed"] for item in results),
+        "macro_precision_proxy": round(macro_precision, 3),
+        "macro_required_recall": round(macro_recall, 3),
+        "forbidden_hits": sum(item["forbidden_count"] for item in results),
+    }
+
+
+def run_benchmark(fixture: Path = DEFAULT_FIXTURE) -> dict:
+    data = load(fixture)
+    cases = data.get("cases", [])
+    baseline = [evaluate_case(case, "baseline") for case in cases]
+    candidate = [evaluate_case(case, "candidate") for case in cases]
+    baseline_by_id = {item["id"]: item for item in baseline}
+    candidate_by_id = {item["id"]: item for item in candidate}
+
+    recall_regressions: list[str] = []
+    forbidden_regressions: list[str] = []
+    precision_improvements: list[str] = []
+    recall_improvements: list[str] = []
+    for case in cases:
+        case_id = case["id"]
+        before = baseline_by_id[case_id]
+        after = candidate_by_id[case_id]
+        if after["required_recall"] < before["required_recall"]:
+            recall_regressions.append(case_id)
+        if after["forbidden_count"] > before["forbidden_count"]:
+            forbidden_regressions.append(case_id)
+        if after["precision_proxy"] > before["precision_proxy"]:
+            precision_improvements.append(case_id)
+        if after["required_recall"] > before["required_recall"]:
+            recall_improvements.append(case_id)
+
+    baseline_summary = summarize(baseline)
+    candidate_summary = summarize(candidate)
+    false_positive_improved = (
+        candidate_summary["forbidden_hits"] < baseline_summary["forbidden_hits"]
+        or candidate_summary["macro_precision_proxy"] > baseline_summary["macro_precision_proxy"]
+    )
+    accepted = (
+        candidate_summary["failed"] == 0
+        and not recall_regressions
+        and not forbidden_regressions
+        and candidate_summary["macro_precision_proxy"] >= baseline_summary["macro_precision_proxy"]
+        and candidate_summary["macro_required_recall"] >= baseline_summary["macro_required_recall"]
+        and false_positive_improved
+    )
+
+    return {
         "version": data.get("version"),
-        "cases": results,
-        "summary": {
-            "case_count": len(results),
-            "passed": sum(item["passed"] for item in results),
-            "failed": sum(not item["passed"] for item in results),
-            "macro_precision_proxy": round(macro_precision, 3),
-            "macro_required_recall": round(macro_recall, 3),
+        "baseline_mode": {
+            "strict_seed_gating": False,
+            "query_relevant_bridge": False,
+            "description": "Permissive pre-dogfood comparison: any non-zero lexical concept can seed one-hop graph expansion.",
+        },
+        "candidate_mode": {
+            "strict_seed_gating": True,
+            "query_relevant_bridge": True,
+            "description": "Current deterministic ranker: strong seed gating plus second hop only through a query-relevant graph bridge.",
+        },
+        "baseline": {"cases": baseline, "summary": baseline_summary},
+        "candidate": {"cases": candidate, "summary": candidate_summary},
+        "comparison": {
+            "macro_precision_delta": round(candidate_summary["macro_precision_proxy"] - baseline_summary["macro_precision_proxy"], 3),
+            "macro_required_recall_delta": round(candidate_summary["macro_required_recall"] - baseline_summary["macro_required_recall"], 3),
+            "forbidden_hits_delta": candidate_summary["forbidden_hits"] - baseline_summary["forbidden_hits"],
+            "precision_improved_cases": precision_improvements,
+            "recall_improved_cases": recall_improvements,
+            "recall_regressions": recall_regressions,
+            "forbidden_regressions": forbidden_regressions,
+            "accepted": accepted,
         },
     }
 
 
-def print_report(report: dict) -> None:
-    for item in report["cases"]:
-        status = "PASS" if item["passed"] else "FAIL"
-        print(
-            f"{status} {item['id']}: precision={item['precision_proxy']:.3f} "
-            f"required_recall={item['required_recall']:.3f} returned={','.join(item['returned'])}"
-        )
-        for failure in item["failures"]:
-            print(f"  - {failure}")
-        for trace in item["traces"]:
-            if trace["type"] == "lexical":
-                print(f"  trace {trace['concept_id']}: terms={','.join(trace['matched_terms'])}")
-            else:
-                via = ",".join(f"{hop['seed']}:{hop['type']}:{hop['direction']}" for hop in trace["via"])
-                print(f"  trace {trace['concept_id']}: via={via}")
-    summary = report["summary"]
+def print_case(item: dict, prefix: str = "") -> None:
+    status = "PASS" if item["passed"] else "FAIL"
     print(
-        f"Summary: {summary['passed']}/{summary['case_count']} passed; "
-        f"macro precision={summary['macro_precision_proxy']:.3f}; "
-        f"macro required recall={summary['macro_required_recall']:.3f}"
+        f"{prefix}{status} {item['id']}: precision={item['precision_proxy']:.3f} "
+        f"required_recall={item['required_recall']:.3f} forbidden={item['forbidden_count']} "
+        f"returned={','.join(item['returned'])}"
     )
+    for failure in item["failures"]:
+        print(f"  - {failure}")
+
+
+def print_report(report: dict) -> None:
+    print("Baseline — permissive lexical seeds + one graph hop")
+    for item in report["baseline"]["cases"]:
+        print_case(item, "  ")
+    before = report["baseline"]["summary"]
+    print(
+        f"  Summary: precision={before['macro_precision_proxy']:.3f}; "
+        f"required_recall={before['macro_required_recall']:.3f}; "
+        f"forbidden_hits={before['forbidden_hits']}"
+    )
+
+    print("\nCandidate — strict seeds + query-relevant bridge")
+    for item in report["candidate"]["cases"]:
+        print_case(item, "  ")
+    after = report["candidate"]["summary"]
+    print(
+        f"  Summary: {after['passed']}/{after['case_count']} passed; "
+        f"precision={after['macro_precision_proxy']:.3f}; "
+        f"required_recall={after['macro_required_recall']:.3f}; "
+        f"forbidden_hits={after['forbidden_hits']}"
+    )
+
+    comparison = report["comparison"]
+    print(
+        "\nComparison: "
+        f"precision_delta={comparison['macro_precision_delta']:+.3f}; "
+        f"recall_delta={comparison['macro_required_recall_delta']:+.3f}; "
+        f"forbidden_delta={comparison['forbidden_hits_delta']:+d}; "
+        f"accepted={comparison['accepted']}"
+    )
+    if comparison["precision_improved_cases"]:
+        print("  precision improved: " + ", ".join(comparison["precision_improved_cases"]))
+    if comparison["recall_improved_cases"]:
+        print("  recall improved: " + ", ".join(comparison["recall_improved_cases"]))
+    if comparison["recall_regressions"]:
+        print("  recall regressions: " + ", ".join(comparison["recall_regressions"]))
+    if comparison["forbidden_regressions"]:
+        print("  forbidden regressions: " + ", ".join(comparison["forbidden_regressions"]))
 
 
 def main() -> int:
@@ -132,7 +230,7 @@ def main() -> int:
         print(json.dumps(report, ensure_ascii=False, indent=2))
     else:
         print_report(report)
-    return 1 if report["summary"]["failed"] else 0
+    return 0 if report["comparison"]["accepted"] else 1
 
 
 if __name__ == "__main__":

--- a/scripts/graph_context.py
+++ b/scripts/graph_context.py
@@ -34,16 +34,6 @@ def normalized_phrase(value: str) -> str:
     return " ".join(TOKEN.findall(value.lower()))
 
 
-def searchable(concept: dict) -> str:
-    return " ".join([
-        concept.get("label", ""),
-        concept.get("summary", ""),
-        concept.get("domain", ""),
-        " ".join(concept.get("aliases", [])),
-        " ".join(concept.get("tags", [])),
-    ])
-
-
 def lexical_features(query: str, query_words: set[str], concept: dict) -> dict:
     label_and_aliases = concept.get("label", "") + " " + " ".join(concept.get("aliases", []))
     label_words = words(label_and_aliases)
@@ -76,14 +66,24 @@ def is_strong_seed(features: dict) -> bool:
         return True
     if features["label_hits"]:
         return True
-    # No label match: require at least two independent topical terms. A single tag such as
-    # 'retrieval', 'engine' or 'system' is not enough evidence that two domains are related.
     if len(features["distinct_hits"]) >= 2 and (features["tag_hits"] or len(features["body_hits"]) >= 2):
         return True
     return False
 
 
-def rank(query: str, limit: int = 5) -> dict:
+def rank(
+    query: str,
+    limit: int = 5,
+    *,
+    strict_seed_gating: bool = True,
+    query_relevant_bridge: bool = True,
+) -> dict:
+    """Rank prior concepts.
+
+    The default is the current candidate algorithm. Benchmark callers can disable both
+    dogfood-derived protections to reproduce the permissive one-hop baseline on the same
+    graph and gold set without maintaining a second retrieval implementation.
+    """
     graph = json.loads(GRAPH.read_text(encoding="utf-8"))
     insight_data = json.loads(INSIGHTS.read_text(encoding="utf-8"))
     insights = {item["id"]: item for item in insight_data.get("insights", [])}
@@ -97,7 +97,8 @@ def rank(query: str, limit: int = 5) -> dict:
     for concept in concepts.values():
         features = lexical_features(query, query_words, concept)
         feature_map[concept["id"]] = features
-        if is_strong_seed(features):
+        eligible = is_strong_seed(features) if strict_seed_gating else features["score"] > 0
+        if eligible:
             scored.append((features["score"], concept["id"]))
     scored.sort(key=lambda item: (-item[0], concepts[item[1]]["label"].lower()))
 
@@ -121,7 +122,7 @@ def rank(query: str, limit: int = 5) -> dict:
             neighbors[left].append(entry)
             if right not in seeds:
                 neighbor_candidates.setdefault(right, {"via": [], "strength": 0})
-                neighbor_candidates[right]["via"].append({"seed": left, "type": relation["type"], "direction": "out"})
+                neighbor_candidates[right]["via"].append({"seed": left, "type": relation["type"], "direction": "out", "hop": 1})
                 neighbor_candidates[right]["strength"] += score_map.get(left, 0)
         if right in seeds:
             entry = {
@@ -134,39 +135,40 @@ def rank(query: str, limit: int = 5) -> dict:
             neighbors[right].append(entry)
             if left not in seeds:
                 neighbor_candidates.setdefault(left, {"via": [], "strength": 0})
-                neighbor_candidates[left]["via"].append({"seed": right, "type": relation["type"], "direction": "in"})
+                neighbor_candidates[left]["via"].append({"seed": right, "type": relation["type"], "direction": "in", "hop": 1})
                 neighbor_candidates[left]["strength"] += score_map.get(right, 0)
 
-    # One hop is normally enough and keeps retrieval precise. Real dogfood exposed one
-    # important miss, though: a query can directly match several source-specific concepts
-    # whose shared parent/prior model is one more edge away. Allow that second hop only when
-    # the intermediate neighbor independently has a strong lexical match to the query.
-    # This makes the graph act as semantic context without opening arbitrary two-hop drift.
-    bridge_ids = {
-        concept_id
-        for concept_id in neighbor_candidates
-        if is_strong_seed(feature_map[concept_id])
-    }
-    direct_candidates = set(neighbor_candidates)
-    for relation in graph.get("relations", []):
-        left = relation["from"]
-        right = relation["to"]
-        bridge_id: str | None = None
-        target_id: str | None = None
-        direction: str | None = None
-        if left in bridge_ids:
-            bridge_id, target_id, direction = left, right, "out"
-        elif right in bridge_ids:
-            bridge_id, target_id, direction = right, left, "in"
-        if bridge_id is None or target_id is None or direction is None:
-            continue
-        if target_id in seeds or target_id in direct_candidates or target_id == bridge_id:
-            continue
-        bridge_strength = neighbor_candidates[bridge_id]["strength"]
-        neighbor_candidates[target_id] = {
-            "via": [{"seed": bridge_id, "type": relation["type"], "direction": direction, "hop": 2}],
-            "strength": max(1, bridge_strength // 2),
+    if query_relevant_bridge:
+        # Real dogfood exposed a recall miss where source-specific monitoring concepts were
+        # direct lexical matches and the broader prior `observability` model was one graph
+        # edge beyond them. Permit that second hop only through an intermediate concept that
+        # independently has a strong lexical match to the query. This restores parent context
+        # without opening arbitrary two-hop graph wandering.
+        bridge_ids = {
+            concept_id
+            for concept_id in neighbor_candidates
+            if is_strong_seed(feature_map[concept_id])
         }
+        direct_candidates = set(neighbor_candidates)
+        for relation in graph.get("relations", []):
+            left = relation["from"]
+            right = relation["to"]
+            bridge_id: str | None = None
+            target_id: str | None = None
+            direction: str | None = None
+            if left in bridge_ids:
+                bridge_id, target_id, direction = left, right, "out"
+            elif right in bridge_ids:
+                bridge_id, target_id, direction = right, left, "in"
+            if bridge_id is None or target_id is None or direction is None:
+                continue
+            if target_id in seeds or target_id in direct_candidates or target_id == bridge_id:
+                continue
+            bridge_strength = neighbor_candidates[bridge_id]["strength"]
+            neighbor_candidates[target_id] = {
+                "via": [{"seed": bridge_id, "type": relation["type"], "direction": direction, "hop": 2}],
+                "strength": max(1, bridge_strength // 2),
+            }
 
     remaining = max(0, limit - len(seeds))
     expanded = sorted(
@@ -186,22 +188,16 @@ def rank(query: str, limit: int = 5) -> dict:
             for item in neighbors[relation["from"]]
         ):
             neighbors[relation["from"]].append({
-                "direction": "out",
-                "type": relation["type"],
-                "concept_id": relation["to"],
-                "label": concepts[relation["to"]]["label"],
-                "rationale": relation["rationale"],
+                "direction": "out", "type": relation["type"], "concept_id": relation["to"],
+                "label": concepts[relation["to"]]["label"], "rationale": relation["rationale"],
             })
         if relation["to"] in selected_set and not any(
             item["concept_id"] == relation["from"] and item["type"] == relation["type"] and item["direction"] == "in"
             for item in neighbors[relation["to"]]
         ):
             neighbors[relation["to"]].append({
-                "direction": "in",
-                "type": relation["type"],
-                "concept_id": relation["from"],
-                "label": concepts[relation["from"]]["label"],
-                "rationale": relation["rationale"],
+                "direction": "in", "type": relation["type"], "concept_id": relation["from"],
+                "label": concepts[relation["from"]]["label"], "rationale": relation["rationale"],
             })
 
     matches = []
@@ -235,6 +231,10 @@ def rank(query: str, limit: int = 5) -> dict:
         "query": query,
         "query_terms": sorted(query_words),
         "matches": matches,
+        "retrieval_mode": {
+            "strict_seed_gating": strict_seed_gating,
+            "query_relevant_bridge": query_relevant_bridge,
+        },
         "instruction": "Use lexical matches as likely prior concepts and graph-neighbor matches as context. Distinguish reinforcement, refinement, contradiction and genuinely new concepts before drafting a new insight."
     }
 
@@ -263,7 +263,7 @@ def self_test() -> int:
         print(f"graph context self-test failed; OPA query retained lexical noise: {opa_ids}")
         return 1
     if not any(item["match_type"] == "graph_neighbor" for item in opa["matches"]):
-        print("graph context self-test failed; expected one-hop graph context")
+        print("graph context self-test failed; expected graph context")
         return 1
 
     learning = rank(
@@ -291,13 +291,19 @@ def main() -> int:
     parser.add_argument("query", nargs="?", help="New-source topic, question or short description")
     parser.add_argument("--limit", type=int, default=5)
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument("--baseline", action="store_true", help="Use permissive pre-dogfood one-hop ranking for comparison")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
     if args.self_test:
         return self_test()
     if not args.query:
         parser.error("query is required unless --self-test is used")
-    result = rank(args.query, max(1, args.limit))
+    result = rank(
+        args.query,
+        max(1, args.limit),
+        strict_seed_gating=not args.baseline,
+        query_relevant_bridge=not args.baseline,
+    )
     if args.json:
         print(json.dumps(result, indent=2, ensure_ascii=False))
         return 0

--- a/tests/fixtures/retrieval-benchmark.json
+++ b/tests/fixtures/retrieval-benchmark.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.2.0",
   "cases": [
     {
       "id": "durable-workflow-retry",
@@ -80,6 +80,46 @@
       "forbidden": ["execution-history", "event-history", "replayable-evaluation", "controlled-execution"],
       "min_precision": 0.6,
       "classification_probe": "cohort-precision-regression"
+    },
+    {
+      "id": "kubernetes-reconciliation-not-temporal",
+      "query": "Understand reconciliation control loops desired state current state small controllers resilient automation",
+      "limit": 5,
+      "required": ["reconciliation-loop", "desired-state", "observed-state"],
+      "acceptable": [],
+      "forbidden": ["durable-execution", "workflow-execution", "controlled-execution", "event-history", "worker-process"],
+      "min_precision": 0.6,
+      "classification_probe": "cohort-negative-kubernetes-temporal"
+    },
+    {
+      "id": "postgresql-mvcc-not-sqlite-wal-snapshot",
+      "query": "Understand MVCC concurrency snapshots read write non blocking isolation boundaries transactions",
+      "limit": 5,
+      "required": ["multiversion-concurrency-control", "mvcc-snapshot", "transaction-isolation"],
+      "acceptable": [],
+      "forbidden": ["wal-reader-snapshot", "write-ahead-log", "checkpointing", "execution-history"],
+      "min_precision": 0.6,
+      "classification_probe": "cohort-negative-postgres-sqlite"
+    },
+    {
+      "id": "transformer-attention-not-cross-domain",
+      "query": "Understand why self attention replaced recurrence Transformer architecture parallelism dependency modeling machine translation",
+      "limit": 5,
+      "required": ["transformer-sequence-transduction", "self-attention", "sequence-computation-parallelism"],
+      "acceptable": ["attention-dependency-path", "positional-encoding"],
+      "forbidden": ["retrieval-practice", "policy-as-code", "controlled-execution", "observation-grounding"],
+      "min_precision": 0.8,
+      "classification_probe": "cohort-negative-transformer-cross-domain"
+    },
+    {
+      "id": "opentelemetry-trace-not-execution-ledger",
+      "query": "Understand traces causal distributed work spans parent child context propagation links observability",
+      "limit": 5,
+      "required": ["distributed-trace", "trace-context-propagation", "span-link"],
+      "acceptable": ["telemetry-span", "observability"],
+      "forbidden": ["execution-history", "controlled-execution", "durable-execution", "open-policy-agent"],
+      "min_precision": 0.8,
+      "classification_probe": "cohort-negative-trace-execution"
     }
   ]
 }


### PR DESCRIPTION
Superseded by merged PR #101 / commit `dfec073`, which satisfies #98 more completely: evidence-backed cohort rejection corpus, 12-case gold benchmark, same-gold baseline/candidate comparison, traceable suppression experiment, measured result documentation and an explicit DO NOT ADOPT decision because the current deterministic baseline already has full required recall and zero forbidden hits. This duplicate branch is intentionally not merged.